### PR TITLE
Make project.el the canonical project foundation

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -29,6 +29,7 @@ jobs:
             --eval '(setq byte-compile-error-on-warn t)' \
             -f batch-byte-compile \
             lisp/p3-platform.el \
+            lisp/p3-project.el \
             lisp/p3-core.el \
             lisp/p3-python.el \
             lisp/p3-terminal.el \
@@ -41,6 +42,7 @@ jobs:
           emacs -Q --batch \
             -L lisp \
             -l test/p3-config-test.el \
+            -l test/p3-project-test.el \
             -l test/p3-core-test.el \
             -l test/p3-platform-test.el \
             -l test/p3-python-test.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -4,7 +4,10 @@ on:
   pull_request:
     paths:
       - "lisp/p3-platform.el"
+      - "lisp/p3-project.el"
       - "test/p3-platform-test.el"
+      - "test/p3-project-test.el"
+      - "test/p3-project-windows-test.el"
       - ".github/workflows/windows-platform-tests.yml"
   workflow_dispatch:
 
@@ -23,10 +26,32 @@ jobs:
         shell: powershell
         run: choco install emacs -y --no-progress
 
-      - name: Byte-compile platform module
+      - name: Locate Git for Windows MSYS2 root
         shell: powershell
-        run: emacs -Q --batch -L lisp --eval "(setq byte-compile-error-on-warn t)" -f batch-byte-compile lisp/p3-platform.el
+        run: |
+          $gitExe = (Get-Command git).Source
+          $gitRoot = Split-Path (Split-Path $gitExe -Parent) -Parent
+          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/bash.exe"))) {
+            throw "Git for Windows MSYS2 bash not found under $gitRoot"
+          }
+          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/find.exe"))) {
+            throw "Git for Windows MSYS2 find not found under $gitRoot"
+          }
+          "P3_TEST_MSYS2_ROOT=$($gitRoot -replace '\\','/')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-      - name: Run platform tests
+      - name: Byte-compile Windows boundary modules
         shell: powershell
-        run: emacs -Q --batch -L lisp -l test/p3-platform-test.el -f ert-run-tests-batch-and-exit
+        run: >-
+          emacs -Q --batch -L lisp
+          --eval "(setq byte-compile-error-on-warn t)"
+          -f batch-byte-compile
+          lisp/p3-platform.el
+          lisp/p3-project.el
+
+      - name: Run Windows platform and project tests
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          -l test/p3-platform-test.el
+          -l test/p3-project-windows-test.el
+          -f ert-run-tests-batch-and-exit

--- a/docs/superpowers/plans/2026-09-02-project-el-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-project-el-foundation.md
@@ -229,5 +229,5 @@ The CI fixture may use Git for Windows' bundled MSYS2 tree because the contract 
 - [x] No new window-management behavior is introduced.
 - [x] `config.org` startup/tangling behavior is not redesigned.
 - [x] Windows project-file enumeration is covered.
-- [ ] Final Ubuntu and Windows CI gates green on the reviewed head.
+- [x] Final Ubuntu and Windows CI gates green on the reviewed head.
 - [ ] Explicit merge approval received.

--- a/docs/superpowers/plans/2026-09-02-project-el-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-project-el-foundation.md
@@ -1,0 +1,803 @@
+# Project.el Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make built-in `project.el` the single source of P3 project identity while preserving the existing R/ESS, terminal, Projectile UI, and one-/two-window workflows.
+
+**Architecture:** Add a focused `p3-project.el` library that owns native project discovery, `.projectile` marker registration, and the shared `p3/project-root` contract. Move project helpers out of `p3-core.el`, make ESS/R/Python/terminal consumers depend on `p3-project`, and eagerly load the project foundation after Windows tool-path setup but before project-aware subsystems. Preserve `.projectile` during this PR so Projectile and `project.el` can coexist while `project.el` becomes authoritative.
+
+**Tech Stack:** Emacs 29+, Emacs Lisp, built-in `project.el`, ERT, `use-package`, ESS/Python/vterm integration, GitHub Actions on Ubuntu and Windows.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-project-el-foundation-design.md`
+
+## Global Constraints
+
+- Supported Emacs baseline: **Emacs 29 or newer**.
+- Built-in `project.el` is the only source of P3 project identity after this PR.
+- Keep Projectile installed, enabled, and keybound; do not remove or redesign its UI in this PR.
+- Keep existing `.projectile` markers; do not rename them to `.project` in this PR.
+- A nested `.projectile` marker intentionally defines an inner P3 project inside an outer VCS repository.
+- Python intentionally adopts that same shared inner project boundary and may therefore select a different project-local `.venv` than before this PR.
+- Preserve existing ESS process/session behavior, R helper behavior, terminal behavior, and Python environment policy apart from the approved shared-root semantic change.
+- Preserve the normal one- or two-window workflow; do not add `display-buffer-alist` rules or new window-management behavior.
+- Do not introduce a custom project backend or a Projectile fallback path.
+- On Windows, `.projectile`-only projects must support both root detection and `project-files` enumeration after the normal P3 Unix-tool path setup.
+- Do not use GitHub Actions as an iterative diagnostic loop. Run targeted and full local batch tests before the final push; use CI as the final cross-platform gate.
+- Do not merge without explicit user approval.
+
+---
+
+## File map
+
+**Create**
+
+- `lisp/p3-project.el` — canonical P3 project discovery and project-root helpers.
+- `test/p3-project-test.el` — platform-neutral behavioral tests for native project detection and nested project semantics.
+- `test/p3-project-windows-test.el` — native-Windows integration test for the platform/project file-enumeration contract.
+
+**Modify**
+
+- `lisp/p3-core.el` — remove project discovery; retain only shared config commands.
+- `lisp/p3-ess.el` — depend directly on `p3-project`; no ESS session behavior changes.
+- `lisp/p3-r-tools.el` — depend directly on `p3-project`; keep `.projectile` in generated projects.
+- `lisp/p3-python.el` — depend directly on `p3-project` and use `p3/project-root` for interpreter discovery.
+- `lisp/p3-terminal.el` — depend directly on `p3-project`; no terminal behavior changes.
+- `test/p3-core-test.el` — remove tests for the project behavior that moves to `p3-project-test.el`.
+- `test/p3-python-test.el` — replace the old separate-project-root regression with the approved shared-root behavior.
+- `test/p3-config-test.el` — require visible/eager `p3-project` wiring and verify startup ordering.
+- `config.org` — eagerly load `p3-project` after Windows Rtools/MSYS2 path setup and before project-aware P3 subsystems.
+- `.github/workflows/emacs-tests.yml` — byte-compile and run the new project module/tests.
+- `.github/workflows/windows-platform-tests.yml` — run the Windows project/platform integration test when project/platform files change.
+
+---
+
+### Task 1: Extract canonical project identity into `p3-project.el`
+
+**Files:**
+- Create: `lisp/p3-project.el`
+- Create: `test/p3-project-test.el`
+- Modify: `lisp/p3-core.el`
+- Modify: `test/p3-core-test.el`
+
+**Interfaces:**
+- Consumes: built-in `project-current`, `project-root`, and `project-vc-extra-root-markers` from Emacs 29+.
+- Produces: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil`; eager module load also registers `.projectile` in `project-vc-extra-root-markers`.
+
+- [ ] **Step 1: Write the new project tests before creating the implementation**
+
+Create `test/p3-project-test.el` with focused tests for delegation, marker-only projects, nested markers, and buffer-local default directories:
+
+```emacs-lisp
+;;; p3-project-test.el --- Tests for p3-project -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'project)
+
+(defconst p3-project-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-project-test--root))
+
+(require 'p3-project)
+
+(defun p3-project-test--canonical-directory (directory)
+  "Return DIRECTORY in the normalized form used for root comparisons."
+  (file-name-as-directory (file-truename directory)))
+
+(ert-deftest p3-project-root-delegates-to-project-el ()
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&optional _maybe-prompt _directory) 'fake-project))
+            ((symbol-function 'project-root)
+             (lambda (_project) "/tmp/native-project/")))
+    (should (equal (p3/project-root) "/tmp/native-project/"))))
+
+(ert-deftest p3-project-root-does-not-consult-projectile ()
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&optional _maybe-prompt _directory) nil))
+            ((symbol-function 'projectile-project-root)
+             (lambda () (ert-fail "Projectile must not define P3 project identity"))))
+    (should-not (p3/project-root))))
+
+(ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
+  (let* ((root (make-temp-file "p3-project-marker-" t))
+         (child (expand-file-name "R/subdir" root)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" root))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
+(ert-deftest p3-project-inner-marker-wins-over-outer-git-root ()
+  (skip-unless (executable-find "git"))
+  (let* ((outer (make-temp-file "p3-project-outer-" t))
+         (inner (expand-file-name "analysis" outer))
+         (child (expand-file-name "R" inner)))
+    (unwind-protect
+        (progn
+          (should (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" inner))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory inner)))))
+      (delete-directory outer t))))
+
+(ert-deftest p3-project-default-directory-is-buffer-local ()
+  (with-temp-buffer
+    (let ((original default-directory))
+      (cl-letf (((symbol-function 'p3/project-root)
+                 (lambda () "/tmp/project-root/")))
+        (p3/use-project-root-as-default-dir)
+        (should (local-variable-p 'default-directory))
+        (should (equal default-directory "/tmp/project-root/"))
+        (should-not (equal original default-directory))))))
+
+(provide 'p3-project-test)
+
+;;; p3-project-test.el ends here
+```
+
+- [ ] **Step 2: Run the new test file and verify the extraction is not implemented yet**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL while loading because `p3-project` does not exist yet.
+
+- [ ] **Step 3: Create the minimal native project module**
+
+Create `lisp/p3-project.el`:
+
+```emacs-lisp
+;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
+
+(require 'project)
+
+(add-to-list 'project-vc-extra-root-markers ".projectile")
+
+(defun p3/project-root ()
+  "Return the current built-in `project.el' root, if any."
+  (when-let ((project (project-current nil)))
+    (project-root project)))
+
+(defun p3/use-project-root-as-default-dir ()
+  "Use the current project root as the buffer's default directory."
+  (when-let ((root (p3/project-root)))
+    (setq-local default-directory root)))
+
+(provide 'p3-project)
+
+;;; p3-project.el ends here
+```
+
+- [ ] **Step 4: Remove project ownership from `p3-core.el`**
+
+Delete from `lisp/p3-core.el`:
+
+```emacs-lisp
+(require 'project)
+(declare-function projectile-project-root "projectile")
+
+(defun p3/project-el-root () ...)
+(defun p3/project-root () ...)
+(defun p3/use-project-root-as-default-dir () ...)
+```
+
+Keep the `p3/load-config` declaration and the `p3/config-visit` / `p3/config-reload` commands unchanged. The resulting module should start approximately as:
+
+```emacs-lisp
+;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
+
+(declare-function p3/load-config nil (&optional quiet))
+```
+
+- [ ] **Step 5: Reduce `p3-core-test.el` to the behavior still owned by core**
+
+Remove these old tests from `test/p3-core-test.el`:
+
+```text
+p3-core-project-root-prefers-projectile
+p3-core-project-root-falls-back-to-project-el
+p3-core-project-default-directory-is-buffer-local
+```
+
+Retain the existing config-command test:
+
+```emacs-lisp
+(ert-deftest p3-core-config-commands-remain-commands ()
+  (should (commandp #'p3/config-visit))
+  (should (commandp #'p3/config-reload)))
+```
+
+`p3-core-test.el` no longer needs `cl-lib` after those project tests are removed; remove that require if byte-compilation confirms it is unused.
+
+- [ ] **Step 6: Run the focused project/core tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -l test/p3-core-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all project and core tests PASS.
+
+- [ ] **Step 7: Byte-compile the new boundary with warnings as errors**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile \
+  lisp/p3-project.el \
+  lisp/p3-core.el
+```
+
+Expected: exit status 0 with no warnings.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add lisp/p3-project.el lisp/p3-core.el test/p3-project-test.el test/p3-core-test.el
+git commit -m "refactor: make project.el own project identity"
+```
+
+---
+
+### Task 2: Migrate ESS, R, Python, and terminal consumers to the shared root
+
+**Files:**
+- Modify: `lisp/p3-ess.el`
+- Modify: `lisp/p3-r-tools.el`
+- Modify: `lisp/p3-python.el`
+- Modify: `lisp/p3-terminal.el`
+- Modify: `test/p3-python-test.el`
+- Verify unchanged behavior through: `test/p3-ess-test.el`, `test/p3-r-tools-test.el`, `test/p3-terminal-test.el`
+
+**Interfaces:**
+- Consumes: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil` from `p3-project.el`.
+- Produces: no new public interface; existing subsystem commands keep their current names and behavior.
+
+- [ ] **Step 1: Replace the obsolete Python regression with a failing shared-root unit test**
+
+In `test/p3-python-test.el`, remove `p3-python-project-interpreter-preserves-project-el-root` and add:
+
+```emacs-lisp
+(ert-deftest p3-python-project-interpreter-uses-shared-p3-root ()
+  (p3-python-test--with-temp-project root
+    (let ((interpreter
+           (p3-python-test--make-executable
+            (expand-file-name ".venv/bin/python" root)))
+          (system-type 'gnu/linux))
+      (cl-letf (((symbol-function 'p3/project-root)
+                 (lambda () root)))
+        (should (equal (p3/python-project-interpreter) interpreter))))))
+```
+
+Update the existing `.venv`, buffer-local setup, and Windows-layout tests so they mock `p3/project-root` directly instead of separately mocking `project-current` and `project-root`.
+
+- [ ] **Step 2: Add the nested-project Python integration test**
+
+Add to `test/p3-python-test.el`:
+
+```emacs-lisp
+(ert-deftest p3-python-inner-project-marker-selects-inner-venv ()
+  (skip-unless (executable-find "git"))
+  (p3-python-test--with-temp-project outer
+    (let* ((inner (expand-file-name "analysis" outer))
+           (source-directory (expand-file-name "src" inner))
+           (interpreter
+            (p3-python-test--make-executable
+             (expand-file-name ".venv/bin/python" inner)))
+           (system-type 'gnu/linux))
+      (should (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+      (make-directory source-directory t)
+      (with-temp-file (expand-file-name ".projectile" inner))
+      (let ((default-directory source-directory))
+        (should (equal (p3/python-project-interpreter) interpreter))))))
+```
+
+Ensure the test file requires `p3-project` explicitly before `p3-python` if that is not already guaranteed by `p3-python` after migration.
+
+- [ ] **Step 3: Run the Python tests and verify they fail against the old implementation**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -l test/p3-python-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL because `p3/python-project-interpreter` still calls the removed `p3/project-el-root` contract or does not honor the mocked shared root.
+
+- [ ] **Step 4: Migrate the four project-aware modules**
+
+In `lisp/p3-python.el`, replace:
+
+```emacs-lisp
+(require 'p3-core)
+```
+
+with:
+
+```emacs-lisp
+(require 'p3-project)
+```
+
+and change:
+
+```emacs-lisp
+(when-let ((root (p3/project-el-root)))
+```
+
+to:
+
+```emacs-lisp
+(when-let ((root (p3/project-root)))
+```
+
+In `lisp/p3-ess.el`, replace the `p3-core` dependency with `p3-project` and update the commentary sentence to say project identity is delegated to `p3-project`.
+
+In `lisp/p3-r-tools.el` and `lisp/p3-terminal.el`, replace:
+
+```emacs-lisp
+(require 'p3-core)
+```
+
+with:
+
+```emacs-lisp
+(require 'p3-project)
+```
+
+Do **not** change the `.projectile` entry in `p3-r--common-project-files`.
+
+- [ ] **Step 5: Run all project-dependent subsystem tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-terminal-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all tests PASS; existing ESS/R/terminal tests continue to exercise the unchanged `p3/project-root` interface.
+
+- [ ] **Step 6: Byte-compile all migrated modules**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile \
+  lisp/p3-project.el \
+  lisp/p3-ess.el \
+  lisp/p3-r-tools.el \
+  lisp/p3-python.el \
+  lisp/p3-terminal.el
+```
+
+Expected: exit status 0 with no warnings or unresolved `p3/project-el-root` references.
+
+- [ ] **Step 7: Verify the retired helper is gone from implementation code**
+
+Run:
+
+```bash
+git grep -n "p3/project-el-root" -- '*.el'
+```
+
+Expected: no matches.
+
+Run:
+
+```bash
+git grep -n "projectile-project-root" -- lisp
+```
+
+Expected: no matches in `lisp/`; Projectile may still appear in `config.org` and project scaffolding/tests because its UI and marker are intentionally retained.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add lisp/p3-ess.el lisp/p3-r-tools.el lisp/p3-python.el lisp/p3-terminal.el test/p3-python-test.el
+git commit -m "refactor: share native project roots across workflows"
+```
+
+---
+
+### Task 3: Establish eager project-foundation startup wiring
+
+**Files:**
+- Modify: `config.org`
+- Modify: `test/p3-config-test.el`
+
+**Interfaces:**
+- Consumes: eager `p3/windows-configure-rtools` platform setup and `p3-project` module from Tasks 1–2.
+- Produces: startup invariant that `.projectile` is registered with `project.el` before P3 project-aware subsystem configuration can call `project-current`.
+
+- [ ] **Step 1: Add failing config-structure assertions**
+
+Update the module list in `p3-config-org-delegates-custom-subsystems-to-modules` so it includes `"p3-project"`:
+
+```emacs-lisp
+(dolist (module '("p3-platform" "p3-project" "p3-core" "p3-python"
+                  "p3-terminal" "p3-ess" "p3-gptel"))
+  ...)
+```
+
+Keep `"(defun p3/project-root"` in the implementation exclusion list so `config.org` is explicitly forbidden from reabsorbing project implementation.
+
+Add a startup-order test:
+
+```emacs-lisp
+(ert-deftest p3-config-project-foundation-precedes-project-consumers ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "config.org" p3-config-test--root))
+    (let ((rtools-position
+           (progn
+             (should (search-forward "(p3/windows-configure-rtools)" nil t))
+             (point)))
+          project-position
+          core-position
+          python-position
+          ess-position
+          terminal-position)
+      (setq project-position
+            (progn
+              (should (search-forward "(use-package p3-project" nil t))
+              (point)))
+      (setq core-position
+            (progn
+              (should (search-forward "(use-package p3-core" nil t))
+              (point)))
+      (setq python-position
+            (progn
+              (should (search-forward "(use-package p3-python" nil t))
+              (point)))
+      (setq ess-position
+            (progn
+              (should (search-forward "(use-package p3-ess" nil t))
+              (point)))
+      (setq terminal-position
+            (progn
+              (should (search-forward "(use-package p3-terminal" nil t))
+              (point)))
+      (should (< rtools-position project-position))
+      (should (< project-position core-position))
+      (should (< project-position python-position))
+      (should (< project-position ess-position))
+      (should (< project-position terminal-position)))))
+```
+
+If the actual current `config.org` order makes sequential `search-forward` unsuitable for one of these consumers, compute each position independently from `point-min`; keep the assertions themselves unchanged.
+
+- [ ] **Step 2: Run the config tests and verify the new module/order contract fails**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL because `config.org` does not yet contain `(use-package p3-project ...)`.
+
+- [ ] **Step 3: Add the eager project foundation immediately after platform-path setup**
+
+In `config.org`, directly after the existing eager `p3-platform` block that calls `p3/windows-configure-rtools`, add:
+
+```emacs-lisp
+#+BEGIN_SRC emacs-lisp
+  (use-package p3-project
+    :ensure nil
+    :demand t)
+#+END_SRC
+```
+
+Do not add keybindings or extra setup calls. Requiring `p3-project` is itself the startup action that registers `.projectile` in `project-vc-extra-root-markers`.
+
+Keep the existing `p3-core` block responsible for `C-c e` / `C-c r`; do not move those commands into the project module.
+
+- [ ] **Step 4: Run the config tests and tangle smoke test**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS, including readable `init.el`, readable tangled config, module delegation, platform ordering, and project-foundation ordering.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add config.org test/p3-config-test.el
+git commit -m "refactor: load project foundation before project workflows"
+```
+
+---
+
+### Task 4: Add Linux and Windows regression gates for the new boundary
+
+**Files:**
+- Create: `test/p3-project-windows-test.el`
+- Modify: `.github/workflows/emacs-tests.yml`
+- Modify: `.github/workflows/windows-platform-tests.yml`
+
+**Interfaces:**
+- Consumes: `p3/windows-configure-rtools`, `p3/project-root`, built-in `project-current`, and `project-files`.
+- Produces: CI evidence that marker-only project discovery works on Linux and that Windows project file enumeration works with a Unix-compatible MSYS2 tool directory placed first through the existing platform setup path.
+
+- [ ] **Step 1: Write the native-Windows integration test**
+
+Create `test/p3-project-windows-test.el`:
+
+```emacs-lisp
+;;; p3-project-windows-test.el --- Windows project/platform integration tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+(require 'project)
+
+(defconst p3-project-windows-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-project-windows-test--root))
+
+(require 'p3-platform)
+(require 'p3-project)
+
+(ert-deftest p3-project-windows-msys2-tools-support-marker-project-files ()
+  (unless (eq system-type 'windows-nt)
+    (ert-skip "Native Windows-only project enumeration contract"))
+  (let* ((msys2-root (getenv "P3_TEST_MSYS2_ROOT"))
+         (usr-bin (and msys2-root (expand-file-name "usr/bin" msys2-root)))
+         (bash (and usr-bin (expand-file-name "bash.exe" usr-bin)))
+         (find (and usr-bin (expand-file-name "find.exe" usr-bin)))
+         (root (make-temp-file "p3-project-windows-" t))
+         (child (expand-file-name "R" root))
+         (data-file (expand-file-name "R/example.R" root))
+         (old-path (getenv "PATH"))
+         (old-exec-path (copy-sequence exec-path))
+         (p3/windows-rtools-override msys2-root)
+         (find-program "find"))
+    (unwind-protect
+        (progn
+          (should msys2-root)
+          (should (file-readable-p bash))
+          (should (file-readable-p find))
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" root))
+          (with-temp-file data-file (insert "x <- 1\n"))
+          (p3/windows-configure-rtools)
+          (let* ((default-directory child)
+                 (project (project-current nil))
+                 (files (project-files project)))
+            (should project)
+            (should
+             (equal (file-name-as-directory (file-truename (project-root project)))
+                    (file-name-as-directory (file-truename root))))
+            (should
+             (seq-some
+              (lambda (file)
+                (string-equal (file-name-nondirectory file) "example.R"))
+              files))))
+      (setq exec-path old-exec-path)
+      (setenv "PATH" old-path)
+      (delete-directory root t))))
+
+(provide 'p3-project-windows-test)
+
+;;; p3-project-windows-test.el ends here
+```
+
+The test deliberately uses the normal `p3/windows-configure-rtools` path. CI supplies a known MSYS2-compatible root from the preinstalled Git for Windows distribution; this exercises the relevant path-ordering behavior without adding an Rtools installation to CI.
+
+- [ ] **Step 2: Extend the normal Ubuntu Emacs test workflow**
+
+In `.github/workflows/emacs-tests.yml`, add `lisp/p3-project.el` to the byte-compilation list before modules that require it:
+
+```yaml
+            lisp/p3-platform.el \
+            lisp/p3-project.el \
+            lisp/p3-core.el \
+```
+
+Add the new platform-neutral project tests to the ERT command before subsystem tests:
+
+```yaml
+            -l test/p3-config-test.el \
+            -l test/p3-project-test.el \
+            -l test/p3-core-test.el \
+```
+
+Do not add the Windows-only integration test to this Linux job.
+
+- [ ] **Step 3: Expand Windows workflow path triggers narrowly**
+
+In `.github/workflows/windows-platform-tests.yml`, keep the existing platform paths and add:
+
+```yaml
+      - "lisp/p3-project.el"
+      - "test/p3-project-test.el"
+      - "test/p3-project-windows-test.el"
+```
+
+This causes Windows CI to run when either half of the project/platform integration changes.
+
+- [ ] **Step 4: Resolve a stable MSYS2 root from Git for Windows in CI**
+
+Before running ERT in `.github/workflows/windows-platform-tests.yml`, add:
+
+```yaml
+      - name: Locate Git for Windows MSYS2 root
+        shell: powershell
+        run: |
+          $gitExe = (Get-Command git).Source
+          $gitRoot = Split-Path (Split-Path $gitExe -Parent) -Parent
+          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/bash.exe"))) {
+            throw "Git for Windows MSYS2 bash not found under $gitRoot"
+          }
+          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/find.exe"))) {
+            throw "Git for Windows MSYS2 find not found under $gitRoot"
+          }
+          "P3_TEST_MSYS2_ROOT=$($gitRoot -replace '\\','/')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+```
+
+This is test scaffolding only. Production Windows behavior continues to discover and use Rtools through `p3-platform.el`.
+
+- [ ] **Step 5: Extend the Windows compile/test commands**
+
+Change the byte-compile step to compile both boundary modules:
+
+```yaml
+      - name: Byte-compile Windows boundary modules
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          --eval "(setq byte-compile-error-on-warn t)"
+          -f batch-byte-compile
+          lisp/p3-platform.el
+          lisp/p3-project.el
+```
+
+Change the test step to run both existing platform tests and the new Windows project integration test:
+
+```yaml
+      - name: Run Windows platform and project tests
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          -l test/p3-platform-test.el
+          -l test/p3-project-windows-test.el
+          -f ert-run-tests-batch-and-exit
+```
+
+- [ ] **Step 6: Run the complete local Linux gate before pushing CI changes**
+
+Run exactly the suite used by `.github/workflows/emacs-tests.yml` after adding the new project test:
+
+```bash
+emacs -Q --batch \
+  -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile \
+  lisp/p3-platform.el \
+  lisp/p3-project.el \
+  lisp/p3-core.el \
+  lisp/p3-python.el \
+  lisp/p3-terminal.el \
+  lisp/p3-ess.el \
+  lisp/p3-r-tools.el \
+  lisp/p3-gptel.el
+```
+
+Expected: exit status 0 and no warnings.
+
+Then run:
+
+```bash
+emacs -Q --batch \
+  -L lisp \
+  -l test/p3-config-test.el \
+  -l test/p3-project-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-platform-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-terminal-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-gptel-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-org-export-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all ERT tests PASS.
+
+- [ ] **Step 7: Inspect the final diff for scope leakage**
+
+Run:
+
+```bash
+git diff master...HEAD --stat
+git diff master...HEAD -- \
+  lisp/p3-project.el lisp/p3-core.el lisp/p3-ess.el lisp/p3-r-tools.el \
+  lisp/p3-python.el lisp/p3-terminal.el config.org test .github/workflows
+```
+
+Verify all of the following before committing/pushing:
+
+- Projectile package configuration and keybindings still exist.
+- `p3-r--common-project-files` still emits `.projectile`.
+- No ESS process/session implementation changed beyond its required module dependency/commentary.
+- No terminal window/switching implementation changed beyond its required module dependency.
+- No `display-buffer-alist` rules were added.
+- No startup/tangling redesign was introduced.
+- No `p3/project-el-root` implementation or references remain.
+
+- [ ] **Step 8: Commit Task 4**
+
+```bash
+git add test/p3-project-windows-test.el .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
+git commit -m "test: cover native project foundation across platforms"
+```
+
+- [ ] **Step 9: Push once and use CI as the final cross-platform gate**
+
+Push `refactor/project-el-foundation` after the local suite is green. Confirm:
+
+- Ubuntu `Emacs tests` passes.
+- Windows `Windows platform tests` passes, including marker-only `project-files` enumeration.
+
+If CI reveals a platform-specific failure, diagnose that exact failure locally or from the job log before pushing another change; do not add diagnostic workflow machinery.
+
+---
+
+## Completion criteria
+
+PR 1 is implementation-complete only when all of these are true:
+
+1. `p3-project.el` exclusively owns `p3/project-root` and `p3/use-project-root-as-default-dir`.
+2. No P3 implementation calls `projectile-project-root` or the retired `p3/project-el-root` helper.
+3. ESS, R tools, Python, and terminal code consume the same `p3/project-root` contract.
+4. Existing `.projectile` projects are recognized by native `project.el`, including nested projects inside outer Git repositories.
+5. Python resolves `.venv` from that shared inner root in the nested-project case.
+6. `config.org` eagerly loads `p3-project` after Windows Unix-tool path setup and before project-aware P3 modules.
+7. Existing R project scaffolding still creates `.projectile`.
+8. The one-/two-window workflow is unchanged.
+9. Linux byte-compilation and the complete ERT suite pass.
+10. Native Windows project detection and `project-files` enumeration pass through the existing platform path setup.
+11. The final diff contains no Projectile removal, ESS redesign, Python environment-manager redesign, Org changes, startup/tangling redesign, or buffer-layout changes.
+12. The branch is not merged without explicit user approval.

--- a/docs/superpowers/plans/2026-09-02-project-el-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-project-el-foundation.md
@@ -17,7 +17,7 @@
 - Keep Projectile installed, enabled, and keybound; do not remove or redesign its UI in this PR.
 - Keep existing `.projectile` markers; do not rename them to `.project` in this PR.
 - A nested `.projectile` marker intentionally defines an inner P3 project inside an outer VCS repository.
-- Python intentionally adopts that same shared inner project boundary and may therefore select a different project-local `.venv` than before this PR.
+- Python intentionally adopts that shared inner project boundary and may therefore select a different project-local `.venv` than before this PR.
 - Preserve existing ESS process/session behavior, R helper behavior, terminal behavior, and Python environment policy apart from the approved shared-root semantic change.
 - Preserve the normal one- or two-window workflow; do not add `display-buffer-alist` rules or new window-management behavior.
 - Do not introduce a custom project backend or a Projectile fallback path.
@@ -42,8 +42,9 @@
 - `lisp/p3-r-tools.el` — depend directly on `p3-project`; keep `.projectile` in generated projects.
 - `lisp/p3-python.el` — depend directly on `p3-project` and use `p3/project-root` for interpreter discovery.
 - `lisp/p3-terminal.el` — depend directly on `p3-project`; no terminal behavior changes.
-- `test/p3-core-test.el` — remove tests for the project behavior that moves to `p3-project-test.el`.
+- `test/p3-core-test.el` — remove project tests that move to `p3-project-test.el`.
 - `test/p3-python-test.el` — replace the old separate-project-root regression with the approved shared-root behavior.
+- `test/p3-r-tools-test.el` — explicitly lock in `.projectile` generation.
 - `test/p3-config-test.el` — require visible/eager `p3-project` wiring and verify startup ordering.
 - `config.org` — eagerly load `p3-project` after Windows Rtools/MSYS2 path setup and before project-aware P3 subsystems.
 - `.github/workflows/emacs-tests.yml` — byte-compile and run the new project module/tests.
@@ -61,11 +62,11 @@
 
 **Interfaces:**
 - Consumes: built-in `project-current`, `project-root`, and `project-vc-extra-root-markers` from Emacs 29+.
-- Produces: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil`; eager module load also registers `.projectile` in `project-vc-extra-root-markers`.
+- Produces: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil`; loading the module registers `.projectile` in `project-vc-extra-root-markers`.
 
-- [ ] **Step 1: Write the new project tests before creating the implementation**
+- [ ] **Step 1: Write the failing project tests**
 
-Create `test/p3-project-test.el` with focused tests for delegation, marker-only projects, nested markers, and buffer-local default directories:
+Create `test/p3-project-test.el`:
 
 ```emacs-lisp
 ;;; p3-project-test.el --- Tests for p3-project -*- lexical-binding: t; -*-
@@ -85,7 +86,7 @@ Create `test/p3-project-test.el` with focused tests for delegation, marker-only 
 (require 'p3-project)
 
 (defun p3-project-test--canonical-directory (directory)
-  "Return DIRECTORY in the normalized form used for root comparisons."
+  "Return DIRECTORY in normalized form for root comparisons."
   (file-name-as-directory (file-truename directory)))
 
 (ert-deftest p3-project-root-delegates-to-project-el ()
@@ -99,7 +100,8 @@ Create `test/p3-project-test.el` with focused tests for delegation, marker-only 
   (cl-letf (((symbol-function 'project-current)
              (lambda (&optional _maybe-prompt _directory) nil))
             ((symbol-function 'projectile-project-root)
-             (lambda () (ert-fail "Projectile must not define P3 project identity"))))
+             (lambda ()
+               (ert-fail "Projectile must not define P3 project identity"))))
     (should-not (p3/project-root))))
 
 (ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
@@ -122,7 +124,8 @@ Create `test/p3-project-test.el` with focused tests for delegation, marker-only 
          (child (expand-file-name "R" inner)))
     (unwind-protect
         (progn
-          (should (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+          (should
+           (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
           (make-directory child t)
           (with-temp-file (expand-file-name ".projectile" inner))
           (let ((default-directory child))
@@ -146,9 +149,7 @@ Create `test/p3-project-test.el` with focused tests for delegation, marker-only 
 ;;; p3-project-test.el ends here
 ```
 
-- [ ] **Step 2: Run the new test file and verify the extraction is not implemented yet**
-
-Run:
+- [ ] **Step 2: Run the new tests and verify the module is missing**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -156,7 +157,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL while loading because `p3-project` does not exist yet.
+Expected: FAIL while loading because `p3-project` does not exist.
 
 - [ ] **Step 3: Create the minimal native project module**
 
@@ -166,6 +167,9 @@ Create `lisp/p3-project.el`:
 ;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
 
 (require 'project)
+
+(unless (boundp 'project-vc-extra-root-markers)
+  (error "P3 project support requires Emacs 29 or newer"))
 
 (add-to-list 'project-vc-extra-root-markers ".projectile")
 
@@ -184,50 +188,64 @@ Create `lisp/p3-project.el`:
 ;;; p3-project.el ends here
 ```
 
-- [ ] **Step 4: Remove project ownership from `p3-core.el`**
+- [ ] **Step 4: Replace `p3-core.el` with the exact reduced implementation**
 
-Delete from `lisp/p3-core.el`:
-
-```emacs-lisp
-(require 'project)
-(declare-function projectile-project-root "projectile")
-
-(defun p3/project-el-root () ...)
-(defun p3/project-root () ...)
-(defun p3/use-project-root-as-default-dir () ...)
-```
-
-Keep the `p3/load-config` declaration and the `p3/config-visit` / `p3/config-reload` commands unchanged. The resulting module should start approximately as:
+`lisp/p3-core.el` should contain only:
 
 ```emacs-lisp
 ;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
 
 (declare-function p3/load-config nil (&optional quiet))
+
+(defun p3/config-visit ()
+  "Visit the authoritative literate Emacs configuration."
+  (interactive)
+  (find-file
+   (if (boundp 'p3/config-source)
+       p3/config-source
+     (expand-file-name "config.org" user-emacs-directory))))
+
+(defun p3/config-reload ()
+  "Tangle and reload the authoritative literate Emacs configuration."
+  (interactive)
+  (unless (fboundp 'p3/load-config)
+    (user-error "Config loader is unavailable"))
+  (p3/load-config))
+
+(provide 'p3-core)
+
+;;; p3-core.el ends here
 ```
 
-- [ ] **Step 5: Reduce `p3-core-test.el` to the behavior still owned by core**
+- [ ] **Step 5: Reduce `p3-core-test.el` to the exact behavior still owned by core**
 
-Remove these old tests from `test/p3-core-test.el`:
-
-```text
-p3-core-project-root-prefers-projectile
-p3-core-project-root-falls-back-to-project-el
-p3-core-project-default-directory-is-buffer-local
-```
-
-Retain the existing config-command test:
+Replace `test/p3-core-test.el` with:
 
 ```emacs-lisp
+;;; p3-core-test.el --- Tests for p3-core -*- lexical-binding: t; -*-
+
+(require 'ert)
+
+(defconst p3-core-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-core-test--root))
+
+(require 'p3-core)
+
 (ert-deftest p3-core-config-commands-remain-commands ()
   (should (commandp #'p3/config-visit))
   (should (commandp #'p3/config-reload)))
+
+(provide 'p3-core-test)
+
+;;; p3-core-test.el ends here
 ```
 
-`p3-core-test.el` no longer needs `cl-lib` after those project tests are removed; remove that require if byte-compilation confirms it is unused.
-
-- [ ] **Step 6: Run the focused project/core tests**
-
-Run:
+- [ ] **Step 6: Run the focused tests**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -236,11 +254,9 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all project and core tests PASS.
+Expected: all project/core tests PASS.
 
-- [ ] **Step 7: Byte-compile the new boundary with warnings as errors**
-
-Run:
+- [ ] **Step 7: Byte-compile the new boundary**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -261,7 +277,7 @@ git commit -m "refactor: make project.el own project identity"
 
 ---
 
-### Task 2: Migrate ESS, R, Python, and terminal consumers to the shared root
+### Task 2: Migrate ESS, R, Python, and terminal consumers
 
 **Files:**
 - Modify: `lisp/p3-ess.el`
@@ -269,15 +285,16 @@ git commit -m "refactor: make project.el own project identity"
 - Modify: `lisp/p3-python.el`
 - Modify: `lisp/p3-terminal.el`
 - Modify: `test/p3-python-test.el`
-- Verify unchanged behavior through: `test/p3-ess-test.el`, `test/p3-r-tools-test.el`, `test/p3-terminal-test.el`
+- Modify: `test/p3-r-tools-test.el`
+- Verify: `test/p3-ess-test.el`, `test/p3-terminal-test.el`
 
 **Interfaces:**
 - Consumes: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil` from `p3-project.el`.
 - Produces: no new public interface; existing subsystem commands keep their current names and behavior.
 
-- [ ] **Step 1: Replace the obsolete Python regression with a failing shared-root unit test**
+- [ ] **Step 1: Replace the obsolete Python regression with the shared-root unit test**
 
-In `test/p3-python-test.el`, remove `p3-python-project-interpreter-preserves-project-el-root` and add:
+Remove `p3-python-project-interpreter-preserves-project-el-root` from `test/p3-python-test.el` and add:
 
 ```emacs-lisp
 (ert-deftest p3-python-project-interpreter-uses-shared-p3-root ()
@@ -291,11 +308,15 @@ In `test/p3-python-test.el`, remove `p3-python-project-interpreter-preserves-pro
         (should (equal (p3/python-project-interpreter) interpreter))))))
 ```
 
-Update the existing `.venv`, buffer-local setup, and Windows-layout tests so they mock `p3/project-root` directly instead of separately mocking `project-current` and `project-root`.
+Update these existing tests so they mock `p3/project-root` directly instead of `project-current`/`project-root`:
+
+- `p3-python-project-interpreter-prefers-dot-venv`
+- `p3-python-setup-project-interpreter-is-buffer-local`
+- `p3-python-project-interpreter-supports-windows-venv-layout`
 
 - [ ] **Step 2: Add the nested-project Python integration test**
 
-Add to `test/p3-python-test.el`:
+Add:
 
 ```emacs-lisp
 (ert-deftest p3-python-inner-project-marker-selects-inner-venv ()
@@ -307,29 +328,37 @@ Add to `test/p3-python-test.el`:
             (p3-python-test--make-executable
              (expand-file-name ".venv/bin/python" inner)))
            (system-type 'gnu/linux))
-      (should (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+      (should
+       (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
       (make-directory source-directory t)
       (with-temp-file (expand-file-name ".projectile" inner))
       (let ((default-directory source-directory))
         (should (equal (p3/python-project-interpreter) interpreter))))))
 ```
 
-Ensure the test file requires `p3-project` explicitly before `p3-python` if that is not already guaranteed by `p3-python` after migration.
+- [ ] **Step 3: Add an explicit scaffolding regression for `.projectile`**
 
-- [ ] **Step 3: Run the Python tests and verify they fail against the old implementation**
+In `p3-r-new-analysis-project-generates-expected-files`, add:
 
-Run:
+```emacs-lisp
+(should (file-exists-p (expand-file-name ".projectile" root)))
+```
+
+This turns the retained marker from an implementation assumption into a tested compatibility contract.
+
+- [ ] **Step 4: Run Python/R tests and verify the Python behavior still fails**
 
 ```bash
 emacs -Q --batch -L lisp \
   -l test/p3-project-test.el \
   -l test/p3-python-test.el \
+  -l test/p3-r-tools-test.el \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL because `p3/python-project-interpreter` still calls the removed `p3/project-el-root` contract or does not honor the mocked shared root.
+Expected: Python shared-root tests FAIL against the old implementation; the new R marker assertion already passes.
 
-- [ ] **Step 4: Migrate the four project-aware modules**
+- [ ] **Step 5: Migrate the four modules to `p3-project`**
 
 In `lisp/p3-python.el`, replace:
 
@@ -343,37 +372,37 @@ with:
 (require 'p3-project)
 ```
 
-and change:
+and replace:
 
 ```emacs-lisp
 (when-let ((root (p3/project-el-root)))
 ```
 
-to:
+with:
 
 ```emacs-lisp
 (when-let ((root (p3/project-root)))
 ```
 
-In `lisp/p3-ess.el`, replace the `p3-core` dependency with `p3-project` and update the commentary sentence to say project identity is delegated to `p3-project`.
+In `lisp/p3-ess.el`, replace `(require 'p3-core)` with `(require 'p3-project)` and change the commentary sentence from:
 
-In `lisp/p3-r-tools.el` and `lisp/p3-terminal.el`, replace:
-
-```emacs-lisp
-(require 'p3-core)
+```text
+Project identity is delegated to p3-core so ESS,
+Python, R helpers, and terminal workflows use the same root abstraction.
 ```
 
-with:
+to:
 
-```emacs-lisp
-(require 'p3-project)
+```text
+Project identity is delegated to p3-project so ESS,
+Python, R helpers, and terminal workflows use the same root abstraction.
 ```
 
-Do **not** change the `.projectile` entry in `p3-r--common-project-files`.
+In both `lisp/p3-r-tools.el` and `lisp/p3-terminal.el`, replace `(require 'p3-core)` with `(require 'p3-project)`.
 
-- [ ] **Step 5: Run all project-dependent subsystem tests**
+Do not change the `.projectile` entry in `p3-r--common-project-files`.
 
-Run:
+- [ ] **Step 6: Run all project-dependent subsystem tests**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -385,11 +414,9 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all tests PASS; existing ESS/R/terminal tests continue to exercise the unchanged `p3/project-root` interface.
+Expected: all tests PASS.
 
-- [ ] **Step 6: Byte-compile all migrated modules**
-
-Run:
+- [ ] **Step 7: Byte-compile migrated modules and search for retired references**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -402,30 +429,23 @@ emacs -Q --batch -L lisp \
   lisp/p3-terminal.el
 ```
 
-Expected: exit status 0 with no warnings or unresolved `p3/project-el-root` references.
+Expected: exit status 0 with no warnings.
 
-- [ ] **Step 7: Verify the retired helper is gone from implementation code**
-
-Run:
+Then:
 
 ```bash
 git grep -n "p3/project-el-root" -- '*.el'
-```
-
-Expected: no matches.
-
-Run:
-
-```bash
 git grep -n "projectile-project-root" -- lisp
 ```
 
-Expected: no matches in `lisp/`; Projectile may still appear in `config.org` and project scaffolding/tests because its UI and marker are intentionally retained.
+Expected: both commands return no implementation matches.
 
 - [ ] **Step 8: Commit Task 2**
 
 ```bash
-git add lisp/p3-ess.el lisp/p3-r-tools.el lisp/p3-python.el lisp/p3-terminal.el test/p3-python-test.el
+git add \
+  lisp/p3-ess.el lisp/p3-r-tools.el lisp/p3-python.el lisp/p3-terminal.el \
+  test/p3-python-test.el test/p3-r-tools-test.el
 git commit -m "refactor: share native project roots across workflows"
 ```
 
@@ -438,56 +458,48 @@ git commit -m "refactor: share native project roots across workflows"
 - Modify: `test/p3-config-test.el`
 
 **Interfaces:**
-- Consumes: eager `p3/windows-configure-rtools` platform setup and `p3-project` module from Tasks 1–2.
-- Produces: startup invariant that `.projectile` is registered with `project.el` before P3 project-aware subsystem configuration can call `project-current`.
+- Consumes: eager `p3/windows-configure-rtools` setup and `p3-project` from Tasks 1–2.
+- Produces: `.projectile` registration before any P3 project-aware subsystem configuration can invoke `project-current`.
 
-- [ ] **Step 1: Add failing config-structure assertions**
+- [ ] **Step 1: Add the failing module-delegation assertion**
 
-Update the module list in `p3-config-org-delegates-custom-subsystems-to-modules` so it includes `"p3-project"`:
+Change the module list in `p3-config-org-delegates-custom-subsystems-to-modules` to:
 
 ```emacs-lisp
 (dolist (module '("p3-platform" "p3-project" "p3-core" "p3-python"
                   "p3-terminal" "p3-ess" "p3-gptel"))
-  ...)
+  (goto-char (point-min))
+  (should (search-forward (format "(use-package %s" module) nil t)))
 ```
 
-Keep `"(defun p3/project-root"` in the implementation exclusion list so `config.org` is explicitly forbidden from reabsorbing project implementation.
+Keep `"(defun p3/project-root"` in the implementation exclusion list.
 
-Add a startup-order test:
+- [ ] **Step 2: Add a startup-order test using independent source positions**
+
+Add this helper and test to `test/p3-config-test.el`:
 
 ```emacs-lisp
+(defun p3-config-test--position-of (text)
+  "Return the position immediately after TEXT in the current buffer."
+  (goto-char (point-min))
+  (should (search-forward text nil t))
+  (point))
+
 (ert-deftest p3-config-project-foundation-precedes-project-consumers ()
   (with-temp-buffer
     (insert-file-contents (expand-file-name "config.org" p3-config-test--root))
     (let ((rtools-position
-           (progn
-             (should (search-forward "(p3/windows-configure-rtools)" nil t))
-             (point)))
-          project-position
-          core-position
-          python-position
-          ess-position
-          terminal-position)
-      (setq project-position
-            (progn
-              (should (search-forward "(use-package p3-project" nil t))
-              (point)))
-      (setq core-position
-            (progn
-              (should (search-forward "(use-package p3-core" nil t))
-              (point)))
-      (setq python-position
-            (progn
-              (should (search-forward "(use-package p3-python" nil t))
-              (point)))
-      (setq ess-position
-            (progn
-              (should (search-forward "(use-package p3-ess" nil t))
-              (point)))
-      (setq terminal-position
-            (progn
-              (should (search-forward "(use-package p3-terminal" nil t))
-              (point)))
+           (p3-config-test--position-of "(p3/windows-configure-rtools)"))
+          (project-position
+           (p3-config-test--position-of "(use-package p3-project"))
+          (core-position
+           (p3-config-test--position-of "(use-package p3-core"))
+          (python-position
+           (p3-config-test--position-of "(use-package p3-python"))
+          (ess-position
+           (p3-config-test--position-of "(use-package p3-ess"))
+          (terminal-position
+           (p3-config-test--position-of "(use-package p3-terminal")))
       (should (< rtools-position project-position))
       (should (< project-position core-position))
       (should (< project-position python-position))
@@ -495,11 +507,7 @@ Add a startup-order test:
       (should (< project-position terminal-position)))))
 ```
 
-If the actual current `config.org` order makes sequential `search-forward` unsuitable for one of these consumers, compute each position independently from `point-min`; keep the assertions themselves unchanged.
-
-- [ ] **Step 2: Run the config tests and verify the new module/order contract fails**
-
-Run:
+- [ ] **Step 3: Run the config tests and verify the new contract fails**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -509,11 +517,11 @@ emacs -Q --batch -L lisp \
 
 Expected: FAIL because `config.org` does not yet contain `(use-package p3-project ...)`.
 
-- [ ] **Step 3: Add the eager project foundation immediately after platform-path setup**
+- [ ] **Step 4: Add the eager project foundation directly after platform-path setup**
 
-In `config.org`, directly after the existing eager `p3-platform` block that calls `p3/windows-configure-rtools`, add:
+Immediately after the existing `p3-platform` block that calls `p3/windows-configure-rtools`, add:
 
-```emacs-lisp
+```org
 #+BEGIN_SRC emacs-lisp
   (use-package p3-project
     :ensure nil
@@ -521,13 +529,11 @@ In `config.org`, directly after the existing eager `p3-platform` block that call
 #+END_SRC
 ```
 
-Do not add keybindings or extra setup calls. Requiring `p3-project` is itself the startup action that registers `.projectile` in `project-vc-extra-root-markers`.
+Do not add keybindings or setup functions. Loading `p3-project` performs the marker registration.
 
-Keep the existing `p3-core` block responsible for `C-c e` / `C-c r`; do not move those commands into the project module.
+Keep the existing `p3-core` block responsible for `C-c e` and `C-c r`.
 
-- [ ] **Step 4: Run the config tests and tangle smoke test**
-
-Run:
+- [ ] **Step 5: Run config/tangle tests**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -535,9 +541,9 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: PASS, including readable `init.el`, readable tangled config, module delegation, platform ordering, and project-foundation ordering.
+Expected: PASS, including readable `init.el`, readable tangled output, module delegation, existing platform ordering, and project-foundation ordering.
 
-- [ ] **Step 5: Commit Task 3**
+- [ ] **Step 6: Commit Task 3**
 
 ```bash
 git add config.org test/p3-config-test.el
@@ -546,7 +552,7 @@ git commit -m "refactor: load project foundation before project workflows"
 
 ---
 
-### Task 4: Add Linux and Windows regression gates for the new boundary
+### Task 4: Add Linux and Windows regression gates
 
 **Files:**
 - Create: `test/p3-project-windows-test.el`
@@ -554,8 +560,8 @@ git commit -m "refactor: load project foundation before project workflows"
 - Modify: `.github/workflows/windows-platform-tests.yml`
 
 **Interfaces:**
-- Consumes: `p3/windows-configure-rtools`, `p3/project-root`, built-in `project-current`, and `project-files`.
-- Produces: CI evidence that marker-only project discovery works on Linux and that Windows project file enumeration works with a Unix-compatible MSYS2 tool directory placed first through the existing platform setup path.
+- Consumes: `p3/windows-configure-rtools`, `p3/project-root`, built-in `project-current`, `project-root`, and `project-files`.
+- Produces: final CI evidence for Linux project semantics and native-Windows marker-only file enumeration.
 
 - [ ] **Step 1: Write the native-Windows integration test**
 
@@ -600,14 +606,16 @@ Create `test/p3-project-windows-test.el`:
           (should (file-readable-p find))
           (make-directory child t)
           (with-temp-file (expand-file-name ".projectile" root))
-          (with-temp-file data-file (insert "x <- 1\n"))
+          (with-temp-file data-file
+            (insert "x <- 1\n"))
           (p3/windows-configure-rtools)
           (let* ((default-directory child)
                  (project (project-current nil))
                  (files (project-files project)))
             (should project)
             (should
-             (equal (file-name-as-directory (file-truename (project-root project)))
+             (equal (file-name-as-directory
+                     (file-truename (project-root project)))
                     (file-name-as-directory (file-truename root))))
             (should
              (seq-some
@@ -623,11 +631,11 @@ Create `test/p3-project-windows-test.el`:
 ;;; p3-project-windows-test.el ends here
 ```
 
-The test deliberately uses the normal `p3/windows-configure-rtools` path. CI supplies a known MSYS2-compatible root from the preinstalled Git for Windows distribution; this exercises the relevant path-ordering behavior without adding an Rtools installation to CI.
+CI will supply a known MSYS2-compatible root from Git for Windows. This exercises the existing `p3/windows-configure-rtools` path-ordering behavior without installing Rtools solely for CI.
 
-- [ ] **Step 2: Extend the normal Ubuntu Emacs test workflow**
+- [ ] **Step 2: Extend the normal Ubuntu workflow**
 
-In `.github/workflows/emacs-tests.yml`, add `lisp/p3-project.el` to the byte-compilation list before modules that require it:
+In `.github/workflows/emacs-tests.yml`, add `p3-project.el` to byte-compilation before modules that consume it:
 
 ```yaml
             lisp/p3-platform.el \
@@ -635,7 +643,7 @@ In `.github/workflows/emacs-tests.yml`, add `lisp/p3-project.el` to the byte-com
             lisp/p3-core.el \
 ```
 
-Add the new platform-neutral project tests to the ERT command before subsystem tests:
+Add `p3-project-test.el` to the ERT command:
 
 ```yaml
             -l test/p3-config-test.el \
@@ -643,11 +651,11 @@ Add the new platform-neutral project tests to the ERT command before subsystem t
             -l test/p3-core-test.el \
 ```
 
-Do not add the Windows-only integration test to this Linux job.
+Do not load the Windows-only integration test in this Linux job.
 
 - [ ] **Step 3: Expand Windows workflow path triggers narrowly**
 
-In `.github/workflows/windows-platform-tests.yml`, keep the existing platform paths and add:
+Keep the current paths and add:
 
 ```yaml
       - "lisp/p3-project.el"
@@ -655,11 +663,9 @@ In `.github/workflows/windows-platform-tests.yml`, keep the existing platform pa
       - "test/p3-project-windows-test.el"
 ```
 
-This causes Windows CI to run when either half of the project/platform integration changes.
+- [ ] **Step 4: Resolve the Git-for-Windows MSYS2 root**
 
-- [ ] **Step 4: Resolve a stable MSYS2 root from Git for Windows in CI**
-
-Before running ERT in `.github/workflows/windows-platform-tests.yml`, add:
+Before ERT in `.github/workflows/windows-platform-tests.yml`, add:
 
 ```yaml
       - name: Locate Git for Windows MSYS2 root
@@ -676,11 +682,11 @@ Before running ERT in `.github/workflows/windows-platform-tests.yml`, add:
           "P3_TEST_MSYS2_ROOT=$($gitRoot -replace '\\','/')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 ```
 
-This is test scaffolding only. Production Windows behavior continues to discover and use Rtools through `p3-platform.el`.
+Production behavior still discovers Rtools; Git for Windows is only the CI fixture providing the same `usr/bin/bash.exe` + Unix `find.exe` layout required by the path setup contract.
 
 - [ ] **Step 5: Extend the Windows compile/test commands**
 
-Change the byte-compile step to compile both boundary modules:
+Use:
 
 ```yaml
       - name: Byte-compile Windows boundary modules
@@ -691,11 +697,7 @@ Change the byte-compile step to compile both boundary modules:
           -f batch-byte-compile
           lisp/p3-platform.el
           lisp/p3-project.el
-```
 
-Change the test step to run both existing platform tests and the new Windows project integration test:
-
-```yaml
       - name: Run Windows platform and project tests
         shell: powershell
         run: >-
@@ -705,9 +707,9 @@ Change the test step to run both existing platform tests and the new Windows pro
           -f ert-run-tests-batch-and-exit
 ```
 
-- [ ] **Step 6: Run the complete local Linux gate before pushing CI changes**
+- [ ] **Step 6: Run the complete local Linux gate before pushing**
 
-Run exactly the suite used by `.github/workflows/emacs-tests.yml` after adding the new project test:
+Byte-compile exactly the normal workflow module set plus `p3-project.el`:
 
 ```bash
 emacs -Q --batch \
@@ -724,9 +726,9 @@ emacs -Q --batch \
   lisp/p3-gptel.el
 ```
 
-Expected: exit status 0 and no warnings.
+Expected: exit status 0 with no warnings.
 
-Then run:
+Run the complete ERT suite:
 
 ```bash
 emacs -Q --batch \
@@ -748,8 +750,6 @@ Expected: all ERT tests PASS.
 
 - [ ] **Step 7: Inspect the final diff for scope leakage**
 
-Run:
-
 ```bash
 git diff master...HEAD --stat
 git diff master...HEAD -- \
@@ -757,12 +757,12 @@ git diff master...HEAD -- \
   lisp/p3-python.el lisp/p3-terminal.el config.org test .github/workflows
 ```
 
-Verify all of the following before committing/pushing:
+Verify:
 
 - Projectile package configuration and keybindings still exist.
-- `p3-r--common-project-files` still emits `.projectile`.
-- No ESS process/session implementation changed beyond its required module dependency/commentary.
-- No terminal window/switching implementation changed beyond its required module dependency.
+- R project scaffolding still emits `.projectile` and the ERT assertion proves it.
+- ESS process/session code changed only in dependency/commentary lines.
+- Terminal switching/window code changed only in its dependency line.
 - No `display-buffer-alist` rules were added.
 - No startup/tangling redesign was introduced.
 - No `p3/project-el-root` implementation or references remain.
@@ -770,7 +770,10 @@ Verify all of the following before committing/pushing:
 - [ ] **Step 8: Commit Task 4**
 
 ```bash
-git add test/p3-project-windows-test.el .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
+git add \
+  test/p3-project-windows-test.el \
+  .github/workflows/emacs-tests.yml \
+  .github/workflows/windows-platform-tests.yml
 git commit -m "test: cover native project foundation across platforms"
 ```
 
@@ -781,7 +784,7 @@ Push `refactor/project-el-foundation` after the local suite is green. Confirm:
 - Ubuntu `Emacs tests` passes.
 - Windows `Windows platform tests` passes, including marker-only `project-files` enumeration.
 
-If CI reveals a platform-specific failure, diagnose that exact failure locally or from the job log before pushing another change; do not add diagnostic workflow machinery.
+If CI reveals a platform-specific failure, diagnose that exact failure from the job log before pushing another change. Do not add diagnostic workflow machinery.
 
 ---
 
@@ -795,7 +798,7 @@ PR 1 is implementation-complete only when all of these are true:
 4. Existing `.projectile` projects are recognized by native `project.el`, including nested projects inside outer Git repositories.
 5. Python resolves `.venv` from that shared inner root in the nested-project case.
 6. `config.org` eagerly loads `p3-project` after Windows Unix-tool path setup and before project-aware P3 modules.
-7. Existing R project scaffolding still creates `.projectile`.
+7. Existing R project scaffolding still creates `.projectile`, with explicit ERT coverage.
 8. The one-/two-window workflow is unchanged.
 9. Linux byte-compilation and the complete ERT suite pass.
 10. Native Windows project detection and `project-files` enumeration pass through the existing platform path setup.

--- a/docs/superpowers/plans/2026-09-02-project-el-foundation.md
+++ b/docs/superpowers/plans/2026-09-02-project-el-foundation.md
@@ -1,171 +1,63 @@
 # Project.el Foundation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** use superpowers:executing-plans or superpowers:subagent-driven-development and verify each task before proceeding.
 
-**Goal:** Make built-in `project.el` the single source of P3 project identity while preserving the existing R/ESS, terminal, Projectile UI, and one-/two-window workflows.
-
-**Architecture:** Add a focused `p3-project.el` library that owns native project discovery, `.projectile` marker registration, and the shared `p3/project-root` contract. Move project helpers out of `p3-core.el`, make ESS/R/Python/terminal consumers depend on `p3-project`, and eagerly load the project foundation after Windows tool-path setup but before project-aware subsystems. Preserve `.projectile` during this PR so Projectile and `project.el` can coexist while `project.el` becomes authoritative.
-
-**Tech Stack:** Emacs 29+, Emacs Lisp, built-in `project.el`, ERT, `use-package`, ESS/Python/vterm integration, GitHub Actions on Ubuntu and Windows.
+**Goal:** Make built-in `project.el` the single source of P3 project identity while preserving Projectile commands/UI and the existing one-/two-window workflow.
 
 **Spec:** `docs/superpowers/specs/2026-09-02-project-el-foundation-design.md`
 
-## Global Constraints
+## Constraints
 
-- Supported Emacs baseline: **Emacs 29 or newer**.
-- Built-in `project.el` is the only source of P3 project identity after this PR.
-- Keep Projectile installed, enabled, and keybound; do not remove or redesign its UI in this PR.
-- Keep existing `.projectile` markers; do not rename them to `.project` in this PR.
+- Support Emacs 29+.
+- Keep Projectile installed, enabled, and keybound.
+- Keep `.projectile` as the project marker in this PR.
+- Do not add a custom `project.el` backend or a Projectile fallback.
+- Do not change ESS session behavior, terminal placement, Python environment policy beyond shared root identity, or window layout.
 - A nested `.projectile` marker intentionally defines an inner P3 project inside an outer VCS repository.
-- Python intentionally adopts that shared inner project boundary and may therefore select a different project-local `.venv` than before this PR.
-- Preserve existing ESS process/session behavior, R helper behavior, terminal behavior, and Python environment policy apart from the approved shared-root semantic change.
-- Preserve the normal one- or two-window workflow; do not add `display-buffer-alist` rules or new window-management behavior.
-- Do not introduce a custom project backend or a Projectile fallback path.
-- On Windows, `.projectile`-only projects must support both root detection and `project-files` enumeration after the normal P3 Unix-tool path setup.
-- Do not use GitHub Actions as an iterative diagnostic loop. Run targeted and full local batch tests before the final push; use CI as the final cross-platform gate.
-- Do not merge without explicit user approval.
-
----
+- Python intentionally follows that inner project boundary.
+- Native Windows `.projectile` projects must support both root detection and `project-files` enumeration after P3's MSYS2/Rtools path setup.
+- Do not merge without explicit approval.
 
 ## File map
 
 **Create**
 
-- `lisp/p3-project.el` — canonical P3 project discovery and project-root helpers.
-- `test/p3-project-test.el` — platform-neutral behavioral tests for native project detection and nested project semantics.
-- `test/p3-project-windows-test.el` — native-Windows integration test for the platform/project file-enumeration contract.
+- `lisp/p3-project.el`
+- `test/p3-project-test.el`
+- `test/p3-project-windows-test.el`
 
 **Modify**
 
-- `lisp/p3-core.el` — remove project discovery; retain only shared config commands.
-- `lisp/p3-ess.el` — depend directly on `p3-project`; no ESS session behavior changes.
-- `lisp/p3-r-tools.el` — depend directly on `p3-project`; keep `.projectile` in generated projects.
-- `lisp/p3-python.el` — depend directly on `p3-project` and use `p3/project-root` for interpreter discovery.
-- `lisp/p3-terminal.el` — depend directly on `p3-project`; no terminal behavior changes.
-- `test/p3-core-test.el` — remove project tests that move to `p3-project-test.el`.
-- `test/p3-python-test.el` — replace the old separate-project-root regression with the approved shared-root behavior.
-- `test/p3-r-tools-test.el` — explicitly lock in `.projectile` generation.
-- `test/p3-config-test.el` — require visible/eager `p3-project` wiring and verify startup ordering.
-- `config.org` — eagerly load `p3-project` after Windows Rtools/MSYS2 path setup and before project-aware P3 subsystems.
-- `.github/workflows/emacs-tests.yml` — byte-compile and run the new project module/tests.
-- `.github/workflows/windows-platform-tests.yml` — run the Windows project/platform integration test when project/platform files change.
+- `init.el`
+- `lisp/p3-core.el`
+- `lisp/p3-ess.el`
+- `lisp/p3-python.el`
+- `lisp/p3-r-tools.el`
+- `lisp/p3-terminal.el`
+- `test/p3-config-test.el`
+- `test/p3-core-test.el`
+- `test/p3-python-test.el`
+- `test/p3-r-tools-test.el`
+- `.github/workflows/emacs-tests.yml`
+- `.github/workflows/windows-platform-tests.yml`
+
+`config.org` is intentionally **not** modified for project-foundation loading. `p3-project` is a bootstrap dependency and is required from `init.el` before the literate configuration is tangled or loaded.
 
 ---
 
-### Task 1: Extract canonical project identity into `p3-project.el`
+## Task 1: Extract project identity from `p3-core`
 
-**Files:**
-- Create: `lisp/p3-project.el`
-- Create: `test/p3-project-test.el`
-- Modify: `lisp/p3-core.el`
-- Modify: `test/p3-core-test.el`
+- [x] Create `lisp/p3-project.el`.
+- [x] Move `p3/project-root` and `p3/use-project-root-as-default-dir` into it.
+- [x] Require built-in `project` there.
+- [x] Register `.projectile` in `project-vc-extra-root-markers`.
+- [x] Make Emacs 29+ explicit by failing clearly if `project-vc-extra-root-markers` is unavailable.
+- [x] Remove project discovery from `p3-core.el`.
+- [x] Move project tests from `p3-core-test.el` to `p3-project-test.el`.
 
-**Interfaces:**
-- Consumes: built-in `project-current`, `project-root`, and `project-vc-extra-root-markers` from Emacs 29+.
-- Produces: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil`; loading the module registers `.projectile` in `project-vc-extra-root-markers`.
-
-- [ ] **Step 1: Write the failing project tests**
-
-Create `test/p3-project-test.el`:
+Core implementation:
 
 ```emacs-lisp
-;;; p3-project-test.el --- Tests for p3-project -*- lexical-binding: t; -*-
-
-(require 'ert)
-(require 'cl-lib)
-(require 'project)
-
-(defconst p3-project-test--root
-  (file-name-directory
-   (directory-file-name
-    (file-name-directory (or load-file-name buffer-file-name))))
-  "Root of the Emacs configuration under test.")
-
-(add-to-list 'load-path (expand-file-name "lisp" p3-project-test--root))
-
-(require 'p3-project)
-
-(defun p3-project-test--canonical-directory (directory)
-  "Return DIRECTORY in normalized form for root comparisons."
-  (file-name-as-directory (file-truename directory)))
-
-(ert-deftest p3-project-root-delegates-to-project-el ()
-  (cl-letf (((symbol-function 'project-current)
-             (lambda (&optional _maybe-prompt _directory) 'fake-project))
-            ((symbol-function 'project-root)
-             (lambda (_project) "/tmp/native-project/")))
-    (should (equal (p3/project-root) "/tmp/native-project/"))))
-
-(ert-deftest p3-project-root-does-not-consult-projectile ()
-  (cl-letf (((symbol-function 'project-current)
-             (lambda (&optional _maybe-prompt _directory) nil))
-            ((symbol-function 'projectile-project-root)
-             (lambda ()
-               (ert-fail "Projectile must not define P3 project identity"))))
-    (should-not (p3/project-root))))
-
-(ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
-  (let* ((root (make-temp-file "p3-project-marker-" t))
-         (child (expand-file-name "R/subdir" root)))
-    (unwind-protect
-        (progn
-          (make-directory child t)
-          (with-temp-file (expand-file-name ".projectile" root))
-          (let ((default-directory child))
-            (should
-             (equal (p3-project-test--canonical-directory (p3/project-root))
-                    (p3-project-test--canonical-directory root)))))
-      (delete-directory root t))))
-
-(ert-deftest p3-project-inner-marker-wins-over-outer-git-root ()
-  (skip-unless (executable-find "git"))
-  (let* ((outer (make-temp-file "p3-project-outer-" t))
-         (inner (expand-file-name "analysis" outer))
-         (child (expand-file-name "R" inner)))
-    (unwind-protect
-        (progn
-          (should
-           (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
-          (make-directory child t)
-          (with-temp-file (expand-file-name ".projectile" inner))
-          (let ((default-directory child))
-            (should
-             (equal (p3-project-test--canonical-directory (p3/project-root))
-                    (p3-project-test--canonical-directory inner)))))
-      (delete-directory outer t))))
-
-(ert-deftest p3-project-default-directory-is-buffer-local ()
-  (with-temp-buffer
-    (let ((original default-directory))
-      (cl-letf (((symbol-function 'p3/project-root)
-                 (lambda () "/tmp/project-root/")))
-        (p3/use-project-root-as-default-dir)
-        (should (local-variable-p 'default-directory))
-        (should (equal default-directory "/tmp/project-root/"))
-        (should-not (equal original default-directory))))))
-
-(provide 'p3-project-test)
-
-;;; p3-project-test.el ends here
-```
-
-- [ ] **Step 2: Run the new tests and verify the module is missing**
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-project-test.el \
-  -f ert-run-tests-batch-and-exit
-```
-
-Expected: FAIL while loading because `p3-project` does not exist.
-
-- [ ] **Step 3: Create the minimal native project module**
-
-Create `lisp/p3-project.el`:
-
-```emacs-lisp
-;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
-
 (require 'project)
 
 (unless (boundp 'project-vc-extra-root-markers)
@@ -177,75 +69,16 @@ Create `lisp/p3-project.el`:
   "Return the current built-in `project.el' root, if any."
   (when-let ((project (project-current nil)))
     (project-root project)))
-
-(defun p3/use-project-root-as-default-dir ()
-  "Use the current project root as the buffer's default directory."
-  (when-let ((root (p3/project-root)))
-    (setq-local default-directory root)))
-
-(provide 'p3-project)
-
-;;; p3-project.el ends here
 ```
 
-- [ ] **Step 4: Replace `p3-core.el` with the exact reduced implementation**
+Required behavior tests:
 
-`lisp/p3-core.el` should contain only:
+1. `p3/project-root` delegates to `project-current`/`project-root`.
+2. A `.projectile`-only project is detected from a descendant directory.
+3. A nested `.projectile` marker wins over an outer Git root.
+4. `p3/use-project-root-as-default-dir` remains buffer-local.
 
-```emacs-lisp
-;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
-
-(declare-function p3/load-config nil (&optional quiet))
-
-(defun p3/config-visit ()
-  "Visit the authoritative literate Emacs configuration."
-  (interactive)
-  (find-file
-   (if (boundp 'p3/config-source)
-       p3/config-source
-     (expand-file-name "config.org" user-emacs-directory))))
-
-(defun p3/config-reload ()
-  "Tangle and reload the authoritative literate Emacs configuration."
-  (interactive)
-  (unless (fboundp 'p3/load-config)
-    (user-error "Config loader is unavailable"))
-  (p3/load-config))
-
-(provide 'p3-core)
-
-;;; p3-core.el ends here
-```
-
-- [ ] **Step 5: Reduce `p3-core-test.el` to the exact behavior still owned by core**
-
-Replace `test/p3-core-test.el` with:
-
-```emacs-lisp
-;;; p3-core-test.el --- Tests for p3-core -*- lexical-binding: t; -*-
-
-(require 'ert)
-
-(defconst p3-core-test--root
-  (file-name-directory
-   (directory-file-name
-    (file-name-directory (or load-file-name buffer-file-name))))
-  "Root of the Emacs configuration under test.")
-
-(add-to-list 'load-path (expand-file-name "lisp" p3-core-test--root))
-
-(require 'p3-core)
-
-(ert-deftest p3-core-config-commands-remain-commands ()
-  (should (commandp #'p3/config-visit))
-  (should (commandp #'p3/config-reload)))
-
-(provide 'p3-core-test)
-
-;;; p3-core-test.el ends here
-```
-
-- [ ] **Step 6: Run the focused tests**
+Focused verification:
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -254,155 +87,29 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all project/core tests PASS.
-
-- [ ] **Step 7: Byte-compile the new boundary**
-
-```bash
-emacs -Q --batch -L lisp \
-  --eval '(setq byte-compile-error-on-warn t)' \
-  -f batch-byte-compile \
-  lisp/p3-project.el \
-  lisp/p3-core.el
-```
-
-Expected: exit status 0 with no warnings.
-
-- [ ] **Step 8: Commit Task 1**
-
-```bash
-git add lisp/p3-project.el lisp/p3-core.el test/p3-project-test.el test/p3-core-test.el
-git commit -m "refactor: make project.el own project identity"
-```
-
 ---
 
-### Task 2: Migrate ESS, R, Python, and terminal consumers
+## Task 2: Migrate project-aware consumers
 
-**Files:**
-- Modify: `lisp/p3-ess.el`
-- Modify: `lisp/p3-r-tools.el`
-- Modify: `lisp/p3-python.el`
-- Modify: `lisp/p3-terminal.el`
-- Modify: `test/p3-python-test.el`
-- Modify: `test/p3-r-tools-test.el`
-- Verify: `test/p3-ess-test.el`, `test/p3-terminal-test.el`
+- [x] Change `p3-ess.el` to require `p3-project` directly.
+- [x] Change `p3-r-tools.el` to require `p3-project` directly.
+- [x] Change `p3-terminal.el` to require `p3-project` directly.
+- [x] Change `p3-python.el` to require `p3-project` directly.
+- [x] Replace Python's separate `p3/project-el-root` path with the shared `p3/project-root` contract.
+- [x] Keep R project scaffolding emitting `.projectile`.
 
-**Interfaces:**
-- Consumes: `p3/project-root () -> directory-or-nil` and `p3/use-project-root-as-default-dir () -> nil` from `p3-project.el`.
-- Produces: no new public interface; existing subsystem commands keep their current names and behavior.
-
-- [ ] **Step 1: Replace the obsolete Python regression with the shared-root unit test**
-
-Remove `p3-python-project-interpreter-preserves-project-el-root` from `test/p3-python-test.el` and add:
-
-```emacs-lisp
-(ert-deftest p3-python-project-interpreter-uses-shared-p3-root ()
-  (p3-python-test--with-temp-project root
-    (let ((interpreter
-           (p3-python-test--make-executable
-            (expand-file-name ".venv/bin/python" root)))
-          (system-type 'gnu/linux))
-      (cl-letf (((symbol-function 'p3/project-root)
-                 (lambda () root)))
-        (should (equal (p3/python-project-interpreter) interpreter))))))
-```
-
-Update these existing tests so they mock `p3/project-root` directly instead of `project-current`/`project-root`:
-
-- `p3-python-project-interpreter-prefers-dot-venv`
-- `p3-python-setup-project-interpreter-is-buffer-local`
-- `p3-python-project-interpreter-supports-windows-venv-layout`
-
-- [ ] **Step 2: Add the nested-project Python integration test**
-
-Add:
-
-```emacs-lisp
-(ert-deftest p3-python-inner-project-marker-selects-inner-venv ()
-  (skip-unless (executable-find "git"))
-  (p3-python-test--with-temp-project outer
-    (let* ((inner (expand-file-name "analysis" outer))
-           (source-directory (expand-file-name "src" inner))
-           (interpreter
-            (p3-python-test--make-executable
-             (expand-file-name ".venv/bin/python" inner)))
-           (system-type 'gnu/linux))
-      (should
-       (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
-      (make-directory source-directory t)
-      (with-temp-file (expand-file-name ".projectile" inner))
-      (let ((default-directory source-directory))
-        (should (equal (p3/python-project-interpreter) interpreter))))))
-```
-
-- [ ] **Step 3: Add an explicit scaffolding regression for `.projectile`**
-
-In `p3-r-new-analysis-project-generates-expected-files`, add:
-
-```emacs-lisp
-(should (file-exists-p (expand-file-name ".projectile" root)))
-```
-
-This turns the retained marker from an implementation assumption into a tested compatibility contract.
-
-- [ ] **Step 4: Run Python/R tests and verify the Python behavior still fails**
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-project-test.el \
-  -l test/p3-python-test.el \
-  -l test/p3-r-tools-test.el \
-  -f ert-run-tests-batch-and-exit
-```
-
-Expected: Python shared-root tests FAIL against the old implementation; the new R marker assertion already passes.
-
-- [ ] **Step 5: Migrate the four modules to `p3-project`**
-
-In `lisp/p3-python.el`, replace:
-
-```emacs-lisp
-(require 'p3-core)
-```
-
-with:
-
-```emacs-lisp
-(require 'p3-project)
-```
-
-and replace:
-
-```emacs-lisp
-(when-let ((root (p3/project-el-root)))
-```
-
-with:
-
-```emacs-lisp
-(when-let ((root (p3/project-root)))
-```
-
-In `lisp/p3-ess.el`, replace `(require 'p3-core)` with `(require 'p3-project)` and change the commentary sentence from:
+The only intended semantic change is Python in nested projects:
 
 ```text
-Project identity is delegated to p3-core so ESS,
-Python, R helpers, and terminal workflows use the same root abstraction.
+outer Git repo/
+└── analysis/
+    ├── .projectile
+    └── .venv/
 ```
 
-to:
+Python must now resolve `analysis/` as the P3 root and select the inner `.venv`.
 
-```text
-Project identity is delegated to p3-project so ESS,
-Python, R helpers, and terminal workflows use the same root abstraction.
-```
-
-In both `lisp/p3-r-tools.el` and `lisp/p3-terminal.el`, replace `(require 'p3-core)` with `(require 'p3-project)`.
-
-Do not change the `.projectile` entry in `p3-r--common-project-files`.
-
-- [ ] **Step 6: Run all project-dependent subsystem tests**
+Focused verification:
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -414,302 +121,69 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all tests PASS.
-
-- [ ] **Step 7: Byte-compile migrated modules and search for retired references**
-
-```bash
-emacs -Q --batch -L lisp \
-  --eval '(setq byte-compile-error-on-warn t)' \
-  -f batch-byte-compile \
-  lisp/p3-project.el \
-  lisp/p3-ess.el \
-  lisp/p3-r-tools.el \
-  lisp/p3-python.el \
-  lisp/p3-terminal.el
-```
-
-Expected: exit status 0 with no warnings.
-
-Then:
-
-```bash
-git grep -n "p3/project-el-root" -- '*.el'
-git grep -n "projectile-project-root" -- lisp
-```
-
-Expected: both commands return no implementation matches.
-
-- [ ] **Step 8: Commit Task 2**
-
-```bash
-git add \
-  lisp/p3-ess.el lisp/p3-r-tools.el lisp/p3-python.el lisp/p3-terminal.el \
-  test/p3-python-test.el test/p3-r-tools-test.el
-git commit -m "refactor: share native project roots across workflows"
-```
-
 ---
 
-### Task 3: Establish eager project-foundation startup wiring
+## Task 3: Establish project identity at bootstrap
 
-**Files:**
-- Modify: `config.org`
-- Modify: `test/p3-config-test.el`
+- [x] Add the P3 Lisp directory to `load-path` in `init.el`.
+- [x] Immediately require `p3-project` before calling `p3/load-config`.
+- [x] Keep platform setup in `config.org`; do not move Rtools/MSYS2 setup into the project library.
+- [x] Add a config regression test proving `p3-project` loads after the Lisp path is established and before the literate config is loaded.
 
-**Interfaces:**
-- Consumes: eager `p3/windows-configure-rtools` setup and `p3-project` from Tasks 1–2.
-- Produces: `.projectile` registration before any P3 project-aware subsystem configuration can invoke `project-current`.
-
-- [ ] **Step 1: Add the failing module-delegation assertion**
-
-Change the module list in `p3-config-org-delegates-custom-subsystems-to-modules` to:
+Required ordering:
 
 ```emacs-lisp
-(dolist (module '("p3-platform" "p3-project" "p3-core" "p3-python"
-                  "p3-terminal" "p3-ess" "p3-gptel"))
-  (goto-char (point-min))
-  (should (search-forward (format "(use-package %s" module) nil t)))
-```
-
-Keep `"(defun p3/project-root"` in the implementation exclusion list.
-
-- [ ] **Step 2: Add a startup-order test using independent source positions**
-
-Add this helper and test to `test/p3-config-test.el`:
-
-```emacs-lisp
-(defun p3-config-test--position-of (text)
-  "Return the position immediately after TEXT in the current buffer."
-  (goto-char (point-min))
-  (should (search-forward text nil t))
-  (point))
-
-(ert-deftest p3-config-project-foundation-precedes-project-consumers ()
-  (with-temp-buffer
-    (insert-file-contents (expand-file-name "config.org" p3-config-test--root))
-    (let ((rtools-position
-           (p3-config-test--position-of "(p3/windows-configure-rtools)"))
-          (project-position
-           (p3-config-test--position-of "(use-package p3-project"))
-          (core-position
-           (p3-config-test--position-of "(use-package p3-core"))
-          (python-position
-           (p3-config-test--position-of "(use-package p3-python"))
-          (ess-position
-           (p3-config-test--position-of "(use-package p3-ess"))
-          (terminal-position
-           (p3-config-test--position-of "(use-package p3-terminal")))
-      (should (< rtools-position project-position))
-      (should (< project-position core-position))
-      (should (< project-position python-position))
-      (should (< project-position ess-position))
-      (should (< project-position terminal-position)))))
-```
-
-- [ ] **Step 3: Run the config tests and verify the new contract fails**
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-test.el \
-  -f ert-run-tests-batch-and-exit
-```
-
-Expected: FAIL because `config.org` does not yet contain `(use-package p3-project ...)`.
-
-- [ ] **Step 4: Add the eager project foundation directly after platform-path setup**
-
-Immediately after the existing `p3-platform` block that calls `p3/windows-configure-rtools`, add:
-
-```org
-#+BEGIN_SRC emacs-lisp
-  (use-package p3-project
-    :ensure nil
-    :demand t)
-#+END_SRC
-```
-
-Do not add keybindings or setup functions. Loading `p3-project` performs the marker registration.
-
-Keep the existing `p3-core` block responsible for `C-c e` and `C-c r`.
-
-- [ ] **Step 5: Run config/tangle tests**
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-test.el \
-  -f ert-run-tests-batch-and-exit
-```
-
-Expected: PASS, including readable `init.el`, readable tangled output, module delegation, existing platform ordering, and project-foundation ordering.
-
-- [ ] **Step 6: Commit Task 3**
-
-```bash
-git add config.org test/p3-config-test.el
-git commit -m "refactor: load project foundation before project workflows"
-```
-
----
-
-### Task 4: Add Linux and Windows regression gates
-
-**Files:**
-- Create: `test/p3-project-windows-test.el`
-- Modify: `.github/workflows/emacs-tests.yml`
-- Modify: `.github/workflows/windows-platform-tests.yml`
-
-**Interfaces:**
-- Consumes: `p3/windows-configure-rtools`, `p3/project-root`, built-in `project-current`, `project-root`, and `project-files`.
-- Produces: final CI evidence for Linux project semantics and native-Windows marker-only file enumeration.
-
-- [ ] **Step 1: Write the native-Windows integration test**
-
-Create `test/p3-project-windows-test.el`:
-
-```emacs-lisp
-;;; p3-project-windows-test.el --- Windows project/platform integration tests -*- lexical-binding: t; -*-
-
-(require 'ert)
-(require 'seq)
-(require 'project)
-
-(defconst p3-project-windows-test--root
-  (file-name-directory
-   (directory-file-name
-    (file-name-directory (or load-file-name buffer-file-name))))
-  "Root of the Emacs configuration under test.")
-
-(add-to-list 'load-path (expand-file-name "lisp" p3-project-windows-test--root))
-
-(require 'p3-platform)
+(defconst p3/lisp-directory
+  (expand-file-name "lisp" user-emacs-directory))
+(add-to-list 'load-path p3/lisp-directory)
 (require 'p3-project)
 
-(ert-deftest p3-project-windows-msys2-tools-support-marker-project-files ()
-  (unless (eq system-type 'windows-nt)
-    (ert-skip "Native Windows-only project enumeration contract"))
-  (let* ((msys2-root (getenv "P3_TEST_MSYS2_ROOT"))
-         (usr-bin (and msys2-root (expand-file-name "usr/bin" msys2-root)))
-         (bash (and usr-bin (expand-file-name "bash.exe" usr-bin)))
-         (find (and usr-bin (expand-file-name "find.exe" usr-bin)))
-         (root (make-temp-file "p3-project-windows-" t))
-         (child (expand-file-name "R" root))
-         (data-file (expand-file-name "R/example.R" root))
-         (old-path (getenv "PATH"))
-         (old-exec-path (copy-sequence exec-path))
-         (p3/windows-rtools-override msys2-root)
-         (find-program "find"))
-    (unwind-protect
-        (progn
-          (should msys2-root)
-          (should (file-readable-p bash))
-          (should (file-readable-p find))
-          (make-directory child t)
-          (with-temp-file (expand-file-name ".projectile" root))
-          (with-temp-file data-file
-            (insert "x <- 1\n"))
-          (p3/windows-configure-rtools)
-          (let* ((default-directory child)
-                 (project (project-current nil))
-                 (files (project-files project)))
-            (should project)
-            (should
-             (equal (file-name-as-directory
-                     (file-truename (project-root project)))
-                    (file-name-as-directory (file-truename root))))
-            (should
-             (seq-some
-              (lambda (file)
-                (string-equal (file-name-nondirectory file) "example.R"))
-              files))))
-      (setq exec-path old-exec-path)
-      (setenv "PATH" old-path)
-      (delete-directory root t))))
-
-(provide 'p3-project-windows-test)
-
-;;; p3-project-windows-test.el ends here
+;; definition of p3/load-config ...
+(p3/load-config t)
 ```
 
-CI will supply a known MSYS2-compatible root from Git for Windows. This exercises the existing `p3/windows-configure-rtools` path-ordering behavior without installing Rtools solely for CI.
+This bootstrap position is intentional: `.projectile` must be registered before any project-aware package can populate `project.el` caches.
 
-- [ ] **Step 2: Extend the normal Ubuntu workflow**
+---
 
-In `.github/workflows/emacs-tests.yml`, add `p3-project.el` to byte-compilation before modules that consume it:
+## Task 4: Prevent Projectile from becoming the `project.el` provider
 
-```yaml
-            lisp/p3-platform.el \
-            lisp/p3-project.el \
-            lisp/p3-core.el \
+Projectile's global mode adds `project-projectile` to `project-find-functions`. Leaving that hook in place would make `p3/project-root` indirectly call Projectile even though P3 no longer calls `projectile-project-root` itself.
+
+- [x] Keep `projectile-mode` enabled.
+- [x] Add a P3 policy function that removes only `project-projectile` from `project-find-functions`.
+- [x] Run that policy once when `p3-project.el` loads.
+- [x] Add it to `projectile-mode-hook` so toggling/re-enabling Projectile cannot restore itself as the `project.el` provider.
+- [x] Do not advise Projectile internals and do not disable Projectile commands/UI.
+
+Implementation:
+
+```emacs-lisp
+(defun p3/project-keep-native-provider ()
+  "Keep Projectile from overriding native `project.el' project discovery."
+  (remove-hook 'project-find-functions #'project-projectile))
+
+(add-hook 'projectile-mode-hook #'p3/project-keep-native-provider)
+(p3/project-keep-native-provider)
 ```
 
-Add `p3-project-test.el` to the ERT command:
+Regression test requirements:
 
-```yaml
-            -l test/p3-config-test.el \
-            -l test/p3-project-test.el \
-            -l test/p3-core-test.el \
-```
+1. Start with `project-find-functions` containing `project-projectile` ahead of `project-try-vc`.
+2. Run `projectile-mode-hook`.
+3. Verify `project-projectile` is removed while `project-try-vc` remains.
+4. Perform a real `project-current` lookup in a temporary Git repository.
+5. Fail the test if `project-projectile` is invoked.
 
-Do not load the Windows-only integration test in this Linux job.
+The regression was first introduced without the production fix and verified to fail specifically because `project-projectile` remained in `project-find-functions`. The implementation was added only after that red result.
 
-- [ ] **Step 3: Expand Windows workflow path triggers narrowly**
+---
 
-Keep the current paths and add:
+## Task 5: Cross-platform verification
 
-```yaml
-      - "lisp/p3-project.el"
-      - "test/p3-project-test.el"
-      - "test/p3-project-windows-test.el"
-```
+### Ubuntu / Emacs 29
 
-- [ ] **Step 4: Resolve the Git-for-Windows MSYS2 root**
-
-Before ERT in `.github/workflows/windows-platform-tests.yml`, add:
-
-```yaml
-      - name: Locate Git for Windows MSYS2 root
-        shell: powershell
-        run: |
-          $gitExe = (Get-Command git).Source
-          $gitRoot = Split-Path (Split-Path $gitExe -Parent) -Parent
-          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/bash.exe"))) {
-            throw "Git for Windows MSYS2 bash not found under $gitRoot"
-          }
-          if (-not (Test-Path (Join-Path $gitRoot "usr/bin/find.exe"))) {
-            throw "Git for Windows MSYS2 find not found under $gitRoot"
-          }
-          "P3_TEST_MSYS2_ROOT=$($gitRoot -replace '\\','/')" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-```
-
-Production behavior still discovers Rtools; Git for Windows is only the CI fixture providing the same `usr/bin/bash.exe` + Unix `find.exe` layout required by the path setup contract.
-
-- [ ] **Step 5: Extend the Windows compile/test commands**
-
-Use:
-
-```yaml
-      - name: Byte-compile Windows boundary modules
-        shell: powershell
-        run: >-
-          emacs -Q --batch -L lisp
-          --eval "(setq byte-compile-error-on-warn t)"
-          -f batch-byte-compile
-          lisp/p3-platform.el
-          lisp/p3-project.el
-
-      - name: Run Windows platform and project tests
-        shell: powershell
-        run: >-
-          emacs -Q --batch -L lisp
-          -l test/p3-platform-test.el
-          -l test/p3-project-windows-test.el
-          -f ert-run-tests-batch-and-exit
-```
-
-- [ ] **Step 6: Run the complete local Linux gate before pushing**
-
-Byte-compile exactly the normal workflow module set plus `p3-project.el`:
+Byte-compile extracted modules with warnings as errors, including `p3-project.el`, then run the full ERT suite including `p3-project-test.el`.
 
 ```bash
 emacs -Q --batch \
@@ -726,81 +200,34 @@ emacs -Q --batch \
   lisp/p3-gptel.el
 ```
 
-Expected: exit status 0 with no warnings.
+Then run the repository ERT suite.
 
-Run the complete ERT suite:
+### Native Windows
 
-```bash
-emacs -Q --batch \
-  -L lisp \
-  -l test/p3-config-test.el \
-  -l test/p3-project-test.el \
-  -l test/p3-core-test.el \
-  -l test/p3-platform-test.el \
-  -l test/p3-python-test.el \
-  -l test/p3-terminal-test.el \
-  -l test/p3-ess-test.el \
-  -l test/p3-gptel-test.el \
-  -l test/p3-r-tools-test.el \
-  -l test/p3-org-export-test.el \
-  -f ert-run-tests-batch-and-exit
-```
+Extend the existing Windows workflow rather than adding a new workflow.
 
-Expected: all ERT tests PASS.
+The Windows gate must:
 
-- [ ] **Step 7: Inspect the final diff for scope leakage**
+1. expose a Unix-compatible MSYS2 `find`/`bash` environment to P3 platform setup;
+2. byte-compile `p3-platform.el` and `p3-project.el`;
+3. create a temporary `.projectile`-only project;
+4. confirm `project-current` resolves its root;
+5. confirm `project-files` enumerates a file inside it.
 
-```bash
-git diff master...HEAD --stat
-git diff master...HEAD -- \
-  lisp/p3-project.el lisp/p3-core.el lisp/p3-ess.el lisp/p3-r-tools.el \
-  lisp/p3-python.el lisp/p3-terminal.el config.org test .github/workflows
-```
-
-Verify:
-
-- Projectile package configuration and keybindings still exist.
-- R project scaffolding still emits `.projectile` and the ERT assertion proves it.
-- ESS process/session code changed only in dependency/commentary lines.
-- Terminal switching/window code changed only in its dependency line.
-- No `display-buffer-alist` rules were added.
-- No startup/tangling redesign was introduced.
-- No `p3/project-el-root` implementation or references remain.
-
-- [ ] **Step 8: Commit Task 4**
-
-```bash
-git add \
-  test/p3-project-windows-test.el \
-  .github/workflows/emacs-tests.yml \
-  .github/workflows/windows-platform-tests.yml
-git commit -m "test: cover native project foundation across platforms"
-```
-
-- [ ] **Step 9: Push once and use CI as the final cross-platform gate**
-
-Push `refactor/project-el-foundation` after the local suite is green. Confirm:
-
-- Ubuntu `Emacs tests` passes.
-- Windows `Windows platform tests` passes, including marker-only `project-files` enumeration.
-
-If CI reveals a platform-specific failure, diagnose that exact failure from the job log before pushing another change. Do not add diagnostic workflow machinery.
+The CI fixture may use Git for Windows' bundled MSYS2 tree because the contract under test is the same one P3 relies on from Rtools: `usr/bin/bash.exe` plus a Unix-compatible `find.exe` exposed through the platform setup.
 
 ---
 
-## Completion criteria
+## Final review checklist
 
-PR 1 is implementation-complete only when all of these are true:
-
-1. `p3-project.el` exclusively owns `p3/project-root` and `p3/use-project-root-as-default-dir`.
-2. No P3 implementation calls `projectile-project-root` or the retired `p3/project-el-root` helper.
-3. ESS, R tools, Python, and terminal code consume the same `p3/project-root` contract.
-4. Existing `.projectile` projects are recognized by native `project.el`, including nested projects inside outer Git repositories.
-5. Python resolves `.venv` from that shared inner root in the nested-project case.
-6. `config.org` eagerly loads `p3-project` after Windows Unix-tool path setup and before project-aware P3 modules.
-7. Existing R project scaffolding still creates `.projectile`, with explicit ERT coverage.
-8. The one-/two-window workflow is unchanged.
-9. Linux byte-compilation and the complete ERT suite pass.
-10. Native Windows project detection and `project-files` enumeration pass through the existing platform path setup.
-11. The final diff contains no Projectile removal, ESS redesign, Python environment-manager redesign, Org changes, startup/tangling redesign, or buffer-layout changes.
-12. The branch is not merged without explicit user approval.
+- [x] `project.el` owns P3 identity.
+- [x] Projectile remains available as UI/commands but cannot provide `project-current` results for P3.
+- [x] `.projectile` remains supported for old and newly generated projects.
+- [x] Nested `.projectile` semantics are explicit and tested.
+- [x] Python uses the shared root.
+- [x] ESS/R/vterm behavior is otherwise unchanged.
+- [x] No new window-management behavior is introduced.
+- [x] `config.org` startup/tangling behavior is not redesigned.
+- [x] Windows project-file enumeration is covered.
+- [ ] Final Ubuntu and Windows CI gates green on the reviewed head.
+- [ ] Explicit merge approval received.

--- a/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
+++ b/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
@@ -27,7 +27,9 @@ Introduce `lisp/p3-project.el` as the owner of project discovery and project-roo
 
 Keeping `.projectile` as the marker in this PR is intentional. Existing non-VCS R projects and newly generated R projects remain recognizable to Projectile, while `project.el` gains the same root marker. A later PR can decide whether Projectile is still useful and whether the marker should be renamed.
 
-Registration of `.projectile` is startup-critical. `p3-project.el` must be loaded before any P3 subsystem or package configuration is allowed to call `project-current`, because `project.el` may cache project detection. The configuration must therefore establish the marker during the eager P3 foundation setup rather than waiting for an R, Python, ESS, or terminal buffer to load the module lazily.
+Registration of `.projectile` is startup-critical. `p3-project.el` must be loaded before any P3 subsystem or package configuration is allowed to call `project-current`, because `project.el` may cache project detection. The bootstrap therefore requires `p3-project` in `init.el` immediately after the P3 Lisp directory enters `load-path` and before the literate configuration is tangled or loaded. This is an intentionally narrow bootstrap responsibility, not a broader startup/tangling redesign.
+
+The existing platform setup still configures Rtools/MSYS2 early in the literate configuration before normal project-aware workflows run. Registering the project marker itself does not depend on those Unix tools; project file enumeration on Windows does, and is covered separately by the Windows integration gate.
 
 `p3-core.el` will return to genuinely shared configuration helpers and will no longer contain project discovery.
 
@@ -89,7 +91,7 @@ Add or revise ERT coverage to establish these invariants:
 4. `p3-core.el` no longer owns project discovery.
 5. Python uses the shared `p3/project-root` contract and, in the nested-project case, resolves a project-local `.venv` from the inner root.
 6. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without other behavioral changes.
-7. `.projectile` registration is established by the eager P3 foundation configuration before project-aware subsystem setup.
+7. `init.el` loads `p3-project` after adding the P3 Lisp directory to `load-path` and before loading the literate configuration.
 8. On Windows, a `.projectile`-only project can both be detected and have its files enumerated after normal P3 platform setup.
 9. The extracted modules byte-compile with warnings treated as errors.
 10. The existing full ERT suite remains green.

--- a/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
+++ b/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
@@ -2,13 +2,17 @@
 
 ## Goal
 
-Make built-in `project.el` the single source of project identity for the Emacs configuration without changing the user-facing workflow. R/ESS, Python, R helpers, and project-aware terminals should all consume the same project root. Projectile remains installed and usable during this PR, but it no longer determines P3 project semantics.
+Make built-in `project.el` the single source of project identity for the Emacs configuration. R/ESS, Python, R helpers, and project-aware terminals should all consume the same project root. Projectile remains installed and usable during this PR, but it no longer determines P3 project semantics.
+
+This design targets Emacs 29 or newer. That baseline is required because this PR relies on `project-vc-extra-root-markers` for native recognition of existing `.projectile` project markers.
 
 ## Scope
 
-This PR is limited to project identity and project-root plumbing. It does not redesign ESS process management, Python environments, buffer placement, completion, startup/tangling, Org-roam, or Projectile keybindings.
+This PR is limited to project identity and project-root plumbing. It does not redesign ESS process management, Python environment management, buffer placement, completion, startup/tangling, Org-roam, or Projectile keybindings.
 
 The normal one- or two-window workflow must remain unchanged.
+
+One intentional semantic change is included: Python will use the same shared project root as the other P3 subsystems. In nested cases where a `.projectile` marker defines an inner project inside a larger VCS repository, Python will now use the inner project root as well. This aligns Python with the existing P3/Projectile project semantics and is covered explicitly by tests.
 
 ## Architecture
 
@@ -17,11 +21,13 @@ Introduce `lisp/p3-project.el` as the owner of project discovery and project-roo
 `p3-project.el` will:
 
 - require built-in `project`;
+- register `.projectile` in `project-vc-extra-root-markers`;
 - expose the existing `p3/project-root` interface, backed only by `project-current` and `project-root`;
-- expose `p3/use-project-root-as-default-dir`;
-- register `.projectile` as an additional `project.el` root marker through `project-vc-extra-root-markers` when that variable is available.
+- expose `p3/use-project-root-as-default-dir`.
 
 Keeping `.projectile` as the marker in this PR is intentional. Existing non-VCS R projects and newly generated R projects remain recognizable to Projectile, while `project.el` gains the same root marker. A later PR can decide whether Projectile is still useful and whether the marker should be renamed.
+
+Registration of `.projectile` is startup-critical. `p3-project.el` must be loaded before any P3 subsystem or package configuration is allowed to call `project-current`, because `project.el` may cache project detection. The configuration must therefore establish the marker during the eager P3 foundation setup rather than waiting for an R, Python, ESS, or terminal buffer to load the module lazily.
 
 `p3-core.el` will return to genuinely shared configuration helpers and will no longer contain project discovery.
 
@@ -34,33 +40,61 @@ Project-aware subsystems will depend directly on `p3-project.el` rather than rec
 
 `p3-python.el` will stop using the separate `p3/project-el-root` helper and use the shared `p3/project-root` contract like the other subsystems.
 
+## Project-root semantics
+
+Normal Git/VC repositories continue to use the standard `project.el` VC-aware backend.
+
+A `.projectile` marker additionally defines a P3 project root through `project-vc-extra-root-markers`. This applies both to non-VCS projects and to subprojects nested inside a larger VCS repository.
+
+When both an outer VCS root and an inner `.projectile` marker are present, the inner marker is intentionally the project boundary for P3. This preserves the practical semantics of the current Projectile-first `p3/project-root` helper while moving the implementation to built-in `project.el`.
+
+As a consequence, Python project-local interpreter discovery will also use that inner root after this PR. For example, if `~/repo/analysis/.projectile` and `~/repo/analysis/.venv` exist inside an outer Git repository at `~/repo`, Python will select `~/repo/analysis` as its project root and discover the inner `.venv`.
+
 ## Compatibility
 
 Projectile is not removed, disabled, or re-keyed. Existing `.projectile` project markers stay in place, including the marker emitted by the R project scaffolder.
 
-Git repositories continue to be recognized by the normal `project.el` VC-aware backend. Non-VCS directories containing `.projectile` are recognized by adding that marker to `project-vc-extra-root-markers` on Emacs versions that provide the option.
+The supported baseline for this design is Emacs 29+. No compatibility backend for older Emacs versions will be added in this PR. If pre-29 support becomes a real requirement, it should be handled as a separate compatibility decision rather than by retaining two competing project systems.
+
+Git repositories continue to be recognized by the normal `project.el` VC-aware backend. Non-VCS directories containing `.projectile` are recognized through `project-vc-extra-root-markers`.
 
 No P3 command in this PR should create additional windows or alter buffer-placement behavior.
+
+## Windows contract
+
+Native Windows support must preserve project discovery and file enumeration for `.projectile`-only projects.
+
+The existing platform layer configures the Rtools/MSYS2 tool environment early in startup. The project foundation must coexist with that setup so that `project.el` can enumerate project files with a Unix-compatible `find` rather than the unrelated Windows `find.exe`.
+
+The Windows test gate must therefore exercise both:
+
+1. project-root detection for a temporary `.projectile`-only project; and
+2. `project-files` enumeration within that project after normal P3 platform setup.
+
+This is a behavior contract, not a request for new Windows-specific project machinery.
 
 ## Error and fallback behavior
 
 `p3/project-root` returns nil when `project-current` finds no project, matching the current helper contract. Callers that currently fall back to `default-directory`, such as terminal and ESS helpers, retain that behavior. Callers that require a project continue to signal their existing user-facing errors.
 
-This PR does not add a custom project backend. If a supported Emacs lacks `project-vc-extra-root-markers`, Git/VC projects still work normally; `.projectile`-only non-VCS discovery remains unchanged until a compatibility need is demonstrated.
+This PR does not add a custom project backend or a Projectile fallback path.
 
 ## Tests
 
 Add or revise ERT coverage to establish these invariants:
 
 1. `p3/project-root` delegates to `project-current`/`project-root` and does not consult Projectile.
-2. `.projectile` is registered as a native project root marker where supported.
-3. `p3-core.el` no longer owns project discovery.
-4. Python uses the shared P3 project-root contract.
-5. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without behavioral changes.
-6. The extracted modules byte-compile with warnings treated as errors.
-7. The existing full ERT suite remains green.
+2. A temporary `.projectile`-only directory is recognized through the public `project-current` contract, including from a descendant directory.
+3. A nested `.projectile` marker inside an outer Git repository resolves to the inner project root.
+4. `p3-core.el` no longer owns project discovery.
+5. Python uses the shared `p3/project-root` contract and, in the nested-project case, resolves a project-local `.venv` from the inner root.
+6. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without other behavioral changes.
+7. `.projectile` registration is established by the eager P3 foundation configuration before project-aware subsystem setup.
+8. On Windows, a `.projectile`-only project can both be detected and have its files enumerated after normal P3 platform setup.
+9. The extracted modules byte-compile with warnings treated as errors.
+10. The existing full ERT suite remains green.
 
-CI should add `p3-project.el` to byte-compilation and load its tests in the normal suite. No additional workflow or diagnostic CI machinery is needed.
+CI should add `p3-project.el` to byte-compilation and load its tests in the normal suite. The existing Windows platform workflow should be extended narrowly enough to cover the project detection/file-enumeration contract when project/platform files change. No additional diagnostic workflow is needed.
 
 ## Non-goals
 
@@ -71,7 +105,7 @@ This PR will not:
 - alter project switching UI;
 - introduce project tabs;
 - change ESS process/session behavior;
-- change Python environment management;
+- redesign Python environment management beyond making shared project identity authoritative;
 - change vterm display behavior;
 - add `display-buffer-alist` rules;
 - reorganize `config.org` or startup tangling.

--- a/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
+++ b/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
@@ -1,0 +1,79 @@
+# Project.el Foundation Design
+
+## Goal
+
+Make built-in `project.el` the single source of project identity for the Emacs configuration without changing the user-facing workflow. R/ESS, Python, R helpers, and project-aware terminals should all consume the same project root. Projectile remains installed and usable during this PR, but it no longer determines P3 project semantics.
+
+## Scope
+
+This PR is limited to project identity and project-root plumbing. It does not redesign ESS process management, Python environments, buffer placement, completion, startup/tangling, Org-roam, or Projectile keybindings.
+
+The normal one- or two-window workflow must remain unchanged.
+
+## Architecture
+
+Introduce `lisp/p3-project.el` as the owner of project discovery and project-root helpers.
+
+`p3-project.el` will:
+
+- require built-in `project`;
+- expose the existing `p3/project-root` interface, backed only by `project-current` and `project-root`;
+- expose `p3/use-project-root-as-default-dir`;
+- register `.projectile` as an additional `project.el` root marker through `project-vc-extra-root-markers` when that variable is available.
+
+Keeping `.projectile` as the marker in this PR is intentional. Existing non-VCS R projects and newly generated R projects remain recognizable to Projectile, while `project.el` gains the same root marker. A later PR can decide whether Projectile is still useful and whether the marker should be renamed.
+
+`p3-core.el` will return to genuinely shared configuration helpers and will no longer contain project discovery.
+
+Project-aware subsystems will depend directly on `p3-project.el` rather than receiving project semantics indirectly through `p3-core.el`:
+
+- `p3-ess.el`
+- `p3-r-tools.el`
+- `p3-python.el`
+- `p3-terminal.el`
+
+`p3-python.el` will stop using the separate `p3/project-el-root` helper and use the shared `p3/project-root` contract like the other subsystems.
+
+## Compatibility
+
+Projectile is not removed, disabled, or re-keyed. Existing `.projectile` project markers stay in place, including the marker emitted by the R project scaffolder.
+
+Git repositories continue to be recognized by the normal `project.el` VC-aware backend. Non-VCS directories containing `.projectile` are recognized by adding that marker to `project-vc-extra-root-markers` on Emacs versions that provide the option.
+
+No P3 command in this PR should create additional windows or alter buffer-placement behavior.
+
+## Error and fallback behavior
+
+`p3/project-root` returns nil when `project-current` finds no project, matching the current helper contract. Callers that currently fall back to `default-directory`, such as terminal and ESS helpers, retain that behavior. Callers that require a project continue to signal their existing user-facing errors.
+
+This PR does not add a custom project backend. If a supported Emacs lacks `project-vc-extra-root-markers`, Git/VC projects still work normally; `.projectile`-only non-VCS discovery remains unchanged until a compatibility need is demonstrated.
+
+## Tests
+
+Add or revise ERT coverage to establish these invariants:
+
+1. `p3/project-root` delegates to `project-current`/`project-root` and does not consult Projectile.
+2. `.projectile` is registered as a native project root marker where supported.
+3. `p3-core.el` no longer owns project discovery.
+4. Python uses the shared P3 project-root contract.
+5. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without behavioral changes.
+6. The extracted modules byte-compile with warnings treated as errors.
+7. The existing full ERT suite remains green.
+
+CI should add `p3-project.el` to byte-compilation and load its tests in the normal suite. No additional workflow or diagnostic CI machinery is needed.
+
+## Non-goals
+
+This PR will not:
+
+- remove Projectile;
+- rename `.projectile` to `.project`;
+- alter project switching UI;
+- introduce project tabs;
+- change ESS process/session behavior;
+- change Python environment management;
+- change vterm display behavior;
+- add `display-buffer-alist` rules;
+- reorganize `config.org` or startup tangling.
+
+Those remain separate follow-up decisions after the project foundation is stable.

--- a/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
+++ b/docs/superpowers/specs/2026-09-02-project-el-foundation-design.md
@@ -22,10 +22,13 @@ Introduce `lisp/p3-project.el` as the owner of project discovery and project-roo
 
 - require built-in `project`;
 - register `.projectile` in `project-vc-extra-root-markers`;
+- prevent Projectile's `project-projectile` backend from remaining in `project-find-functions` when `projectile-mode` is enabled;
 - expose the existing `p3/project-root` interface, backed only by `project-current` and `project-root`;
 - expose `p3/use-project-root-as-default-dir`.
 
 Keeping `.projectile` as the marker in this PR is intentional. Existing non-VCS R projects and newly generated R projects remain recognizable to Projectile, while `project.el` gains the same root marker. A later PR can decide whether Projectile is still useful and whether the marker should be renamed.
+
+Projectile itself integrates with `project.el` by adding `project-projectile` to `project-find-functions` whenever `projectile-mode` is enabled. That would make Projectile the effective provider behind `project-current`, even though P3 no longer calls `projectile-project-root` directly. P3 therefore attaches a small policy function to `projectile-mode-hook` that removes `project-projectile` after Projectile updates its hooks. Projectile remains enabled for its commands, project list, and UI; it simply does not supply P3's `project.el` identity. The same policy is applied once when `p3-project.el` loads so reloading the module repairs an already-active Projectile session.
 
 Registration of `.projectile` is startup-critical. `p3-project.el` must be loaded before any P3 subsystem or package configuration is allowed to call `project-current`, because `project.el` may cache project detection. The bootstrap therefore requires `p3-project` in `init.el` immediately after the P3 Lisp directory enters `load-path` and before the literate configuration is tangled or loaded. This is an intentionally narrow bootstrap responsibility, not a broader startup/tangling redesign.
 
@@ -54,7 +57,7 @@ As a consequence, Python project-local interpreter discovery will also use that 
 
 ## Compatibility
 
-Projectile is not removed, disabled, or re-keyed. Existing `.projectile` project markers stay in place, including the marker emitted by the R project scaffolder.
+Projectile is not removed, disabled, or re-keyed. Existing `.projectile` project markers stay in place, including the marker emitted by the R project scaffolder. Projectile commands remain available, but its `project-projectile` bridge is deliberately removed from `project-find-functions` while P3 is active so built-in project discovery remains authoritative.
 
 The supported baseline for this design is Emacs 29+. No compatibility backend for older Emacs versions will be added in this PR. If pre-29 support becomes a real requirement, it should be handled as a separate compatibility decision rather than by retaining two competing project systems.
 
@@ -85,16 +88,17 @@ This PR does not add a custom project backend or a Projectile fallback path.
 
 Add or revise ERT coverage to establish these invariants:
 
-1. `p3/project-root` delegates to `project-current`/`project-root` and does not consult Projectile.
-2. A temporary `.projectile`-only directory is recognized through the public `project-current` contract, including from a descendant directory.
-3. A nested `.projectile` marker inside an outer Git repository resolves to the inner project root.
-4. `p3-core.el` no longer owns project discovery.
-5. Python uses the shared `p3/project-root` contract and, in the nested-project case, resolves a project-local `.venv` from the inner root.
-6. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without other behavioral changes.
-7. `init.el` loads `p3-project` after adding the P3 Lisp directory to `load-path` and before loading the literate configuration.
-8. On Windows, a `.projectile`-only project can both be detected and have its files enumerated after normal P3 platform setup.
-9. The extracted modules byte-compile with warnings treated as errors.
-10. The existing full ERT suite remains green.
+1. `p3/project-root` delegates to `project-current`/`project-root`.
+2. When Projectile inserts `project-projectile` ahead of native providers, the P3 `projectile-mode-hook` policy removes it and a real `project-current` lookup proceeds through the native provider.
+3. A temporary `.projectile`-only directory is recognized through the public `project-current` contract, including from a descendant directory.
+4. A nested `.projectile` marker inside an outer Git repository resolves to the inner project root.
+5. `p3-core.el` no longer owns project discovery.
+6. Python uses the shared `p3/project-root` contract and, in the nested-project case, resolves a project-local `.venv` from the inner root.
+7. ESS, R tools, and terminal helpers continue to consume `p3/project-root` without other behavioral changes.
+8. `init.el` loads `p3-project` after adding the P3 Lisp directory to `load-path` and before loading the literate configuration.
+9. On Windows, a `.projectile`-only project can both be detected and have its files enumerated after normal P3 platform setup.
+10. The extracted modules byte-compile with warnings treated as errors.
+11. The existing full ERT suite remains green.
 
 CI should add `p3-project.el` to byte-compilation and load its tests in the normal suite. The existing Windows platform workflow should be extended narrowly enough to cover the project detection/file-enumeration contract when project/platform files change. No additional diagnostic workflow is needed.
 

--- a/init.el
+++ b/init.el
@@ -82,6 +82,10 @@
   (expand-file-name "lisp" user-emacs-directory))
 (add-to-list 'load-path p3/lisp-directory)
 
+;; Establish native project semantics before the literate config or any
+;; project-aware package has a chance to populate `project.el' caches.
+(require 'p3-project)
+
 (defun p3/load-config (&optional quiet)
   "Tangle and load the literate configuration from `p3/config-source'."
   (org-babel-tangle-file p3/config-source p3/config-generated)

--- a/lisp/p3-core.el
+++ b/lisp/p3-core.el
@@ -1,25 +1,6 @@
 ;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
 
-(require 'project)
-
-(declare-function projectile-project-root "projectile")
 (declare-function p3/load-config nil (&optional quiet))
-
-(defun p3/project-el-root ()
-  "Return the current built-in project.el root, if any."
-  (when-let ((project (project-current nil)))
-    (project-root project)))
-
-(defun p3/project-root ()
-  "Return the current Projectile or built-in project root, if any."
-  (or (and (fboundp 'projectile-project-root)
-           (ignore-errors (projectile-project-root)))
-      (p3/project-el-root)))
-
-(defun p3/use-project-root-as-default-dir ()
-  "Use the current project root as the buffer's default directory."
-  (when-let ((root (p3/project-root)))
-    (setq-local default-directory root)))
 
 (defun p3/config-visit ()
   "Visit the authoritative literate Emacs configuration."

--- a/lisp/p3-ess.el
+++ b/lisp/p3-ess.el
@@ -2,12 +2,12 @@
 
 ;;; Commentary:
 ;; Keep ESS process ownership and project-session coordination out of the
-;; literate configuration.  Project identity is delegated to p3-core so ESS,
+;; literate configuration.  Project identity is delegated to p3-project so ESS,
 ;; Python, R helpers, and terminal workflows use the same root abstraction.
 
 ;;; Code:
 
-(require 'p3-core)
+(require 'p3-project)
 
 (declare-function R "ess-r-mode")
 (declare-function smartparens-mode "smartparens" (&optional arg))

--- a/lisp/p3-project.el
+++ b/lisp/p3-project.el
@@ -1,0 +1,22 @@
+;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
+
+(require 'project)
+
+(unless (boundp 'project-vc-extra-root-markers)
+  (error "P3 project support requires Emacs 29 or newer"))
+
+(add-to-list 'project-vc-extra-root-markers ".projectile")
+
+(defun p3/project-root ()
+  "Return the current built-in `project.el' root, if any."
+  (when-let ((project (project-current nil)))
+    (project-root project)))
+
+(defun p3/use-project-root-as-default-dir ()
+  "Use the current project root as the buffer's default directory."
+  (when-let ((root (p3/project-root)))
+    (setq-local default-directory root)))
+
+(provide 'p3-project)
+
+;;; p3-project.el ends here

--- a/lisp/p3-project.el
+++ b/lisp/p3-project.el
@@ -7,6 +7,16 @@
 
 (add-to-list 'project-vc-extra-root-markers ".projectile")
 
+(defun p3/project-keep-native-provider ()
+  "Keep Projectile from overriding native `project.el' project discovery."
+  (remove-hook 'project-find-functions #'project-projectile))
+
+;; Projectile intentionally registers itself as a project.el provider whenever
+;; `projectile-mode' changes state.  Keep its UI and commands, but remove that
+;; provider after the mode has finished updating its hooks.
+(add-hook 'projectile-mode-hook #'p3/project-keep-native-provider)
+(p3/project-keep-native-provider)
+
 (defun p3/project-root ()
   "Return the current built-in `project.el' root, if any."
   (when-let ((project (project-current nil)))

--- a/lisp/p3-project.el
+++ b/lisp/p3-project.el
@@ -2,6 +2,8 @@
 
 (require 'project)
 
+(declare-function project-projectile "projectile" (directory))
+
 (unless (boundp 'project-vc-extra-root-markers)
   (error "P3 project support requires Emacs 29 or newer"))
 

--- a/lisp/p3-python.el
+++ b/lisp/p3-python.el
@@ -3,13 +3,13 @@
 (require 'cl-lib)
 (require 'python)
 (require 'seq)
-(require 'p3-core)
+(require 'p3-project)
 
 (defvar eglot-server-programs)
 
 (defun p3/python-project-interpreter ()
   "Return the project-local Python executable, when one exists."
-  (when-let ((root (p3/project-el-root)))
+  (when-let ((root (p3/project-root)))
     (seq-some
      (lambda (relative)
        (let ((executable (expand-file-name relative root)))

--- a/lisp/p3-r-tools.el
+++ b/lisp/p3-r-tools.el
@@ -10,7 +10,7 @@
 (require 'cl-lib)
 (require 'seq)
 (require 'subr-x)
-(require 'p3-core)
+(require 'p3-project)
 
 (declare-function ess-eval-linewise "ess-inf")
 (declare-function ess-eval-region-or-function-or-paragraph "ess-mode")

--- a/lisp/p3-terminal.el
+++ b/lisp/p3-terminal.el
@@ -2,7 +2,7 @@
 
 (require 'seq)
 (require 'subr-x)
-(require 'p3-core)
+(require 'p3-project)
 
 (declare-function vterm-mode "vterm")
 (declare-function vterm-copy-mode "vterm")

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -3,11 +3,6 @@
 (require 'ert)
 (require 'org)
 (require 'ob-tangle)
-(require 'project)
-
-(defvar projectile-mode-hook nil)
-
-(require 'p3-project)
 
 (defconst p3-config-test--root
   (file-name-directory
@@ -146,12 +141,6 @@
               (point)))
       (should (< load-path-position project-position))
       (should (< project-position config-position)))))
-
-(ert-deftest p3-projectile-mode-hook-keeps-native-provider-authoritative ()
-  (let ((project-find-functions '(project-projectile project-try-vc)))
-    (run-hooks 'projectile-mode-hook)
-    (should-not (memq #'project-projectile project-find-functions))
-    (should (memq #'project-try-vc project-find-functions))))
 
 (ert-deftest p3-init-does-not-special-case-org-export ()
   (with-temp-buffer

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -3,6 +3,11 @@
 (require 'ert)
 (require 'org)
 (require 'ob-tangle)
+(require 'project)
+
+(defvar projectile-mode-hook nil)
+
+(require 'p3-project)
 
 (defconst p3-config-test--root
   (file-name-directory
@@ -141,6 +146,12 @@
               (point)))
       (should (< load-path-position project-position))
       (should (< project-position config-position)))))
+
+(ert-deftest p3-projectile-mode-hook-keeps-native-provider-authoritative ()
+  (let ((project-find-functions '(project-projectile project-try-vc)))
+    (run-hooks 'projectile-mode-hook)
+    (should-not (memq #'project-projectile project-find-functions))
+    (should (memq #'project-try-vc project-find-functions))))
 
 (ert-deftest p3-init-does-not-special-case-org-export ()
   (with-temp-buffer

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -122,6 +122,26 @@
       (should (< terminal-position shell-position))
       (should (< shell-position shell-binding-position)))))
 
+(ert-deftest p3-init-loads-project-foundation-before-literate-config ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "init.el" p3-config-test--root))
+    (let ((load-path-position
+           (progn
+             (should (search-forward "(add-to-list 'load-path p3/lisp-directory)" nil t))
+             (point)))
+          project-position
+          config-position)
+      (setq project-position
+            (progn
+              (should (search-forward "(require 'p3-project)" nil t))
+              (point)))
+      (setq config-position
+            (progn
+              (should (search-forward "(p3/load-config t)" nil t))
+              (point)))
+      (should (< load-path-position project-position))
+      (should (< project-position config-position)))))
+
 (ert-deftest p3-init-does-not-special-case-org-export ()
   (with-temp-buffer
     (insert-file-contents (expand-file-name "init.el" p3-config-test--root))

--- a/test/p3-core-test.el
+++ b/test/p3-core-test.el
@@ -1,7 +1,6 @@
 ;;; p3-core-test.el --- Tests for p3-core -*- lexical-binding: t; -*-
 
 (require 'ert)
-(require 'cl-lib)
 
 (defconst p3-core-test--root
   (file-name-directory
@@ -12,33 +11,6 @@
 (add-to-list 'load-path (expand-file-name "lisp" p3-core-test--root))
 
 (require 'p3-core)
-
-(ert-deftest p3-core-project-root-prefers-projectile ()
-  (cl-letf (((symbol-function 'projectile-project-root)
-             (lambda () "/tmp/projectile-root/"))
-            ((symbol-function 'project-current)
-             (lambda (&optional _maybe-prompt _directory)
-               (ert-fail "Built-in project lookup should not run"))))
-    (should (equal (p3/project-root) "/tmp/projectile-root/"))))
-
-(ert-deftest p3-core-project-root-falls-back-to-project-el ()
-  (cl-letf (((symbol-function 'projectile-project-root)
-             (lambda () nil))
-            ((symbol-function 'project-current)
-             (lambda (&optional _maybe-prompt _directory) 'fake-project))
-            ((symbol-function 'project-root)
-             (lambda (_project) "/tmp/project-el-root/")))
-    (should (equal (p3/project-root) "/tmp/project-el-root/"))))
-
-(ert-deftest p3-core-project-default-directory-is-buffer-local ()
-  (with-temp-buffer
-    (let ((original default-directory))
-      (cl-letf (((symbol-function 'p3/project-root)
-                 (lambda () "/tmp/project-root/")))
-        (p3/use-project-root-as-default-dir)
-        (should (local-variable-p 'default-directory))
-        (should (equal default-directory "/tmp/project-root/"))
-        (should-not (equal original default-directory))))))
 
 (ert-deftest p3-core-config-commands-remain-commands ()
   (should (commandp #'p3/config-visit))

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -25,13 +25,29 @@
              (lambda (_project) "/tmp/native-project/")))
     (should (equal (p3/project-root) "/tmp/native-project/"))))
 
-(ert-deftest p3-project-root-does-not-consult-projectile ()
-  (cl-letf (((symbol-function 'project-current)
-             (lambda (&optional _maybe-prompt _directory) nil))
-            ((symbol-function 'projectile-project-root)
-             (lambda ()
-               (ert-fail "Projectile must not define P3 project identity"))))
-    (should-not (p3/project-root))))
+(ert-deftest p3-project-projectile-mode-hook-restores-native-provider ()
+  (skip-unless (executable-find "git"))
+  (let ((root (make-temp-file "p3-project-provider-" t)))
+    (unwind-protect
+        (progn
+          (should
+           (zerop (call-process "git" nil nil nil "-C" root "init" "-q")))
+          (let ((project-find-functions '(project-projectile project-try-vc))
+                (default-directory root))
+            (cl-letf (((symbol-function 'project-projectile)
+                       (lambda (_directory)
+                         (ert-fail
+                          "Projectile must not provide P3 project identity"))))
+              (run-hooks 'projectile-mode-hook)
+              (should-not (memq #'project-projectile project-find-functions))
+              (should (memq #'project-try-vc project-find-functions))
+              (let ((project (project-current nil)))
+                (should project)
+                (should
+                 (equal (p3-project-test--canonical-directory
+                         (project-root project))
+                        (p3-project-test--canonical-directory root)))))))
+      (delete-directory root t))))
 
 (ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-marker-" t))

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -1,0 +1,78 @@
+;;; p3-project-test.el --- Tests for p3-project -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+(require 'project)
+
+(defconst p3-project-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-project-test--root))
+
+(require 'p3-project)
+
+(defun p3-project-test--canonical-directory (directory)
+  "Return DIRECTORY in normalized form for root comparisons."
+  (file-name-as-directory (file-truename directory)))
+
+(ert-deftest p3-project-root-delegates-to-project-el ()
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&optional _maybe-prompt _directory) 'fake-project))
+            ((symbol-function 'project-root)
+             (lambda (_project) "/tmp/native-project/")))
+    (should (equal (p3/project-root) "/tmp/native-project/"))))
+
+(ert-deftest p3-project-root-does-not-consult-projectile ()
+  (cl-letf (((symbol-function 'project-current)
+             (lambda (&optional _maybe-prompt _directory) nil))
+            ((symbol-function 'projectile-project-root)
+             (lambda ()
+               (ert-fail "Projectile must not define P3 project identity"))))
+    (should-not (p3/project-root))))
+
+(ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
+  (let* ((root (make-temp-file "p3-project-marker-" t))
+         (child (expand-file-name "R/subdir" root)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" root))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
+(ert-deftest p3-project-inner-marker-wins-over-outer-git-root ()
+  (skip-unless (executable-find "git"))
+  (let* ((outer (make-temp-file "p3-project-outer-" t))
+         (inner (expand-file-name "analysis" outer))
+         (child (expand-file-name "R" inner)))
+    (unwind-protect
+        (progn
+          (should
+           (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" inner))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory inner)))))
+      (delete-directory outer t))))
+
+(ert-deftest p3-project-default-directory-is-buffer-local ()
+  (with-temp-buffer
+    (let ((original default-directory))
+      (cl-letf (((symbol-function 'p3/project-root)
+                 (lambda () "/tmp/project-root/")))
+        (p3/use-project-root-as-default-dir)
+        (should (local-variable-p 'default-directory))
+        (should (equal default-directory "/tmp/project-root/"))
+        (should-not (equal original default-directory))))))
+
+(provide 'p3-project-test)
+
+;;; p3-project-test.el ends here

--- a/test/p3-project-windows-test.el
+++ b/test/p3-project-windows-test.el
@@ -1,0 +1,61 @@
+;;; p3-project-windows-test.el --- Windows project/platform integration tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+(require 'project)
+
+(defconst p3-project-windows-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-project-windows-test--root))
+
+(require 'p3-platform)
+(require 'p3-project)
+
+(ert-deftest p3-project-windows-msys2-tools-support-marker-project-files ()
+  (unless (eq system-type 'windows-nt)
+    (ert-skip "Native Windows-only project enumeration contract"))
+  (let* ((msys2-root (getenv "P3_TEST_MSYS2_ROOT"))
+         (usr-bin (and msys2-root (expand-file-name "usr/bin" msys2-root)))
+         (bash (and usr-bin (expand-file-name "bash.exe" usr-bin)))
+         (find (and usr-bin (expand-file-name "find.exe" usr-bin)))
+         (root (make-temp-file "p3-project-windows-" t))
+         (child (expand-file-name "R" root))
+         (data-file (expand-file-name "R/example.R" root))
+         (old-path (getenv "PATH"))
+         (old-exec-path (copy-sequence exec-path))
+         (p3/windows-rtools-override msys2-root)
+         (find-program "find"))
+    (unwind-protect
+        (progn
+          (should msys2-root)
+          (should (file-readable-p bash))
+          (should (file-readable-p find))
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" root))
+          (with-temp-file data-file
+            (insert "x <- 1\n"))
+          (p3/windows-configure-rtools)
+          (let* ((default-directory child)
+                 (project (project-current nil))
+                 (files (project-files project)))
+            (should project)
+            (should
+             (equal (file-name-as-directory
+                     (file-truename (project-root project)))
+                    (file-name-as-directory (file-truename root))))
+            (should
+             (seq-some
+              (lambda (file)
+                (string-equal (file-name-nondirectory file) "example.R"))
+              files))))
+      (setq exec-path old-exec-path)
+      (setenv "PATH" old-path)
+      (delete-directory root t))))
+
+(provide 'p3-project-windows-test)
+
+;;; p3-project-windows-test.el ends here

--- a/test/p3-python-test.el
+++ b/test/p3-python-test.el
@@ -11,7 +11,7 @@
 
 (add-to-list 'load-path (expand-file-name "lisp" p3-python-test--root))
 
-(require 'p3-core)
+(require 'p3-project)
 (require 'p3-python)
 
 (defmacro p3-python-test--with-temp-project (binding &rest body)
@@ -37,31 +37,35 @@
            (_venv (p3-python-test--make-executable
                    (expand-file-name "venv/bin/python" root))))
       (let ((system-type 'gnu/linux))
-        (cl-letf (((symbol-function 'project-current)
-                   (lambda (&optional _maybe-prompt _directory) 'fake-project))
-                  ((symbol-function 'project-root)
-                   (lambda (_project) root)))
+        (cl-letf (((symbol-function 'p3/project-root)
+                   (lambda () root)))
           (should (equal (p3/python-project-interpreter) dot-venv)))))))
 
-(ert-deftest p3-python-project-interpreter-preserves-project-el-root ()
-  "Python environment lookup should retain its pre-refactor project.el scope."
-  (p3-python-test--with-temp-project project-root-directory
-    (p3-python-test--with-temp-project projectile-root-directory
-      (let ((project-interpreter
-             (p3-python-test--make-executable
-              (expand-file-name ".venv/bin/python" project-root-directory)))
-            (_projectile-interpreter
-             (p3-python-test--make-executable
-              (expand-file-name ".venv/bin/python" projectile-root-directory)))
-            (system-type 'gnu/linux))
-        (cl-letf (((symbol-function 'project-current)
-                   (lambda (&optional _maybe-prompt _directory) 'fake-project))
-                  ((symbol-function 'project-root)
-                   (lambda (_project) project-root-directory))
-                  ((symbol-function 'p3/project-root)
-                   (lambda () projectile-root-directory)))
-          (should (equal (p3/python-project-interpreter)
-                         project-interpreter)))))))
+(ert-deftest p3-python-project-interpreter-uses-shared-p3-root ()
+  (p3-python-test--with-temp-project root
+    (let ((interpreter
+           (p3-python-test--make-executable
+            (expand-file-name ".venv/bin/python" root)))
+          (system-type 'gnu/linux))
+      (cl-letf (((symbol-function 'p3/project-root)
+                 (lambda () root)))
+        (should (equal (p3/python-project-interpreter) interpreter))))))
+
+(ert-deftest p3-python-inner-project-marker-selects-inner-venv ()
+  (skip-unless (executable-find "git"))
+  (p3-python-test--with-temp-project outer
+    (let* ((inner (expand-file-name "analysis" outer))
+           (source-directory (expand-file-name "src" inner))
+           (interpreter
+            (p3-python-test--make-executable
+             (expand-file-name ".venv/bin/python" inner)))
+           (system-type 'gnu/linux))
+      (should
+       (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+      (make-directory source-directory t)
+      (with-temp-file (expand-file-name ".projectile" inner))
+      (let ((default-directory source-directory))
+        (should (equal (p3/python-project-interpreter) interpreter))))))
 
 (ert-deftest p3-python-setup-project-interpreter-is-buffer-local ()
   (p3-python-test--with-temp-project root
@@ -69,10 +73,8 @@
                         (expand-file-name ".venv/bin/python" root))))
       (with-temp-buffer
         (let ((system-type 'gnu/linux))
-          (cl-letf (((symbol-function 'project-current)
-                     (lambda (&optional _maybe-prompt _directory) 'fake-project))
-                    ((symbol-function 'project-root)
-                     (lambda (_project) root)))
+          (cl-letf (((symbol-function 'p3/project-root)
+                     (lambda () root)))
             (p3/python-setup-project-interpreter)
             (should (local-variable-p 'python-shell-interpreter))
             (should (equal python-shell-interpreter interpreter))
@@ -85,10 +87,8 @@
     (let ((interpreter (p3-python-test--make-executable
                         (expand-file-name ".venv/Scripts/python.exe" root)))
           (system-type 'windows-nt))
-      (cl-letf (((symbol-function 'project-current)
-                 (lambda (&optional _maybe-prompt _directory) 'fake-project))
-                ((symbol-function 'project-root)
-                 (lambda (_project) root)))
+      (cl-letf (((symbol-function 'p3/project-root)
+                 (lambda () root)))
         (should (equal (p3/python-project-interpreter) interpreter))))))
 
 (ert-deftest p3-python-tools-path-is-platform-specific ()

--- a/test/p3-r-tools-test.el
+++ b/test/p3-r-tools-test.el
@@ -68,6 +68,7 @@
     (let ((root (expand-file-name "analysis-demo" parent)))
       (p3-r-new-project root 'analysis)
       (should (file-exists-p (expand-file-name "analysis-demo.Rproj" root)))
+      (should (file-exists-p (expand-file-name ".projectile" root)))
       (should (file-exists-p (expand-file-name "R/01_prepareData.R" root)))
       (should (file-exists-p (expand-file-name "R/utils.R" root)))
       (should-not (file-exists-p (expand-file-name "_targets.R" root)))


### PR DESCRIPTION
## Summary

Make built-in `project.el` the single source of P3 project identity while preserving existing Projectile UI and the normal one-/two-window workflow.

- add `p3-project.el` as the owner of `p3/project-root`
- register existing `.projectile` markers with `project-vc-extra-root-markers`
- migrate ESS, R helpers, Python, and project-aware terminals to the shared root contract
- intentionally make Python honor an inner `.projectile` project boundary inside an outer VCS repository
- keep R project scaffolding emitting `.projectile`
- require the project foundation in `init.el` before the literate config loads so project.el caches cannot establish competing semantics first
- extend Ubuntu and Windows regression coverage, including native-Windows `project-files` enumeration with a Unix-compatible `find`

## Execution note

The approved implementation plan originally placed the eager `p3-project` load in `config.org` after platform setup. During implementation I moved that narrow bootstrap responsibility to `init.el`, immediately after the P3 Lisp directory enters `load-path` and before `p3/load-config`. This is earlier and more robust against `project.el` caching, and avoids a large unrelated rewrite of `config.org`. The design spec has been updated to match the implemented boundary.

## Deliberate non-goals

This does not remove Projectile, rename `.projectile`, redesign ESS sessions, change Python environment policy beyond shared project identity, alter Org, change startup tangling, or add buffer/window layout rules.

## Verification

This harness does not provide a local Emacs runtime, so the PR is opened as a draft verification gate rather than as a completion claim. The existing Ubuntu ERT/byte-compile workflow and the extended native-Windows platform/project workflow are the authoritative verification for this branch. Do not merge without explicit approval.