### PR TITLE
Use a content-validated config cache at startup

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           emacs -Q --batch \
             -L lisp \
+            -l test/p3-config-loader-test.el \
             -l test/p3-config-test.el \
             -l test/p3-project-test.el \
             -l test/p3-core-test.el \

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -30,6 +30,7 @@ jobs:
             -f batch-byte-compile \
             lisp/p3-platform.el \
             lisp/p3-project.el \
+            lisp/p3-config-loader.el \
             lisp/p3-core.el \
             lisp/p3-python.el \
             lisp/p3-terminal.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -64,4 +64,4 @@ jobs:
         run: >-
           emacs -Q --batch -L lisp
           -l test/p3-config-loader-test.el
-          --eval "(ert-run-tests-batch-and-exit \"^p3-config-loader-build-replaces-existing-cache$\")"
+          --eval '(ert-run-tests-batch-and-exit "^p3-config-loader-build-replaces-existing-cache$")'

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -5,9 +5,11 @@ on:
     paths:
       - "lisp/p3-platform.el"
       - "lisp/p3-project.el"
+      - "lisp/p3-config-loader.el"
       - "test/p3-platform-test.el"
       - "test/p3-project-test.el"
       - "test/p3-project-windows-test.el"
+      - "test/p3-config-loader-test.el"
       - ".github/workflows/windows-platform-tests.yml"
   workflow_dispatch:
 
@@ -47,6 +49,7 @@ jobs:
           -f batch-byte-compile
           lisp/p3-platform.el
           lisp/p3-project.el
+          lisp/p3-config-loader.el
 
       - name: Run Windows platform and project tests
         shell: powershell
@@ -55,3 +58,10 @@ jobs:
           -l test/p3-platform-test.el
           -l test/p3-project-windows-test.el
           -f ert-run-tests-batch-and-exit
+
+      - name: Run Windows config-cache replacement test
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          -l test/p3-config-loader-test.el
+          --eval "(ert-run-tests-batch-and-exit \"^p3-config-loader-build-replaces-existing-cache$\")"

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -59,9 +59,9 @@ jobs:
           -l test/p3-project-windows-test.el
           -f ert-run-tests-batch-and-exit
 
-      - name: Run Windows config-cache replacement test
+      - name: Run Windows config-cache tests
         shell: powershell
         run: >-
           emacs -Q --batch -L lisp
           -l test/p3-config-loader-test.el
-          --eval '(ert-run-tests-batch-and-exit "^p3-config-loader-build-replaces-existing-cache$")'
+          -f ert-run-tests-batch-and-exit

--- a/docs/superpowers/plans/2026-09-04-startup-tangle-cache.md
+++ b/docs/superpowers/plans/2026-09-04-startup-tangle-cache.md
@@ -33,7 +33,7 @@
 ## File Structure
 
 - **Create `lisp/p3-config-loader.el`** — config source/cache paths, SHA-256 fingerprint handling, tangle-contract validation, staged build, exact generated-file load, startup load decision.
-- **Create `test/p3-config-loader-test.el`** — isolated unit tests for fingerprinting, direct loading, staged build behavior, failure preservation, and replacement.
+- **Create `test/p3-config-loader-test.el`** — isolated unit tests for fingerprinting, direct loading, stale-cache rebuilds, staged build behavior, failure preservation, and replacement.
 - **Modify `lisp/p3-core.el`** — depend on the loader and implement reload as exactly one explicit build plus one direct load.
 - **Modify `init.el`** — remove unconditional Org/Babel/tangle bootstrap and call `p3/config-load` after `p3-project`.
 - **Modify `test/p3-core-test.el`** — verify reload delegates exactly once to build and direct load.
@@ -54,7 +54,7 @@
 - Produces: `p3/config-generated` — absolute path to ignored `config.el`.
 - Produces: `p3/config-cache-stale-p` — returns non-nil unless the generated header fingerprint exactly matches the current source digest.
 - Produces: `p3/config-load-generated` — loads exactly `p3/config-generated` with `load-file`.
-- Produces: `p3/config-load` — later extended to build on stale/missing cache, then load.
+- Produces: `p3/config-load` — later uses `p3/config-build` on stale/missing cache, then loads the exact generated file.
 - Internal: `p3/config--source-digest`, `p3/config--generated-digest`, `p3/config--fingerprint-prefix`.
 
 - [ ] **Step 1: Write the loader tests for content-based validity**
@@ -124,7 +124,6 @@ Create `test/p3-config-loader-test.el` with a loader-isolation snapshot taken im
     (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
     (with-temp-file p3/config-source
       (insert "source-v2"))
-    ;; Make the stale cache newer than the source to prove mtimes are irrelevant.
     (set-file-times p3/config-source (seconds-to-time 1000000000))
     (set-file-times p3/config-generated (seconds-to-time 2000000000))
     (should (p3/config-cache-stale-p))))
@@ -132,7 +131,6 @@ Create `test/p3-config-loader-test.el` with a loader-isolation snapshot taken im
 (ert-deftest p3-config-loader-matching-fingerprint-is-current-regardless-of-mtime ()
   (p3-config-loader-test--with-files "source"
     (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
-    ;; Make the valid cache older than the source to prove mtimes are irrelevant.
     (set-file-times p3/config-generated (seconds-to-time 1000000000))
     (set-file-times p3/config-source (seconds-to-time 2000000000))
     (should-not (p3/config-cache-stale-p))))
@@ -219,14 +217,20 @@ Append:
     (p3/config-load-generated)
     (should (eq p3-config-loader-test--loaded 'source))))
 
-(ert-deftest p3-config-loader-current-cache-loads-without-build ()
+(ert-deftest p3-config-loader-current-cache-loads-without-build-or-org-require ()
   (p3-config-loader-test--with-files "source"
     (p3-config-loader-test--write-current-cache
      "(setq p3-config-loader-test--loaded 'current)\n")
     (setq p3-config-loader-test--loaded nil)
-    (cl-letf (((symbol-function 'p3/config-build)
-               (lambda () (ert-fail "Current cache attempted a rebuild"))))
-      (p3/config-load))
+    (let ((original-require (symbol-function 'require)))
+      (cl-letf (((symbol-function 'p3/config-build)
+                 (lambda () (ert-fail "Current cache attempted a rebuild")))
+                ((symbol-function 'require)
+                 (lambda (feature &rest args)
+                   (when (memq feature '(org ob-tangle))
+                     (ert-fail (format "Current cache required %S" feature)))
+                   (apply original-require feature args))))
+        (p3/config-load)))
     (should (eq p3-config-loader-test--loaded 'current))))
 ```
 
@@ -234,7 +238,7 @@ Append:
 
 Expected: FAIL because `p3/config-load-generated` / `p3/config-load` are undefined.
 
-- [ ] **Step 7: Implement exact loading and the initial startup entry point**
+- [ ] **Step 7: Implement exact loading and the startup entry point**
 
 Add:
 
@@ -250,7 +254,7 @@ Add:
   (p3/config-load-generated))
 ```
 
-Do not implement a fake `p3/config-build`; Task 2 immediately supplies the build implementation. For this Task 1 green run, bind `p3/config-build` only in the current-cache test as shown above, so the path under test never calls it.
+Do not implement a fake `p3/config-build`; Task 2 immediately supplies the build implementation. For this Task 1 green run, the current-cache test binds `p3/config-build` and therefore never calls the undefined production function.
 
 - [ ] **Step 8: Run only the Task 1 tests and verify green**
 
@@ -350,13 +354,12 @@ Add:
       (let* ((info (org-babel-get-src-block-info 'light))
              (params (nth 2 info))
              (tangle (cdr (assq :tangle params))))
-        ;; The normal pre-tangle effective value is "no".  Reject "yes" and
-        ;; filenames alike: either could override the staged target supplied
-        ;; by this loader.
         (unless (or (null tangle) (equal (format "%s" tangle) "no"))
           (user-error "Unsupported :tangle setting %S in %s"
                       tangle p3/config-source))))))
 ```
+
+Reject `yes` as well as filenames: either can override the staged target supplied by the loader.
 
 - [ ] **Step 4: Write red tests for output validation, syntax preservation, source stability, and cleanup**
 
@@ -427,7 +430,7 @@ Add:
                    "old-cache"))))
 ```
 
-The source-stability test closes a narrow race in the content-fingerprint contract: the digest recorded in `config.el` must describe the same source contents that were actually tangled.
+The source-stability test closes the narrow race between hashing and tangling: the fingerprint published in `config.el` must describe the same source contents that were actually tangled.
 
 - [ ] **Step 5: Implement staged-file validation helpers**
 
@@ -483,8 +486,6 @@ Add:
                  (org-babel-tangle-file
                   p3/config-source staged "emacs-lisp")))
             (p3/config--assert-single-tangle-output outputs staged))
-          ;; Do not stamp or publish output from a source file that changed
-          ;; while Babel was reading/tangling it.
           (unless (equal source-digest (p3/config--source-digest))
             (error "%s changed while the config cache was being built"
                    p3/config-source))
@@ -500,7 +501,7 @@ Add:
 
 Do not catch build errors. The caller must see tangle/validation failures, and stale startup must not silently load the older cache.
 
-- [ ] **Step 7: Add a green replacement/fingerprint test that will also be reused on Windows**
+- [ ] **Step 7: Add green tests for replacement, stale startup rebuilding, and explicit rebuilding**
 
 Add:
 
@@ -512,6 +513,7 @@ Add:
       (insert "old-cache"))
     (let ((directory (file-name-directory p3/config-generated)))
       (should (equal (p3/config-build) p3/config-generated))
+      (should (commandp #'p3/config-build))
       (should-not (p3/config-cache-stale-p))
       (with-temp-buffer
         (insert-file-contents p3/config-generated)
@@ -519,6 +521,32 @@ Add:
         (should (looking-at ";; p3-config-source-sha256: [0-9a-f]\\{64\\}$"))
         (should (search-forward "p3-config-loader-test--replacement" nil t)))
       (should-not (p3-config-loader-test--stage-files directory)))))
+
+(ert-deftest p3-config-loader-mismatched-cache-rebuilds-before-load ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--loaded 'fresh)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: "
+              (make-string 64 ?0)
+              "\n(setq p3-config-loader-test--loaded 'stale)\n"))
+    (setq p3-config-loader-test--loaded nil)
+    (p3/config-load)
+    (should (eq p3-config-loader-test--loaded 'fresh))
+    (should-not (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-explicit-build-rebuilds-current-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--explicit-build t)\n#+end_src\n"
+    (p3/config-build)
+    (should-not (p3/config-cache-stale-p))
+    (let ((original-tangle (symbol-function 'org-babel-tangle-file))
+          (calls 0))
+      (cl-letf (((symbol-function 'org-babel-tangle-file)
+                 (lambda (&rest args)
+                   (setq calls (1+ calls))
+                   (apply original-tangle args))))
+        (p3/config-build))
+      (should (= calls 1)))))
 ```
 
 - [ ] **Step 8: Run the complete loader test file**
@@ -800,7 +828,7 @@ Put the loader test file before `p3-config-test.el` so its module-load snapshot 
             -f ert-run-tests-batch-and-exit
 ```
 
-Do not split the Ubuntu workflow or add a second matrix.
+Keep the remainder of the existing test-file list unchanged; do not split the Ubuntu workflow or add a second matrix.
 
 - [ ] **Step 4: Extend the existing Windows workflow path filter narrowly**
 

--- a/docs/superpowers/plans/2026-09-04-startup-tangle-cache.md
+++ b/docs/superpowers/plans/2026-09-04-startup-tangle-cache.md
@@ -1,0 +1,928 @@
+# Startup/Tangle Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace unconditional startup tangling with a content-validated local `config.el` cache that rebuilds only when `config.org` changes.
+
+**Architecture:** Add `lisp/p3-config-loader.el` as the sole owner of config fingerprinting, staged tangling, validation, replacement, and loading. `init.el` keeps bootstrap ordering and calls the loader; `p3-core.el` keeps user-facing visit/reload commands. Cache validity is an embedded SHA-256 of the exact `config.org` bytes, not filesystem timestamps.
+
+**Tech Stack:** Emacs Lisp 29+, Org/Babel, ERT, package.el/use-package bootstrap, GitHub Actions on Ubuntu and native Windows.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md`
+
+## Global Constraints
+
+- `config.org` remains the only authoritative configuration source.
+- `config.el` remains ignored by Git and is never treated as source.
+- Cache validity uses an embedded SHA-256 of the exact current `config.org` contents; modification times do not participate.
+- The current-cache startup path must not require Org or Babel through the loader.
+- Builds tangle only `emacs-lisp` blocks into one staged same-directory file.
+- Existing alternate `:tangle` behavior is not supported; any effective `:tangle` value other than the normal disabled value (`no`) is rejected before tangling so it cannot bypass staging.
+- A staged file replaces `config.el` only after tangle output, source fingerprint, and Lisp syntax are validated.
+- Replacement uses one same-directory `rename-file` with overwrite enabled; never delete `config.el` first.
+- `p3/config-load-generated` uses `load-file` on the exact `.el` cache; no `.elc` selection.
+- Tangle/validation failures preserve the running session and previous cache; runtime load failures are not transactional and are allowed to leave partial session effects.
+- `p3-project` must still load before the literate configuration.
+- Existing config visit/reload keybindings remain unchanged.
+- Do not reorganize `config.org`, redesign package bootstrap, change project semantics, or alter completion/ESS/Python/Org/terminal/window behavior.
+- Extend existing CI only; do not add a new workflow, matrix, cache service, or diagnostic harness.
+- Keep GitHub Actions use bounded: establish red/green with targeted local batch commands when an Emacs runtime is available, then use the existing remote workflows as the final branch gate rather than as an iterative debugger.
+
+---
+
+## File Structure
+
+- **Create `lisp/p3-config-loader.el`** — config source/cache paths, SHA-256 fingerprint handling, tangle-contract validation, staged build, exact generated-file load, startup load decision.
+- **Create `test/p3-config-loader-test.el`** — isolated unit tests for fingerprinting, direct loading, staged build behavior, failure preservation, and replacement.
+- **Modify `lisp/p3-core.el`** — depend on the loader and implement reload as exactly one explicit build plus one direct load.
+- **Modify `init.el`** — remove unconditional Org/Babel/tangle bootstrap and call `p3/config-load` after `p3-project`.
+- **Modify `test/p3-core-test.el`** — verify reload delegates exactly once to build and direct load.
+- **Modify `test/p3-config-test.el`** — update bootstrap-order assertions and run the real `config.org` through the loader build contract.
+- **Modify `.github/workflows/emacs-tests.yml`** — byte-compile the loader and load loader tests before tests that require Org.
+- **Modify `.github/workflows/windows-platform-tests.yml`** — include loader paths, byte-compile the loader, and run one focused replacement-path ERT test natively on Windows.
+
+---
+
+### Task 1: Content Fingerprinting and Exact Cache Loading
+
+**Files:**
+- Create: `lisp/p3-config-loader.el`
+- Create: `test/p3-config-loader-test.el`
+
+**Interfaces:**
+- Produces: `p3/config-source` — absolute path to `config.org`.
+- Produces: `p3/config-generated` — absolute path to ignored `config.el`.
+- Produces: `p3/config-cache-stale-p` — returns non-nil unless the generated header fingerprint exactly matches the current source digest.
+- Produces: `p3/config-load-generated` — loads exactly `p3/config-generated` with `load-file`.
+- Produces: `p3/config-load` — later extended to build on stale/missing cache, then load.
+- Internal: `p3/config--source-digest`, `p3/config--generated-digest`, `p3/config--fingerprint-prefix`.
+
+- [ ] **Step 1: Write the loader tests for content-based validity**
+
+Create `test/p3-config-loader-test.el` with a loader-isolation snapshot taken immediately after requiring the new module, before this test file itself loads Org:
+
+```elisp
+;;; p3-config-loader-test.el --- Tests for config cache loading -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+
+(defconst p3-config-loader-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-config-loader-test--root))
+(require 'p3-config-loader)
+
+(defconst p3-config-loader-test--org-loaded-by-loader-p (featurep 'org))
+(defconst p3-config-loader-test--ob-tangle-loaded-by-loader-p (featurep 'ob-tangle))
+
+(defun p3-config-loader-test--digest (path)
+  "Return the SHA-256 digest of PATH's exact bytes."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally path)
+    (secure-hash 'sha256 (current-buffer))))
+
+(defmacro p3-config-loader-test--with-files (source-content &rest body)
+  "Run BODY with temporary config source/cache files."
+  (declare (indent 1))
+  `(let* ((directory (make-temp-file "p3-config-loader-test-" t))
+          (p3/config-source (expand-file-name "config.org" directory))
+          (p3/config-generated (expand-file-name "config.el" directory)))
+     (unwind-protect
+         (progn
+           (with-temp-file p3/config-source
+             (insert ,source-content))
+           ,@body)
+       (delete-directory directory t))))
+
+(defun p3-config-loader-test--write-current-cache (body)
+  "Write BODY to the current temporary cache with a matching fingerprint."
+  (let ((digest (p3-config-loader-test--digest p3/config-source)))
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: " digest "\n" body))))
+
+(ert-deftest p3-config-loader-does-not-load-org-at-module-load ()
+  (should-not p3-config-loader-test--org-loaded-by-loader-p)
+  (should-not p3-config-loader-test--ob-tangle-loaded-by-loader-p))
+
+(ert-deftest p3-config-loader-missing-cache-is-stale ()
+  (p3-config-loader-test--with-files "source"
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-malformed-fingerprint-is-stale ()
+  (p3-config-loader-test--with-files "source"
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: not-a-digest\n"))
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-mismatched-fingerprint-is-stale-regardless-of-mtime ()
+  (p3-config-loader-test--with-files "source-v1"
+    (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
+    (with-temp-file p3/config-source
+      (insert "source-v2"))
+    ;; Make the stale cache newer than the source to prove mtimes are irrelevant.
+    (set-file-times p3/config-source (seconds-to-time 1000000000))
+    (set-file-times p3/config-generated (seconds-to-time 2000000000))
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-matching-fingerprint-is-current-regardless-of-mtime ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
+    ;; Make the valid cache older than the source to prove mtimes are irrelevant.
+    (set-file-times p3/config-generated (seconds-to-time 1000000000))
+    (set-file-times p3/config-source (seconds-to-time 2000000000))
+    (should-not (p3/config-cache-stale-p))))
+```
+
+- [ ] **Step 2: Run the new tests and verify the missing module fails red**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL while loading `p3-config-loader` because `lisp/p3-config-loader.el` does not yet exist.
+
+- [ ] **Step 3: Implement the minimal fingerprint reader and stale predicate**
+
+Create `lisp/p3-config-loader.el` with no top-level Org/Babel dependency:
+
+```elisp
+;;; p3-config-loader.el --- Build and load the literate config cache -*- lexical-binding: t; -*-
+
+(defconst p3/config-source
+  (expand-file-name "config.org" user-emacs-directory)
+  "Authoritative literate Emacs configuration.")
+
+(defconst p3/config-generated
+  (expand-file-name "config.el" user-emacs-directory)
+  "Ignored generated cache for `p3/config-source'.")
+
+(defconst p3/config--fingerprint-prefix
+  ";; p3-config-source-sha256: "
+  "Prefix used to record the source digest in the generated cache.")
+
+(defun p3/config--source-digest ()
+  "Return the SHA-256 digest of the exact bytes in `p3/config-source'."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally p3/config-source)
+    (secure-hash 'sha256 (current-buffer))))
+
+(defun p3/config--generated-digest ()
+  "Return the recorded source digest from `p3/config-generated', or nil."
+  (when (file-readable-p p3/config-generated)
+    (with-temp-buffer
+      (insert-file-contents p3/config-generated nil 0 160)
+      (goto-char (point-min))
+      (when (looking-at
+             (concat (regexp-quote p3/config--fingerprint-prefix)
+                     "\\([0-9a-f]\\{64\\}\\)$"))
+        (match-string-no-properties 1)))))
+
+(defun p3/config-cache-stale-p ()
+  "Return non-nil unless the generated cache matches the current source."
+  (let ((recorded (p3/config--generated-digest)))
+    (or (null recorded)
+        (not (equal recorded (p3/config--source-digest))))))
+
+(provide 'p3-config-loader)
+
+;;; p3-config-loader.el ends here
+```
+
+- [ ] **Step 4: Run the fingerprint tests and verify green**
+
+Run the same targeted batch command.
+
+Expected: all fingerprint/isolation tests PASS.
+
+- [ ] **Step 5: Add tests for exact `.el` loading and the current-cache path**
+
+Append:
+
+```elisp
+(ert-deftest p3-config-loader-load-generated-uses-exact-el-file ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache
+     "(setq p3-config-loader-test--loaded 'source)\n")
+    (with-temp-file (concat p3/config-generated "c")
+      (insert "(setq p3-config-loader-test--loaded 'compiled)\n"))
+    (setq p3-config-loader-test--loaded nil)
+    (p3/config-load-generated)
+    (should (eq p3-config-loader-test--loaded 'source))))
+
+(ert-deftest p3-config-loader-current-cache-loads-without-build ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache
+     "(setq p3-config-loader-test--loaded 'current)\n")
+    (setq p3-config-loader-test--loaded nil)
+    (cl-letf (((symbol-function 'p3/config-build)
+               (lambda () (ert-fail "Current cache attempted a rebuild"))))
+      (p3/config-load))
+    (should (eq p3-config-loader-test--loaded 'current))))
+```
+
+- [ ] **Step 6: Run the tests and verify the new functions fail red**
+
+Expected: FAIL because `p3/config-load-generated` / `p3/config-load` are undefined.
+
+- [ ] **Step 7: Implement exact loading and the initial startup entry point**
+
+Add:
+
+```elisp
+(defun p3/config-load-generated ()
+  "Load exactly the generated Emacs Lisp cache."
+  (load-file p3/config-generated))
+
+(defun p3/config-load ()
+  "Load the config cache, rebuilding first when it is stale."
+  (when (p3/config-cache-stale-p)
+    (p3/config-build))
+  (p3/config-load-generated))
+```
+
+Do not implement a fake `p3/config-build`; Task 2 immediately supplies the build implementation. For this Task 1 green run, bind `p3/config-build` only in the current-cache test as shown above, so the path under test never calls it.
+
+- [ ] **Step 8: Run only the Task 1 tests and verify green**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  --eval '(ert-run-tests-batch-and-exit "^p3-config-loader-\\(does-not-load-org\\|missing-cache\\|malformed-fingerprint\\|mismatched-fingerprint\\|matching-fingerprint\\|load-generated\\|current-cache\\)")'
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add lisp/p3-config-loader.el test/p3-config-loader-test.el
+git commit -m "feat: add content-validated config cache loading"
+```
+
+---
+
+### Task 2: Guarded Staged Tangling and Atomic Cache Replacement
+
+**Files:**
+- Modify: `lisp/p3-config-loader.el`
+- Modify: `test/p3-config-loader-test.el`
+
+**Interfaces:**
+- Consumes: Task 1's source/generated paths and fingerprint helpers.
+- Produces: interactive `p3/config-build`, returning `p3/config-generated` after successful replacement.
+- Internal: `p3/config--validate-tangle-contract`, `p3/config--assert-readable-elisp`, `p3/config--insert-fingerprint`, `p3/config--assert-single-tangle-output`.
+
+- [ ] **Step 1: Add Org only after capturing module-load isolation**
+
+Immediately after the two `p3-config-loader-test--*-loaded-by-loader-p` constants in the test file, add:
+
+```elisp
+(require 'org)
+(require 'ob-tangle)
+```
+
+This lets build tests use real Babel while preserving the earlier evidence that loading `p3-config-loader` itself did not load Org/Babel.
+
+- [ ] **Step 2: Write red tests for the tangle boundary and language filter**
+
+Add:
+
+```elisp
+(defun p3-config-loader-test--stage-files (directory)
+  "Return staged config-cache files remaining in DIRECTORY."
+  (directory-files directory t "\\`\\.p3-config-stage-"))
+
+(ert-deftest p3-config-loader-rejects-explicit-tangle-before-writing ()
+  (p3-config-loader-test--with-files
+      "#+PROPERTY: header-args:emacs-lisp :tangle escaped.el\n#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (let ((escaped (expand-file-name "escaped.el" (file-name-directory p3/config-source))))
+      (should-error (p3/config-build))
+      (should-not (file-exists-p escaped))
+      (should-not (file-exists-p p3/config-generated)))))
+
+(ert-deftest p3-config-loader-build-admits-only-emacs-lisp ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--language 'elisp)\n#+end_src\n#+begin_src shell\necho SHOULD_NOT_APPEAR\n#+end_src\n"
+    (p3/config-build)
+    (with-temp-buffer
+      (insert-file-contents p3/config-generated)
+      (should (search-forward "p3-config-loader-test--language" nil t))
+      (goto-char (point-min))
+      (should-not (search-forward "SHOULD_NOT_APPEAR" nil t)))))
+```
+
+Run the loader suite. Expected: FAIL because `p3/config-build` is undefined.
+
+- [ ] **Step 3: Add declarations and tangle-contract validation without a top-level Org require**
+
+Add near the top of `p3-config-loader.el`:
+
+```elisp
+(declare-function org-mode "org" ())
+(declare-function org-babel-next-src-block "ob-core" (&optional arg))
+(declare-function org-babel-get-src-block-info "ob-core" (&optional light datum))
+(declare-function org-babel-tangle-file "ob-tangle" (file &optional target-file lang-re))
+```
+
+Add:
+
+```elisp
+(defun p3/config--validate-tangle-contract ()
+  "Reject source blocks whose existing tangle setting could escape staging."
+  (with-temp-buffer
+    (insert-file-contents p3/config-source)
+    (setq buffer-file-name p3/config-source)
+    (org-mode)
+    (goto-char (point-min))
+    (while (org-babel-next-src-block 1)
+      (let* ((info (org-babel-get-src-block-info 'light))
+             (params (nth 2 info))
+             (tangle (cdr (assq :tangle params))))
+        ;; The normal pre-tangle effective value is "no".  Reject "yes" and
+        ;; filenames alike: either could override the staged target supplied
+        ;; by this loader.
+        (unless (or (null tangle) (equal (format "%s" tangle) "no"))
+          (user-error "Unsupported :tangle setting %S in %s"
+                      tangle p3/config-source))))))
+```
+
+- [ ] **Step 4: Write red tests for output validation, syntax preservation, source stability, and cleanup**
+
+Add:
+
+```elisp
+(ert-deftest p3-config-loader-tangle-failure-preserves-cache-and-cleans-stage ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (let ((directory (file-name-directory p3/config-generated)))
+      (cl-letf (((symbol-function 'org-babel-tangle-file)
+                 (lambda (&rest _) (error "synthetic tangle failure"))))
+        (should-error (p3/config-build)))
+      (should (equal (with-temp-buffer
+                       (insert-file-contents p3/config-generated)
+                       (buffer-string))
+                     "old-cache"))
+      (should-not (p3-config-loader-test--stage-files directory)))))
+
+(ert-deftest p3-config-loader-malformed-output-preserves-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(unclosed"))
+                 (list target))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+
+(ert-deftest p3-config-loader-rejects-unexpected-tangle-output ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(setq p3-test t)\n"))
+                 (list target (expand-file-name "unexpected.el"
+                                                (file-name-directory target)))))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+
+(ert-deftest p3-config-loader-source-change-during-build-preserves-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test 'old)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(setq p3-test 'old)\n"))
+                 (with-temp-file p3/config-source
+                   (insert "#+begin_src emacs-lisp\n(setq p3-test 'new)\n#+end_src\n"))
+                 (list target))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+```
+
+The source-stability test closes a narrow race in the content-fingerprint contract: the digest recorded in `config.el` must describe the same source contents that were actually tangled.
+
+- [ ] **Step 5: Implement staged-file validation helpers**
+
+Add:
+
+```elisp
+(defun p3/config--assert-single-tangle-output (outputs staged)
+  "Require OUTPUTS to contain only STAGED."
+  (unless (and (= (length outputs) 1)
+               (file-equal-p (car outputs) staged))
+    (error "Config tangle produced unexpected outputs: %S" outputs)))
+
+(defun p3/config--insert-fingerprint (path digest)
+  "Insert DIGEST as the generated-cache fingerprint at the start of PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (goto-char (point-min))
+    (insert p3/config--fingerprint-prefix digest "\n")
+    (write-region (point-min) (point-max) path nil 'silent)))
+
+(defun p3/config--assert-readable-elisp (path)
+  "Signal an error unless PATH contains syntactically readable Emacs Lisp."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (emacs-lisp-mode)
+    (check-parens)
+    (goto-char (point-min))
+    (condition-case nil
+        (while t
+          (read (current-buffer)))
+      (end-of-file t))))
+```
+
+- [ ] **Step 6: Implement `p3/config-build` with one guarded replacement**
+
+Add:
+
+```elisp
+(defun p3/config-build ()
+  "Rebuild and validate the generated cache from `p3/config-source'."
+  (interactive)
+  (let* ((source-digest (p3/config--source-digest))
+         (directory (file-name-directory p3/config-generated))
+         (staged (make-temp-file
+                  (expand-file-name ".p3-config-stage-" directory)
+                  nil ".el")))
+    (unwind-protect
+        (progn
+          (require 'org)
+          (require 'ob-tangle)
+          (p3/config--validate-tangle-contract)
+          (let ((outputs
+                 (org-babel-tangle-file
+                  p3/config-source staged "emacs-lisp")))
+            (p3/config--assert-single-tangle-output outputs staged))
+          ;; Do not stamp or publish output from a source file that changed
+          ;; while Babel was reading/tangling it.
+          (unless (equal source-digest (p3/config--source-digest))
+            (error "%s changed while the config cache was being built"
+                   p3/config-source))
+          (p3/config--insert-fingerprint staged source-digest)
+          (p3/config--assert-readable-elisp staged)
+          (rename-file staged p3/config-generated t)
+          (when (called-interactively-p 'interactive)
+            (message "Built %s" p3/config-generated))
+          p3/config-generated)
+      (when (file-exists-p staged)
+        (delete-file staged)))))
+```
+
+Do not catch build errors. The caller must see tangle/validation failures, and stale startup must not silently load the older cache.
+
+- [ ] **Step 7: Add a green replacement/fingerprint test that will also be reused on Windows**
+
+Add:
+
+```elisp
+(ert-deftest p3-config-loader-build-replaces-existing-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--replacement 'new)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (let ((directory (file-name-directory p3/config-generated)))
+      (should (equal (p3/config-build) p3/config-generated))
+      (should-not (p3/config-cache-stale-p))
+      (with-temp-buffer
+        (insert-file-contents p3/config-generated)
+        (goto-char (point-min))
+        (should (looking-at ";; p3-config-source-sha256: [0-9a-f]\\{64\\}$"))
+        (should (search-forward "p3-config-loader-test--replacement" nil t)))
+      (should-not (p3-config-loader-test--stage-files directory)))))
+```
+
+- [ ] **Step 8: Run the complete loader test file**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all loader tests PASS.
+
+- [ ] **Step 9: Byte-compile the loader with warnings as errors**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile lisp/p3-config-loader.el
+```
+
+Expected: success with no warnings. If the compiler reports undeclared Org functions, fix declarations; do not add a top-level `(require 'org)` or `(require 'ob-tangle)`.
+
+- [ ] **Step 10: Commit Task 2**
+
+```bash
+git add lisp/p3-config-loader.el test/p3-config-loader-test.el
+git commit -m "feat: build config cache through guarded staging"
+```
+
+---
+
+### Task 3: Bootstrap and Interactive Reload Wiring
+
+**Files:**
+- Modify: `init.el`
+- Modify: `lisp/p3-core.el`
+- Modify: `test/p3-core-test.el`
+- Modify: `test/p3-config-test.el`
+
+**Interfaces:**
+- Consumes: `p3/config-build`, `p3/config-load-generated`, `p3/config-load`, `p3/config-source` from the loader.
+- Produces: startup sequence `load-path -> p3-project -> p3-config-loader -> p3/config-load`.
+- Produces: `p3/config-reload` = exactly one explicit build, then one direct generated-file load.
+
+- [ ] **Step 1: Write a red delegation test for interactive reload**
+
+Extend `test/p3-core-test.el`:
+
+```elisp
+(require 'cl-lib)
+
+(ert-deftest p3-core-config-reload-builds-once-then-loads-directly ()
+  (let (calls)
+    (cl-letf (((symbol-function 'p3/config-build)
+               (lambda () (push 'build calls)))
+              ((symbol-function 'p3/config-load-generated)
+               (lambda () (push 'load calls))))
+      (p3/config-reload))
+    (should (equal (nreverse calls) '(build load)))))
+```
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-core-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL because current `p3/config-reload` delegates to old `p3/load-config`.
+
+- [ ] **Step 2: Replace the old `p3/load-config` dependency in `p3-core.el`**
+
+Change the module to require the loader and make reload explicit:
+
+```elisp
+;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
+
+(require 'p3-config-loader)
+
+(defun p3/config-visit ()
+  "Visit the authoritative literate Emacs configuration."
+  (interactive)
+  (find-file p3/config-source))
+
+(defun p3/config-reload ()
+  "Rebuild and reload the authoritative literate Emacs configuration."
+  (interactive)
+  (p3/config-build)
+  (p3/config-load-generated)
+  (message "Reloaded %s" p3/config-source))
+
+(provide 'p3-core)
+
+;;; p3-core.el ends here
+```
+
+Run the core tests. Expected: PASS.
+
+- [ ] **Step 3: Write red bootstrap-order assertions for the new loader boundary**
+
+Replace `p3-init-loads-project-foundation-before-literate-config` in `test/p3-config-test.el` with:
+
+```elisp
+(ert-deftest p3-init-loads-project-and-loader-before-literate-config ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "init.el" p3-config-test--root))
+    (let ((load-path-position
+           (progn
+             (should (search-forward "(add-to-list 'load-path p3/lisp-directory)" nil t))
+             (point)))
+          project-position
+          loader-position
+          config-position)
+      (setq project-position
+            (progn
+              (should (search-forward "(require 'p3-project)" nil t))
+              (point)))
+      (setq loader-position
+            (progn
+              (should (search-forward "(require 'p3-config-loader)" nil t))
+              (point)))
+      (setq config-position
+            (progn
+              (should (search-forward "(p3/config-load)" nil t))
+              (point)))
+      (should (< load-path-position project-position))
+      (should (< project-position loader-position))
+      (should (< loader-position config-position)))))
+
+(ert-deftest p3-init-does-not-unconditionally-load-org-for-tangling ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "init.el" p3-config-test--root))
+    (should-not (search-forward "(require 'ob-tangle)" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(org-babel-tangle-file" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defun p3/load-config" nil t))))
+```
+
+Run `test/p3-config-test.el`. Expected: the new ordering test FAILS against the old bootstrap.
+
+- [ ] **Step 4: Simplify `init.el` to bootstrap sequencing only**
+
+Replace the current unconditional Org/Babel/config-path/tangle section with:
+
+```elisp
+(defconst p3/lisp-directory
+  (expand-file-name "lisp" user-emacs-directory))
+(add-to-list 'load-path p3/lisp-directory)
+
+;; Establish native project semantics before the literate config or any
+;; project-aware package has a chance to populate `project.el' caches.
+(require 'p3-project)
+
+;; Load the generated literate-config cache, rebuilding it only when its
+;; embedded source fingerprint no longer matches config.org.
+(require 'p3-config-loader)
+(p3/config-load)
+```
+
+Remove from `init.el`:
+
+```elisp
+(require 'org)
+(require 'ob-tangle)
+(defconst p3/config-source ...)
+(defconst p3/config-generated ...)
+(defun p3/load-config ...)
+(p3/load-config t)
+```
+
+Leave package/use-package bootstrap and the Consult/recentf/custom-file logic untouched.
+
+- [ ] **Step 5: Run focused bootstrap/core tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-config-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Byte-compile loader and core together**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile \
+  lisp/p3-config-loader.el \
+  lisp/p3-core.el
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add init.el lisp/p3-core.el test/p3-core-test.el test/p3-config-test.el
+git commit -m "refactor: load literate config through validated cache"
+```
+
+---
+
+### Task 4: Real-Config Contract and Existing CI Gates
+
+**Files:**
+- Modify: `test/p3-config-test.el`
+- Modify: `.github/workflows/emacs-tests.yml`
+- Modify: `.github/workflows/windows-platform-tests.yml`
+
+**Interfaces:**
+- Consumes: complete loader/build/bootstrap implementation.
+- Produces: real `config.org` integration proof and Linux/Windows regression gates.
+
+- [ ] **Step 1: Route the real `config.org` smoke test through `p3/config-build`**
+
+Replace the existing direct `org-babel-tangle-file` smoke test with a test that uses the production build path:
+
+```elisp
+(require 'p3-config-loader)
+
+(ert-deftest p3-config-org-builds-through-production-cache-contract ()
+  (let* ((directory (make-temp-file "p3-config-real-build-" t))
+         (p3/config-source
+          (expand-file-name "config.org" p3-config-test--root))
+         (p3/config-generated
+          (expand-file-name "config.el" directory)))
+    (unwind-protect
+        (progn
+          (should (equal (p3/config-build) p3/config-generated))
+          (should-not (p3/config-cache-stale-p))
+          (with-temp-buffer
+            (insert-file-contents p3/config-generated)
+            (goto-char (point-min))
+            (should (looking-at ";; p3-config-source-sha256: [0-9a-f]\\{64\\}$")))
+          (p3-config-test--assert-readable-elisp p3/config-generated))
+      (delete-directory directory t))))
+```
+
+Keep the existing `p3-config-test--assert-readable-elisp` helper and the other structural config tests.
+
+Run `test/p3-config-test.el` and the loader tests together. Expected: PASS and one real 124-block tangle through the staged/single-target contract.
+
+- [ ] **Step 2: Add the loader to the Ubuntu byte-compile gate**
+
+In `.github/workflows/emacs-tests.yml`, compile it before `p3-core.el`:
+
+```yaml
+            lisp/p3-platform.el \
+            lisp/p3-project.el \
+            lisp/p3-config-loader.el \
+            lisp/p3-core.el \
+```
+
+- [ ] **Step 3: Load loader tests first in the Ubuntu ERT gate**
+
+Put the loader test file before `p3-config-test.el` so its module-load snapshot is taken before the config smoke tests themselves require Org:
+
+```yaml
+          emacs -Q --batch \
+            -L lisp \
+            -l test/p3-config-loader-test.el \
+            -l test/p3-config-test.el \
+            -l test/p3-project-test.el \
+            -l test/p3-core-test.el \
+            ... \
+            -f ert-run-tests-batch-and-exit
+```
+
+Do not split the Ubuntu workflow or add a second matrix.
+
+- [ ] **Step 4: Extend the existing Windows workflow path filter narrowly**
+
+Add:
+
+```yaml
+      - "lisp/p3-config-loader.el"
+      - "test/p3-config-loader-test.el"
+```
+
+Keep existing platform/project paths.
+
+- [ ] **Step 5: Byte-compile the loader in the existing Windows compile step**
+
+Add:
+
+```yaml
+          lisp/p3-platform.el
+          lisp/p3-project.el
+          lisp/p3-config-loader.el
+```
+
+- [ ] **Step 6: Run one focused loader replacement test natively on Windows**
+
+After the existing platform/project tests, add a step in the same job:
+
+```yaml
+      - name: Run Windows config-cache replacement test
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          -l test/p3-config-loader-test.el
+          --eval "(ert-run-tests-batch-and-exit \"^p3-config-loader-build-replaces-existing-cache$\")"
+```
+
+This exercises creation of a same-directory staged file, overwrite of an existing `config.el` through `rename-file ... t`, fingerprint correctness, and cleanup on native Windows. Do not run the whole loader suite a second time on Windows.
+
+- [ ] **Step 7: Run the full local Ubuntu-equivalent gate once**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  --eval '(setq byte-compile-error-on-warn t)' \
+  -f batch-byte-compile \
+  lisp/p3-platform.el \
+  lisp/p3-project.el \
+  lisp/p3-config-loader.el \
+  lisp/p3-core.el \
+  lisp/p3-python.el \
+  lisp/p3-terminal.el \
+  lisp/p3-ess.el \
+  lisp/p3-r-tools.el \
+  lisp/p3-gptel.el
+
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-project-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-platform-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-terminal-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-gptel-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-org-export-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: byte compilation PASS; complete ERT suite PASS.
+
+- [ ] **Step 8: Commit Task 4**
+
+```bash
+git add test/p3-config-test.el \
+  .github/workflows/emacs-tests.yml \
+  .github/workflows/windows-platform-tests.yml
+git commit -m "test: verify config cache across Linux and Windows"
+```
+
+---
+
+## Final Verification and Review Gate
+
+- [ ] Confirm the branch contains no tracked `config.el`, temporary stage file, `.elc`, or other generated cache artifact:
+
+```bash
+git status --short
+git ls-files config.el '*.elc' '.p3-config-stage-*'
+```
+
+Expected: working tree clean; generated-file query returns nothing.
+
+- [ ] Confirm the obsolete bootstrap API is gone from executable code/tests except historical docs:
+
+```bash
+git grep -n "p3/load-config" -- init.el lisp test
+```
+
+Expected: no matches.
+
+- [ ] Confirm no production top-level Org/Babel require was introduced in the loader:
+
+```bash
+grep -n "^(require 'org)\|^(require 'ob-tangle)" lisp/p3-config-loader.el
+```
+
+Expected: no matches. The requires belong inside `p3/config-build` only.
+
+- [ ] Run the complete Ubuntu-equivalent compile + ERT gate from Task 4 one final time after all edits.
+
+- [ ] Push the completed branch once and use the existing GitHub Actions runs as the remote verification gate. Avoid iterative CI-only diagnosis; if either workflow fails, inspect the exact failing compile/test before making one bounded correction.
+
+- [ ] Perform an adversarial review against `docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md`, with particular attention to:
+  - stale-cache false negatives;
+  - source changes during a build;
+  - any tangle path that can bypass staging;
+  - old-cache preservation before replacement;
+  - runtime error semantics after replacement/load begins;
+  - accidental `.elc` loading;
+  - native-Windows overwrite behavior;
+  - preservation of `p3-project` bootstrap ordering.
+
+- [ ] Do not merge without explicit user approval.

--- a/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
+++ b/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
@@ -1,0 +1,152 @@
+# Startup/Tangle Cache Design
+
+## Goal
+
+Stop tangling the entire literate Emacs configuration on every startup while preserving `config.org` as the sole authoritative configuration source and keeping startup reliable after edits, pulls, checkouts, and merges.
+
+The generated `config.el` remains an ignored local cache. Normal startup should load that cache directly when it is current, rebuild it only when it is missing or stale, and never require a tracked generated configuration file.
+
+## Current behavior and problem
+
+`init.el` currently requires Org and Babel during bootstrap, tangles `config.org` to `config.el` on every startup, and then loads the generated file. This guarantees freshness, but it also performs the full 124-block tangle and rewrites `config.el` even when nothing has changed.
+
+That coupling makes startup do build work unconditionally. It also makes the generated file behave less like a cache and more like an obligatory intermediate artifact, despite being ignored by Git and having no independent authority.
+
+## Architecture
+
+Introduce `lisp/p3-config-loader.el` as the focused owner of the generated-config lifecycle. The loader should be usable independently of the full Emacs configuration so its cache behavior can be tested without invoking package bootstrap or evaluating `config.org`.
+
+`p3-config-loader.el` will own:
+
+- `p3/config-source`, pointing to `config.org`;
+- `p3/config-generated`, pointing to ignored `config.el`;
+- freshness detection for the generated cache;
+- explicit cache rebuilding;
+- conditional cache rebuilding for startup;
+- loading the generated configuration.
+
+`init.el` remains responsible for bootstrap sequencing only. After adding `lisp/` to `load-path` and establishing the early `p3-project` project semantics, it requires `p3-config-loader` and asks it to load the configuration. The loader decides whether a build is required.
+
+`p3-core.el` retains the user-facing visit/reload commands, but delegates build/load behavior to the loader rather than owning the generated-file lifecycle itself.
+
+## Source-of-truth contract
+
+`config.org` remains the only authoritative configuration source.
+
+`config.el` remains ignored by Git and must not be edited as source. It is a disposable local cache that can always be reconstructed from `config.org`.
+
+This PR will not begin tracking `config.el`, add a second canonical representation of the configuration, or introduce a generated-file manifest.
+
+## Freshness contract
+
+The generated cache is considered stale when either:
+
+1. `config.el` does not exist; or
+2. `config.org` is newer than `config.el` according to normal file modification times.
+
+A current cache is loaded without tangling.
+
+This deliberately uses the filesystem timestamp relationship rather than hashes, sidecar metadata, file watchers, or a build system. Git checkouts and pulls that update `config.org` naturally refresh its modification time, causing the next startup to rebuild the cache.
+
+The design assumes `config.el` is not manually edited. If someone manually changes the ignored cache and makes it newer than `config.org`, that cache may be loaded until the source changes or an explicit rebuild is requested. That is acceptable because the generated file is explicitly non-authoritative.
+
+## Build contract
+
+Expose `p3/config-build` as the explicit rebuild command.
+
+A build should:
+
+1. load Org/Babel tangling support lazily;
+2. tangle `config.org` into a temporary file in the same configuration directory;
+3. replace `config.el` only after the tangle succeeds; and
+4. return the generated file path.
+
+Using a temporary file protects the last valid generated cache from a failed or interrupted tangle. The final replacement should occur only after `org-babel-tangle-file` completes successfully.
+
+The temporary file must be cleaned up on both success and failure.
+
+The build command may report a concise interactive success message, but startup-triggered rebuilds should remain quiet unless an error occurs.
+
+## Load and startup contract
+
+Expose a loader entry point that performs the normal startup path:
+
+1. check whether the generated cache is missing or stale;
+2. call `p3/config-build` only when rebuilding is required; and
+3. load `config.el`.
+
+When the cache is current, normal startup must not require `org`, `ob-tangle`, or call `org-babel-tangle-file` as part of the loader path.
+
+A fresh clone or a machine with no generated cache tangles once on first startup, then uses the generated cache on subsequent startups until `config.org` changes.
+
+The startup ordering established by the project foundation remains intact: `p3-project` must still be loaded before the literate configuration, so project detection cannot be cached with competing semantics before the config runs.
+
+## Reload workflow
+
+The existing user-facing `p3/config-reload` command should preserve its current practical meaning: edits to `config.org` are rebuilt and then loaded into the current Emacs session.
+
+`p3/config-reload` therefore must force an explicit `p3/config-build` before loading, rather than relying only on modification-time freshness. This keeps the edit -> reload workflow deterministic even in unusual timestamp situations.
+
+`p3/config-visit` continues to open `config.org`.
+
+Existing keybindings for visiting and reloading the configuration remain unchanged.
+
+## Failure behavior
+
+If a startup-triggered rebuild fails, startup should surface the build error rather than silently load the older cache. The previous valid `config.el` should remain on disk because rebuilding occurs through a temporary file, but stale configuration must not be silently substituted for the authoritative source.
+
+If an interactive `p3/config-build` or `p3/config-reload` fails, the current Emacs session remains as it was before the attempted reload, and the last valid generated cache remains available for later recovery.
+
+If `config.el` is current but cannot be loaded, the load error should propagate normally. The loader should not automatically rebuild merely because evaluation of a current generated file failed; that would obscure the distinction between stale generation and a runtime configuration error.
+
+## Package/bootstrap implications
+
+This PR changes only the configuration build/load boundary. It does not redesign package installation or `use-package` bootstrap.
+
+Org and `ob-tangle` should no longer be unconditional bootstrap dependencies of the loader. They are required only when a build is needed. The literate configuration may still load Org later for normal Org functionality; this PR does not attempt to defer or reorganize that package configuration.
+
+## Tests
+
+Add focused ERT coverage for `p3-config-loader.el` that establishes:
+
+1. a missing generated cache is stale;
+2. an older generated cache is stale;
+3. a generated cache newer than or equal to the source is current;
+4. a current cache loads without invoking the tangler;
+5. a missing or stale cache rebuilds before loading;
+6. explicit `p3/config-build` always rebuilds regardless of timestamps;
+7. `p3/config-reload` always rebuilds before loading;
+8. a failed build does not replace an existing valid generated cache;
+9. temporary build artifacts are cleaned up after success and failure;
+10. the loader does not require Org/Babel on the current-cache path;
+11. `init.el` loads `p3-project` before `p3-config-loader` loads the literate configuration;
+12. the real `config.org` still tangles to syntactically readable Emacs Lisp.
+
+Tests should use temporary source/generated files for cache lifecycle behavior and should not load the real generated configuration as part of unit tests.
+
+The existing full ERT suite remains the regression gate. `p3-config-loader.el` should be byte-compiled with warnings treated as errors.
+
+## CI
+
+The normal Ubuntu workflow should add `p3-config-loader.el` to byte-compilation and load its ERT tests.
+
+CI should continue freshly tangling the real `config.org` to a temporary file and checking that the result is readable. Because `config.el` remains untracked, CI should not compare the repository against a committed generated file.
+
+No new workflow, matrix, cache service, or diagnostic machinery is required. Windows-specific behavior is not changed by this PR, so the existing Windows project/platform workflow does not need a new startup-cache test unless implementation reveals a Windows-specific filesystem issue.
+
+## Non-goals
+
+This PR will not:
+
+- track `config.el` in Git;
+- make `config.el` a second source of truth;
+- remove `config.org`;
+- introduce hashes, manifests, watchers, Makefiles, or external build tooling;
+- byte-compile the generated `config.el`;
+- reorganize `config.org` into package modules;
+- redesign package bootstrap or package installation;
+- alter project semantics from PR #10;
+- change completion, ESS, Python, Org, terminal, or window behavior;
+- add background rebuilding.
+
+The later modules-vs-functionality PR remains responsible for broader configuration decomposition.

--- a/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
+++ b/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
@@ -20,14 +20,16 @@ Introduce `lisp/p3-config-loader.el` as the focused owner of the generated-confi
 
 - `p3/config-source`, pointing to `config.org`;
 - `p3/config-generated`, pointing to ignored `config.el`;
-- freshness detection for the generated cache;
-- explicit cache rebuilding;
-- conditional cache rebuilding for startup;
-- loading the generated configuration.
+- `p3/config-cache-stale-p`, which decides whether regeneration is needed;
+- `p3/config-build`, which explicitly regenerates and validates the cache;
+- `p3/config-load-generated`, which loads the existing generated file without performing freshness logic; and
+- `p3/config-load`, the normal startup entry point that rebuilds only when required and then loads the cache.
 
-`init.el` remains responsible for bootstrap sequencing only. After adding `lisp/` to `load-path` and establishing the early `p3-project` project semantics, it requires `p3-config-loader` and asks it to load the configuration. The loader decides whether a build is required.
+This separation keeps the two workflows explicit. Startup uses `p3/config-load`; interactive reload uses `p3/config-build` followed by `p3/config-load-generated`, so reload cannot accidentally perform a second rebuild because of timestamp edge cases.
 
-`p3-core.el` retains the user-facing visit/reload commands, but delegates build/load behavior to the loader rather than owning the generated-file lifecycle itself.
+`init.el` remains responsible for bootstrap sequencing only. After adding `lisp/` to `load-path` and establishing the early `p3-project` project semantics, it requires `p3-config-loader` and calls `p3/config-load`. The loader decides whether a build is required.
+
+`p3-core.el` retains the user-facing visit/reload commands and depends on `p3-config-loader` for build/load behavior rather than owning the generated-file lifecycle itself.
 
 ## Source-of-truth contract
 
@@ -58,22 +60,25 @@ A build should:
 
 1. load Org/Babel tangling support lazily;
 2. tangle `config.org` into a temporary file in the same configuration directory;
-3. replace `config.el` only after the tangle succeeds; and
-4. return the generated file path.
+3. verify that the temporary file is syntactically readable Emacs Lisp without evaluating it;
+4. replace `config.el` only after tangling and validation both succeed; and
+5. return the generated file path.
 
-Using a temporary file protects the last valid generated cache from a failed or interrupted tangle. The final replacement should occur only after `org-babel-tangle-file` completes successfully.
+Using a staged temporary file protects the last valid generated cache from an interrupted tangle or a source edit that tangles into malformed Lisp. Runtime errors inside otherwise readable configuration are intentionally not part of build validation; they remain load-time errors.
 
-The temporary file must be cleaned up on both success and failure.
+The temporary file must be cleaned up on both success and failure. Replacement should happen only after successful validation and should permit replacing an existing cache.
 
 The build command may report a concise interactive success message, but startup-triggered rebuilds should remain quiet unless an error occurs.
 
 ## Load and startup contract
 
-Expose a loader entry point that performs the normal startup path:
+`p3/config-load-generated` loads `p3/config-generated` exactly as it exists and does no freshness checking or rebuilding.
+
+`p3/config-load` performs the normal startup path:
 
 1. check whether the generated cache is missing or stale;
 2. call `p3/config-build` only when rebuilding is required; and
-3. load `config.el`.
+3. call `p3/config-load-generated`.
 
 When the cache is current, normal startup must not require `org`, `ob-tangle`, or call `org-babel-tangle-file` as part of the loader path.
 
@@ -85,7 +90,7 @@ The startup ordering established by the project foundation remains intact: `p3-p
 
 The existing user-facing `p3/config-reload` command should preserve its current practical meaning: edits to `config.org` are rebuilt and then loaded into the current Emacs session.
 
-`p3/config-reload` therefore must force an explicit `p3/config-build` before loading, rather than relying only on modification-time freshness. This keeps the edit -> reload workflow deterministic even in unusual timestamp situations.
+`p3/config-reload` therefore calls `p3/config-build` unconditionally and, only after that succeeds, calls `p3/config-load-generated`. It does not call the freshness-aware startup entry point. This guarantees exactly one rebuild per reload request and remains deterministic even in unusual timestamp situations.
 
 `p3/config-visit` continues to open `config.org`.
 
@@ -93,7 +98,7 @@ Existing keybindings for visiting and reloading the configuration remain unchang
 
 ## Failure behavior
 
-If a startup-triggered rebuild fails, startup should surface the build error rather than silently load the older cache. The previous valid `config.el` should remain on disk because rebuilding occurs through a temporary file, but stale configuration must not be silently substituted for the authoritative source.
+If a startup-triggered rebuild fails during tangling or syntax validation, startup should surface the build error rather than silently load the older cache. The previous valid `config.el` remains on disk because rebuilding occurs through a staged temporary file, but stale configuration must not be silently substituted for the authoritative source.
 
 If an interactive `p3/config-build` or `p3/config-reload` fails, the current Emacs session remains as it was before the attempted reload, and the last valid generated cache remains available for later recovery.
 
@@ -112,13 +117,13 @@ Add focused ERT coverage for `p3-config-loader.el` that establishes:
 1. a missing generated cache is stale;
 2. an older generated cache is stale;
 3. a generated cache newer than or equal to the source is current;
-4. a current cache loads without invoking the tangler;
+4. a current cache loads without invoking the tangler or requiring Org/Babel through the loader;
 5. a missing or stale cache rebuilds before loading;
 6. explicit `p3/config-build` always rebuilds regardless of timestamps;
-7. `p3/config-reload` always rebuilds before loading;
-8. a failed build does not replace an existing valid generated cache;
-9. temporary build artifacts are cleaned up after success and failure;
-10. the loader does not require Org/Babel on the current-cache path;
+7. `p3/config-reload` performs exactly one explicit build followed by a direct generated-file load;
+8. a tangle failure does not replace an existing valid generated cache;
+9. syntactically malformed tangled output does not replace an existing valid generated cache;
+10. temporary build artifacts are cleaned up after success and failure;
 11. `init.el` loads `p3-project` before `p3-config-loader` loads the literate configuration;
 12. the real `config.org` still tangles to syntactically readable Emacs Lisp.
 
@@ -143,6 +148,7 @@ This PR will not:
 - remove `config.org`;
 - introduce hashes, manifests, watchers, Makefiles, or external build tooling;
 - byte-compile the generated `config.el`;
+- evaluate generated code as part of build validation;
 - reorganize `config.org` into package modules;
 - redesign package bootstrap or package installation;
 - alter project semantics from PR #10;

--- a/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
+++ b/docs/superpowers/specs/2026-09-03-startup-tangle-cache-design.md
@@ -4,7 +4,7 @@
 
 Stop tangling the entire literate Emacs configuration on every startup while preserving `config.org` as the sole authoritative configuration source and keeping startup reliable after edits, pulls, checkouts, and merges.
 
-The generated `config.el` remains an ignored local cache. Normal startup should load that cache directly when it is current, rebuild it only when it is missing or stale, and never require a tracked generated configuration file.
+The generated `config.el` remains an ignored local cache. Normal startup should load that cache directly when it was generated from the exact current contents of `config.org`, rebuild it only when the cache is missing or does not match the source, and never require a tracked generated configuration file.
 
 ## Current behavior and problem
 
@@ -14,18 +14,19 @@ That coupling makes startup do build work unconditionally. It also makes the gen
 
 ## Architecture
 
-Introduce `lisp/p3-config-loader.el` as the focused owner of the generated-config lifecycle. The loader should be usable independently of the full Emacs configuration so its cache behavior can be tested without invoking package bootstrap or evaluating `config.org`.
+Introduce `lisp/p3-config-loader.el` as the focused owner of the generated-config lifecycle. The loader should be usable independently of the full Emacs configuration so its cache behavior can be tested without invoking package bootstrap or evaluating the real generated configuration.
 
 `p3-config-loader.el` will own:
 
 - `p3/config-source`, pointing to `config.org`;
 - `p3/config-generated`, pointing to ignored `config.el`;
+- source fingerprint generation and cache fingerprint reading;
 - `p3/config-cache-stale-p`, which decides whether regeneration is needed;
 - `p3/config-build`, which explicitly regenerates and validates the cache;
-- `p3/config-load-generated`, which loads the existing generated file without performing freshness logic; and
+- `p3/config-load-generated`, which loads the exact generated source file without performing freshness logic; and
 - `p3/config-load`, the normal startup entry point that rebuilds only when required and then loads the cache.
 
-This separation keeps the two workflows explicit. Startup uses `p3/config-load`; interactive reload uses `p3/config-build` followed by `p3/config-load-generated`, so reload cannot accidentally perform a second rebuild because of timestamp edge cases.
+Startup uses `p3/config-load`. Interactive reload uses `p3/config-build` followed by `p3/config-load-generated`, so reload performs exactly one rebuild and one load.
 
 `init.el` remains responsible for bootstrap sequencing only. After adding `lisp/` to `load-path` and establishing the early `p3-project` project semantics, it requires `p3-config-loader` and calls `p3/config-load`. The loader decides whether a build is required.
 
@@ -37,20 +38,43 @@ This separation keeps the two workflows explicit. Startup uses `p3/config-load`;
 
 `config.el` remains ignored by Git and must not be edited as source. It is a disposable local cache that can always be reconstructed from `config.org`.
 
-This PR will not begin tracking `config.el`, add a second canonical representation of the configuration, or introduce a generated-file manifest.
+This PR will not begin tracking `config.el`, add a second canonical representation of the configuration, or introduce a sidecar manifest.
 
 ## Freshness contract
 
-The generated cache is considered stale when either:
+Freshness is content-based, not timestamp-based.
 
-1. `config.el` does not exist; or
-2. `config.org` is newer than `config.el` according to normal file modification times.
+The loader computes a SHA-256 fingerprint from the exact current contents of `config.org`. A successful build records that fingerprint in a generated comment at the top of `config.el`, for example:
 
-A current cache is loaded without tangling.
+```text
+;; p3-config-source-sha256: <digest>
+```
 
-This deliberately uses the filesystem timestamp relationship rather than hashes, sidecar metadata, file watchers, or a build system. Git checkouts and pulls that update `config.org` naturally refresh its modification time, causing the next startup to rebuild the cache.
+The generated cache is stale when any of the following is true:
 
-The design assumes `config.el` is not manually edited. If someone manually changes the ignored cache and makes it newer than `config.org`, that cache may be loaded until the source changes or an explicit rebuild is requested. That is acceptable because the generated file is explicitly non-authoritative.
+1. `config.el` does not exist;
+2. the expected fingerprint header is missing or malformed; or
+3. the recorded fingerprint does not equal the SHA-256 fingerprint of the current `config.org` contents.
+
+A cache is current only when the fingerprints match exactly. Filesystem modification times do not participate in this decision.
+
+This keeps checkouts, pulls, merges, restored timestamps, and same-timestamp edits correct without introducing watchers or persistent metadata. Hashing a configuration file of this size is small startup work and does not require Org or Babel.
+
+If someone manually edits the ignored `config.el`, the embedded fingerprint does not make that edit authoritative. Manual cache edits are unsupported; `p3/config-build` reconstructs the cache from `config.org`.
+
+## Tangle-boundary contract
+
+`config.el` is a single generated Emacs Lisp artifact. The build must not permit `config.org` to redirect individual blocks to unrelated tangle destinations.
+
+Before tangling, the loader must validate the effective Babel tangle configuration and reject explicit per-file, property-level, or block-level `:tangle` destinations that would escape the single-cache contract. This validation occurs before any tangle writes are performed.
+
+The actual tangle must:
+
+- include only `emacs-lisp` source blocks;
+- use one staged file in the same directory as `config.el` as the intended output; and
+- verify that the tangler reports only that intended staged output.
+
+The current `config.org` does not depend on custom `:tangle` destinations. If a future configuration genuinely needs multiple generated artifacts, that is a separate design decision rather than something the startup loader should infer implicitly.
 
 ## Build contract
 
@@ -58,31 +82,37 @@ Expose `p3/config-build` as the explicit rebuild command.
 
 A build should:
 
-1. load Org/Babel tangling support lazily;
-2. tangle `config.org` into a temporary file in the same configuration directory;
-3. verify that the temporary file is syntactically readable Emacs Lisp without evaluating it;
-4. replace `config.el` only after tangling and validation both succeed; and
-5. return the generated file path.
+1. compute the SHA-256 fingerprint of `config.org`;
+2. load Org/Babel tangling support lazily;
+3. validate the single-target tangle contract before any tangle writes occur;
+4. tangle only `emacs-lisp` blocks from `config.org` into a temporary file in the same configuration directory;
+5. verify that the tangler produced only the intended staged file;
+6. insert the source-fingerprint comment into the staged file;
+7. verify that the staged file is syntactically readable Emacs Lisp without evaluating it;
+8. replace `config.el` with one same-directory `rename-file` operation that permits replacing the existing destination; and
+9. return the generated file path.
 
-Using a staged temporary file protects the last valid generated cache from an interrupted tangle or a source edit that tangles into malformed Lisp. Runtime errors inside otherwise readable configuration are intentionally not part of build validation; they remain load-time errors.
+Using a staged same-directory file protects the previous generated cache from interrupted tangling, malformed generated Lisp, and partial replacement. The implementation must not delete `config.el` before renaming the staged file over it.
 
-The temporary file must be cleaned up on both success and failure. Replacement should happen only after successful validation and should permit replacing an existing cache.
+Runtime errors inside otherwise readable configuration are intentionally not part of build validation; they remain load-time errors.
+
+The temporary file must be cleaned up on both success and failure when it still exists. Replacement occurs only after tangling and syntax validation succeed.
 
 The build command may report a concise interactive success message, but startup-triggered rebuilds should remain quiet unless an error occurs.
 
 ## Load and startup contract
 
-`p3/config-load-generated` loads `p3/config-generated` exactly as it exists and does no freshness checking or rebuilding.
+`p3/config-load-generated` loads `p3/config-generated` with `load-file`. It loads that exact `.el` file and does no freshness checking or rebuilding; an unrelated or stale `config.elc` must never enter generated-cache selection.
 
 `p3/config-load` performs the normal startup path:
 
-1. check whether the generated cache is missing or stale;
-2. call `p3/config-build` only when rebuilding is required; and
+1. compare the embedded cache fingerprint with the current source fingerprint;
+2. call `p3/config-build` only when the cache is missing or mismatched; and
 3. call `p3/config-load-generated`.
 
-When the cache is current, normal startup must not require `org`, `ob-tangle`, or call `org-babel-tangle-file` as part of the loader path.
+When the cache fingerprint matches, normal startup must not require `org`, `ob-tangle`, or call the tangler as part of the loader path.
 
-A fresh clone or a machine with no generated cache tangles once on first startup, then uses the generated cache on subsequent startups until `config.org` changes.
+A fresh clone or a machine with no generated cache tangles once on first startup, then uses the generated cache on subsequent startups until the contents of `config.org` change.
 
 The startup ordering established by the project foundation remains intact: `p3-project` must still be loaded before the literate configuration, so project detection cannot be cached with competing semantics before the config runs.
 
@@ -90,7 +120,7 @@ The startup ordering established by the project foundation remains intact: `p3-p
 
 The existing user-facing `p3/config-reload` command should preserve its current practical meaning: edits to `config.org` are rebuilt and then loaded into the current Emacs session.
 
-`p3/config-reload` therefore calls `p3/config-build` unconditionally and, only after that succeeds, calls `p3/config-load-generated`. It does not call the freshness-aware startup entry point. This guarantees exactly one rebuild per reload request and remains deterministic even in unusual timestamp situations.
+`p3/config-reload` therefore calls `p3/config-build` unconditionally and, only after that succeeds, calls `p3/config-load-generated`. It does not call the freshness-aware startup entry point. This guarantees exactly one rebuild per reload request.
 
 `p3/config-visit` continues to open `config.org`.
 
@@ -98,46 +128,59 @@ Existing keybindings for visiting and reloading the configuration remain unchang
 
 ## Failure behavior
 
-If a startup-triggered rebuild fails during tangling or syntax validation, startup should surface the build error rather than silently load the older cache. The previous valid `config.el` remains on disk because rebuilding occurs through a staged temporary file, but stale configuration must not be silently substituted for the authoritative source.
+A tangle, tangle-contract, fingerprint-insertion, or syntax-validation failure occurs before cache replacement. Such a failure must leave both the running Emacs session and the previous `config.el` untouched, clean up the staged file, and propagate the error. Startup must not silently fall back to a cache whose fingerprint does not match the authoritative source.
 
-If an interactive `p3/config-build` or `p3/config-reload` fails, the current Emacs session remains as it was before the attempted reload, and the last valid generated cache remains available for later recovery.
+A load-time error is different. Once a validated `config.el` begins evaluating, Emacs Lisp configuration loading is not transactional. A runtime error may occur after earlier forms have already modified the current Emacs session. The loader must propagate that error normally and must not claim to roll back those effects.
 
-If `config.el` is current but cannot be loaded, the load error should propagate normally. The loader should not automatically rebuild merely because evaluation of a current generated file failed; that would obscure the distinction between stale generation and a runtime configuration error.
+Similarly, when a rebuild succeeds and replaces `config.el` but loading that new cache then fails at runtime, the new syntactically valid cache remains on disk. The loader does not attempt to restore the previous cache automatically or reinterpret a runtime failure as a stale-cache failure.
+
+If a current fingerprint-matching `config.el` cannot be loaded, the load error propagates normally. The loader should not automatically rebuild merely because evaluation failed; that would obscure the distinction between generation correctness and runtime configuration behavior.
 
 ## Package/bootstrap implications
 
 This PR changes only the configuration build/load boundary. It does not redesign package installation or `use-package` bootstrap.
 
-Org and `ob-tangle` should no longer be unconditional bootstrap dependencies of the loader. They are required only when a build is needed. The literate configuration may still load Org later for normal Org functionality; this PR does not attempt to defer or reorganize that package configuration.
+Org and `ob-tangle` are no longer unconditional bootstrap dependencies of the loader. They are required only when a build is needed. The current-cache path uses only ordinary file I/O, hashing, fingerprint parsing, and `load-file`.
+
+The literate configuration may still load Org later for normal Org functionality; this PR does not attempt to defer or reorganize that package configuration.
 
 ## Tests
 
 Add focused ERT coverage for `p3-config-loader.el` that establishes:
 
 1. a missing generated cache is stale;
-2. an older generated cache is stale;
-3. a generated cache newer than or equal to the source is current;
-4. a current cache loads without invoking the tangler or requiring Org/Babel through the loader;
-5. a missing or stale cache rebuilds before loading;
-6. explicit `p3/config-build` always rebuilds regardless of timestamps;
-7. `p3/config-reload` performs exactly one explicit build followed by a direct generated-file load;
-8. a tangle failure does not replace an existing valid generated cache;
-9. syntactically malformed tangled output does not replace an existing valid generated cache;
-10. temporary build artifacts are cleaned up after success and failure;
-11. `init.el` loads `p3-project` before `p3-config-loader` loads the literate configuration;
-12. the real `config.org` still tangles to syntactically readable Emacs Lisp.
+2. a cache with a missing or malformed fingerprint is stale;
+3. a cache whose recorded fingerprint differs from `config.org` is stale regardless of file modification times;
+4. a cache with a matching fingerprint is current regardless of file modification times;
+5. a current cache loads without invoking the tangler or requiring Org/Babel through the loader;
+6. a missing or mismatched cache rebuilds before loading;
+7. explicit `p3/config-build` always rebuilds regardless of the current fingerprint;
+8. `p3/config-reload` performs exactly one explicit build followed by a direct generated-file load;
+9. explicit alternate `:tangle` destinations are rejected before tangling;
+10. only `emacs-lisp` blocks are admitted to the generated cache;
+11. a tangle failure does not replace an existing generated cache;
+12. syntactically malformed tangled output does not replace an existing generated cache;
+13. temporary build artifacts are cleaned up after success and failure;
+14. successful replacement overwrites an existing `config.el` through the staged rename path;
+15. `p3/config-load-generated` uses the exact `.el` cache even if a `config.elc` exists;
+16. `init.el` loads `p3-project` before `p3-config-loader` loads the literate configuration; and
+17. the real `config.org` still tangles to syntactically readable Emacs Lisp under the single-target/emacs-lisp-only contract.
 
 Tests should use temporary source/generated files for cache lifecycle behavior and should not load the real generated configuration as part of unit tests.
 
 The existing full ERT suite remains the regression gate. `p3-config-loader.el` should be byte-compiled with warnings treated as errors.
 
-## CI
+## CI and Windows contract
 
-The normal Ubuntu workflow should add `p3-config-loader.el` to byte-compilation and load its ERT tests.
+The normal Ubuntu workflow should add `p3-config-loader.el` to byte-compilation and load its ERT tests. CI should continue freshly tangling the real `config.org` to a temporary file and checking that the result is readable and respects the single-target contract. Because `config.el` remains untracked, CI should not compare the repository against a committed generated file.
 
-CI should continue freshly tangling the real `config.org` to a temporary file and checking that the result is readable. Because `config.el` remains untracked, CI should not compare the repository against a committed generated file.
+The existing native-Windows workflow should be extended narrowly to exercise the filesystem behavior introduced by this PR. It must verify that, with an existing generated cache:
 
-No new workflow, matrix, cache service, or diagnostic machinery is required. Windows-specific behavior is not changed by this PR, so the existing Windows project/platform workflow does not need a new startup-cache test unless implementation reveals a Windows-specific filesystem issue.
+1. a staged same-directory file can replace `config.el` through the loader's rename path;
+2. the resulting `config.el` contains the expected new contents/fingerprint; and
+3. the staged temporary file no longer exists afterward.
+
+No new workflow, matrix, cache service, or diagnostic machinery is required. The Windows addition belongs in the existing platform workflow and should run only when the relevant loader/test files change under that workflow's normal path filtering.
 
 ## Non-goals
 
@@ -146,13 +189,16 @@ This PR will not:
 - track `config.el` in Git;
 - make `config.el` a second source of truth;
 - remove `config.org`;
-- introduce hashes, manifests, watchers, Makefiles, or external build tooling;
+- use modification times for cache validity;
+- add a sidecar manifest, watcher, Makefile, or external build tool;
 - byte-compile the generated `config.el`;
 - evaluate generated code as part of build validation;
+- make configuration evaluation transactional or add runtime rollback machinery;
+- support multiple independent tangle destinations from `config.org`;
 - reorganize `config.org` into package modules;
 - redesign package bootstrap or package installation;
 - alter project semantics from PR #10;
-- change completion, ESS, Python, Org, terminal, or window behavior;
+- change completion, ESS, Python, Org, terminal, or window behavior; or
 - add background rebuilding.
 
 The later modules-vs-functionality PR remains responsible for broader configuration decomposition.

--- a/init.el
+++ b/init.el
@@ -69,15 +69,6 @@
 (setq use-package-ensure-function #'p3/use-package-ensure
       use-package-always-ensure t)
 
-;; Keep the generated file as a cache, never as an independent source of
-;; truth.  Tangling on every startup prevents config.el from drifting from
-;; config.org, including after a checkout or a merge.
-(require 'org)
-(require 'ob-tangle)
-(defconst p3/config-source
-  (expand-file-name "config.org" user-emacs-directory))
-(defconst p3/config-generated
-  (expand-file-name "config.el" user-emacs-directory))
 (defconst p3/lisp-directory
   (expand-file-name "lisp" user-emacs-directory))
 (add-to-list 'load-path p3/lisp-directory)
@@ -86,13 +77,10 @@
 ;; project-aware package has a chance to populate `project.el' caches.
 (require 'p3-project)
 
-(defun p3/load-config (&optional quiet)
-  "Tangle and load the literate configuration from `p3/config-source'."
-  (org-babel-tangle-file p3/config-source p3/config-generated)
-  (load-file p3/config-generated)
-  (unless quiet
-    (message "Loaded %s" p3/config-source)))
-(p3/load-config t)
+;; Load the generated literate-config cache, rebuilding it only when its
+;; embedded source fingerprint no longer matches config.org.
+(require 'p3-config-loader)
+(p3/config-load)
 
 (defun p3/recentf-record-current-buffer (&rest _)
   "Treat a completed Consult buffer switch as recent file access."

--- a/lisp/p3-config-loader.el
+++ b/lisp/p3-config-loader.el
@@ -48,14 +48,24 @@
     (setq buffer-file-name p3/config-source)
     (org-mode)
     (goto-char (point-min))
-    (while (org-babel-next-src-block 1)
-      (let* ((info (org-babel-get-src-block-info 'light))
-             (params (nth 2 info))
-             (tangle (cdr (assq :tangle params))))
-        (unless (or (null tangle)
-                    (equal (format "%s" tangle) "no"))
-          (user-error "Unsupported :tangle setting %S in %s"
-                      tangle p3/config-source))))))
+    (let ((done nil))
+      (while (not done)
+        (condition-case err
+            (progn
+              (org-babel-next-src-block 1)
+              (let* ((info (org-babel-get-src-block-info 'light))
+                     (params (nth 2 info))
+                     (tangle (cdr (assq :tangle params))))
+                (unless (or (null tangle)
+                            (equal (format "%s" tangle) "no"))
+                  (user-error "Unsupported :tangle setting %S in %s"
+                              tangle p3/config-source))))
+          (user-error
+           (if (string-match-p
+                "\\`No \\(?:further \\)?code blocks\\'"
+                (error-message-string err))
+               (setq done t)
+             (signal (car err) (cdr err)))))))))
 
 (defun p3/config--assert-single-tangle-output (outputs staged)
   "Require OUTPUTS to contain only STAGED."

--- a/lisp/p3-config-loader.el
+++ b/lisp/p3-config-loader.el
@@ -1,0 +1,127 @@
+;;; p3-config-loader.el --- Build and load the literate config cache -*- lexical-binding: t; -*-
+
+(declare-function org-mode "org" ())
+(declare-function org-babel-next-src-block "ob-core" (&optional arg))
+(declare-function org-babel-get-src-block-info "ob-core" (&optional light datum))
+(declare-function org-babel-tangle-file "ob-tangle" (file &optional target-file lang-re))
+
+(defconst p3/config-source
+  (expand-file-name "config.org" user-emacs-directory)
+  "Authoritative literate Emacs configuration.")
+
+(defconst p3/config-generated
+  (expand-file-name "config.el" user-emacs-directory)
+  "Ignored generated cache for `p3/config-source'.")
+
+(defconst p3/config--fingerprint-prefix
+  ";; p3-config-source-sha256: "
+  "Prefix used to record the source digest in the generated cache.")
+
+(defun p3/config--source-digest ()
+  "Return the SHA-256 digest of the exact bytes in `p3/config-source'."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally p3/config-source)
+    (secure-hash 'sha256 (current-buffer))))
+
+(defun p3/config--generated-digest ()
+  "Return the recorded source digest from `p3/config-generated', or nil."
+  (when (file-readable-p p3/config-generated)
+    (with-temp-buffer
+      (insert-file-contents p3/config-generated nil 0 160)
+      (goto-char (point-min))
+      (when (looking-at
+             (concat (regexp-quote p3/config--fingerprint-prefix)
+                     "\\([0-9a-f]\\{64\\}\\)$"))
+        (match-string-no-properties 1)))))
+
+(defun p3/config-cache-stale-p ()
+  "Return non-nil unless the generated cache matches the current source."
+  (let ((recorded (p3/config--generated-digest)))
+    (or (null recorded)
+        (not (equal recorded (p3/config--source-digest))))))
+
+(defun p3/config--validate-tangle-contract ()
+  "Reject source blocks whose tangle setting could escape staging."
+  (with-temp-buffer
+    (insert-file-contents p3/config-source)
+    (setq buffer-file-name p3/config-source)
+    (org-mode)
+    (goto-char (point-min))
+    (while (org-babel-next-src-block 1)
+      (let* ((info (org-babel-get-src-block-info 'light))
+             (params (nth 2 info))
+             (tangle (cdr (assq :tangle params))))
+        (unless (or (null tangle)
+                    (equal (format "%s" tangle) "no"))
+          (user-error "Unsupported :tangle setting %S in %s"
+                      tangle p3/config-source))))))
+
+(defun p3/config--assert-single-tangle-output (outputs staged)
+  "Require OUTPUTS to contain only STAGED."
+  (unless (and (= (length outputs) 1)
+               (file-equal-p (car outputs) staged))
+    (error "Config tangle produced unexpected outputs: %S" outputs)))
+
+(defun p3/config--insert-fingerprint (path digest)
+  "Insert DIGEST as the generated-cache fingerprint at the start of PATH."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (goto-char (point-min))
+    (insert p3/config--fingerprint-prefix digest "\n")
+    (write-region (point-min) (point-max) path nil 'silent)))
+
+(defun p3/config--assert-readable-elisp (path)
+  "Signal an error unless PATH contains syntactically readable Emacs Lisp."
+  (with-temp-buffer
+    (insert-file-contents path)
+    (emacs-lisp-mode)
+    (check-parens)
+    (goto-char (point-min))
+    (condition-case nil
+        (while t
+          (read (current-buffer)))
+      (end-of-file t))))
+
+(defun p3/config-build ()
+  "Rebuild and validate the generated cache from `p3/config-source'."
+  (interactive)
+  (let* ((source-digest (p3/config--source-digest))
+         (directory (file-name-directory p3/config-generated))
+         (staged (make-temp-file
+                  (expand-file-name ".p3-config-stage-" directory)
+                  nil ".el")))
+    (unwind-protect
+        (progn
+          (require 'org)
+          (require 'ob-tangle)
+          (p3/config--validate-tangle-contract)
+          (let ((outputs
+                 (org-babel-tangle-file
+                  p3/config-source staged "emacs-lisp")))
+            (p3/config--assert-single-tangle-output outputs staged))
+          (unless (equal source-digest (p3/config--source-digest))
+            (error "%s changed while the config cache was being built"
+                   p3/config-source))
+          (p3/config--insert-fingerprint staged source-digest)
+          (p3/config--assert-readable-elisp staged)
+          (rename-file staged p3/config-generated t)
+          (when (called-interactively-p 'interactive)
+            (message "Built %s" p3/config-generated))
+          p3/config-generated)
+      (when (file-exists-p staged)
+        (delete-file staged)))))
+
+(defun p3/config-load-generated ()
+  "Load exactly the generated Emacs Lisp cache."
+  (load-file p3/config-generated))
+
+(defun p3/config-load ()
+  "Load the config cache, rebuilding first when it is stale."
+  (when (p3/config-cache-stale-p)
+    (p3/config-build))
+  (p3/config-load-generated))
+
+(provide 'p3-config-loader)
+
+;;; p3-config-loader.el ends here

--- a/lisp/p3-config-loader.el
+++ b/lisp/p3-config-loader.el
@@ -41,6 +41,15 @@
     (or (null recorded)
         (not (equal recorded (p3/config--source-digest))))))
 
+(defun p3/config--assert-safe-tangle-info (info)
+  "Reject an INFO record whose tangle setting could escape staging."
+  (let* ((params (nth 2 info))
+         (tangle (cdr (assq :tangle params))))
+    (unless (or (null tangle)
+                (equal (format "%s" tangle) "no"))
+      (user-error "Unsupported :tangle setting %S in %s"
+                  tangle p3/config-source))))
+
 (defun p3/config--validate-tangle-contract ()
   "Reject source blocks whose tangle setting could escape staging."
   (with-temp-buffer
@@ -48,18 +57,18 @@
     (setq buffer-file-name p3/config-source)
     (org-mode)
     (goto-char (point-min))
+    ;; `org-babel-next-src-block' moves to a later block, so validate a
+    ;; source block already under point before advancing through the file.
+    (let ((info (org-babel-get-src-block-info 'light)))
+      (when info
+        (p3/config--assert-safe-tangle-info info)))
     (let ((done nil))
       (while (not done)
         (condition-case err
             (progn
               (org-babel-next-src-block 1)
-              (let* ((info (org-babel-get-src-block-info 'light))
-                     (params (nth 2 info))
-                     (tangle (cdr (assq :tangle params))))
-                (unless (or (null tangle)
-                            (equal (format "%s" tangle) "no"))
-                  (user-error "Unsupported :tangle setting %S in %s"
-                              tangle p3/config-source))))
+              (p3/config--assert-safe-tangle-info
+               (org-babel-get-src-block-info 'light)))
           (user-error
            (if (string-match-p
                 "\\`No \\(?:further \\)?code blocks\\'"

--- a/lisp/p3-config-loader.el
+++ b/lisp/p3-config-loader.el
@@ -105,7 +105,8 @@
 (defun p3/config-build ()
   "Rebuild and validate the generated cache from `p3/config-source'."
   (interactive)
-  (let* ((source-digest (p3/config--source-digest))
+  (let* ((interactive-build (called-interactively-p 'interactive))
+         (source-digest (p3/config--source-digest))
          (directory (file-name-directory p3/config-generated))
          (staged (make-temp-file
                   (expand-file-name ".p3-config-stage-" directory)
@@ -115,9 +116,10 @@
           (require 'org)
           (require 'ob-tangle)
           (p3/config--validate-tangle-contract)
-          (let ((outputs
-                 (org-babel-tangle-file
-                  p3/config-source staged "emacs-lisp")))
+          (let* ((inhibit-message (not interactive-build))
+                 (outputs
+                  (org-babel-tangle-file
+                   p3/config-source staged "emacs-lisp")))
             (p3/config--assert-single-tangle-output outputs staged))
           (unless (equal source-digest (p3/config--source-digest))
             (error "%s changed while the config cache was being built"
@@ -125,7 +127,7 @@
           (p3/config--insert-fingerprint staged source-digest)
           (p3/config--assert-readable-elisp staged)
           (rename-file staged p3/config-generated t)
-          (when (called-interactively-p 'interactive)
+          (when interactive-build
             (message "Built %s" p3/config-generated))
           p3/config-generated)
       (when (file-exists-p staged)

--- a/lisp/p3-core.el
+++ b/lisp/p3-core.el
@@ -1,21 +1,18 @@
 ;;; p3-core.el --- Shared helpers for the personal Emacs config -*- lexical-binding: t; -*-
 
-(declare-function p3/load-config nil (&optional quiet))
+(require 'p3-config-loader)
 
 (defun p3/config-visit ()
   "Visit the authoritative literate Emacs configuration."
   (interactive)
-  (find-file
-   (if (boundp 'p3/config-source)
-       p3/config-source
-     (expand-file-name "config.org" user-emacs-directory))))
+  (find-file p3/config-source))
 
 (defun p3/config-reload ()
-  "Tangle and reload the authoritative literate Emacs configuration."
+  "Rebuild and reload the authoritative literate Emacs configuration."
   (interactive)
-  (unless (fboundp 'p3/load-config)
-    (user-error "Config loader is unavailable"))
-  (p3/load-config))
+  (p3/config-build)
+  (p3/config-load-generated)
+  (message "Reloaded %s" p3/config-source))
 
 (provide 'p3-core)
 

--- a/test/p3-config-loader-test.el
+++ b/test/p3-config-loader-test.el
@@ -178,7 +178,7 @@
                  (with-temp-file target (insert "(setq p3-test t)\n"))
                  (list target
                        (expand-file-name "unexpected.el"
-                                         (file-name-directory target)))))))
+                                         (file-name-directory target))))))
       (should-error (p3/config-build)))
     (should (equal (with-temp-buffer
                      (insert-file-contents p3/config-generated)

--- a/test/p3-config-loader-test.el
+++ b/test/p3-config-loader-test.el
@@ -1,0 +1,257 @@
+;;; p3-config-loader-test.el --- Tests for config cache loading -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+
+(defconst p3-config-loader-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-config-loader-test--root))
+(require 'p3-config-loader)
+
+(defconst p3-config-loader-test--org-loaded-by-loader-p (featurep 'org))
+(defconst p3-config-loader-test--ob-tangle-loaded-by-loader-p (featurep 'ob-tangle))
+
+(require 'org)
+(require 'ob-tangle)
+
+(defun p3-config-loader-test--digest (path)
+  "Return the SHA-256 digest of PATH's exact bytes."
+  (with-temp-buffer
+    (set-buffer-multibyte nil)
+    (insert-file-contents-literally path)
+    (secure-hash 'sha256 (current-buffer))))
+
+(defmacro p3-config-loader-test--with-files (source-content &rest body)
+  "Run BODY with temporary config source/cache files."
+  (declare (indent 1))
+  `(let* ((directory (make-temp-file "p3-config-loader-test-" t))
+          (p3/config-source (expand-file-name "config.org" directory))
+          (p3/config-generated (expand-file-name "config.el" directory)))
+     (unwind-protect
+         (progn
+           (with-temp-file p3/config-source
+             (insert ,source-content))
+           ,@body)
+       (delete-directory directory t))))
+
+(defun p3-config-loader-test--write-current-cache (body)
+  "Write BODY to the current temporary cache with a matching fingerprint."
+  (let ((digest (p3-config-loader-test--digest p3/config-source)))
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: " digest "\n" body))))
+
+(defun p3-config-loader-test--stage-files (directory)
+  "Return staged config-cache files remaining in DIRECTORY."
+  (directory-files directory t "\\`\\.p3-config-stage-"))
+
+(ert-deftest p3-config-loader-does-not-load-org-at-module-load ()
+  (should-not p3-config-loader-test--org-loaded-by-loader-p)
+  (should-not p3-config-loader-test--ob-tangle-loaded-by-loader-p))
+
+(ert-deftest p3-config-loader-missing-cache-is-stale ()
+  (p3-config-loader-test--with-files "source"
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-missing-fingerprint-is-stale ()
+  (p3-config-loader-test--with-files "source"
+    (with-temp-file p3/config-generated
+      (insert "(setq p3-test-cache t)\n"))
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-malformed-fingerprint-is-stale ()
+  (p3-config-loader-test--with-files "source"
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: not-a-digest\n"))
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-mismatched-fingerprint-is-stale-regardless-of-mtime ()
+  (p3-config-loader-test--with-files "source-v1"
+    (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
+    (with-temp-file p3/config-source
+      (insert "source-v2"))
+    (set-file-times p3/config-source (seconds-to-time 1000000000))
+    (set-file-times p3/config-generated (seconds-to-time 2000000000))
+    (should (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-matching-fingerprint-is-current-regardless-of-mtime ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache "(setq p3-test-cache t)\n")
+    (set-file-times p3/config-generated (seconds-to-time 1000000000))
+    (set-file-times p3/config-source (seconds-to-time 2000000000))
+    (should-not (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-load-generated-uses-exact-el-file ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache
+     "(setq p3-config-loader-test--loaded 'source)\n")
+    (with-temp-file (concat p3/config-generated "c")
+      (insert "(setq p3-config-loader-test--loaded 'compiled)\n"))
+    (setq p3-config-loader-test--loaded nil)
+    (p3/config-load-generated)
+    (should (eq p3-config-loader-test--loaded 'source))))
+
+(ert-deftest p3-config-loader-current-cache-loads-without-build-or-org-require ()
+  (p3-config-loader-test--with-files "source"
+    (p3-config-loader-test--write-current-cache
+     "(setq p3-config-loader-test--loaded 'current)\n")
+    (setq p3-config-loader-test--loaded nil)
+    (let ((original-require (symbol-function 'require)))
+      (cl-letf (((symbol-function 'p3/config-build)
+                 (lambda () (ert-fail "Current cache attempted a rebuild")))
+                ((symbol-function 'require)
+                 (lambda (feature &rest args)
+                   (when (memq feature '(org ob-tangle))
+                     (ert-fail (format "Current cache required %S" feature)))
+                   (apply original-require feature args))))
+        (p3/config-load)))
+    (should (eq p3-config-loader-test--loaded 'current))))
+
+(ert-deftest p3-config-loader-rejects-property-tangle-before-writing ()
+  (p3-config-loader-test--with-files
+      "#+PROPERTY: header-args:emacs-lisp :tangle escaped.el\n#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (let ((escaped (expand-file-name "escaped.el"
+                                     (file-name-directory p3/config-source))))
+      (should-error (p3/config-build))
+      (should-not (file-exists-p escaped))
+      (should-not (file-exists-p p3/config-generated)))))
+
+(ert-deftest p3-config-loader-rejects-block-tangle-before-writing ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp :tangle escaped.el\n(setq p3-test t)\n#+end_src\n"
+    (let ((escaped (expand-file-name "escaped.el"
+                                     (file-name-directory p3/config-source))))
+      (should-error (p3/config-build))
+      (should-not (file-exists-p escaped))
+      (should-not (file-exists-p p3/config-generated)))))
+
+(ert-deftest p3-config-loader-build-admits-only-emacs-lisp ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--language 'elisp)\n#+end_src\n#+begin_src shell\necho SHOULD_NOT_APPEAR\n#+end_src\n"
+    (p3/config-build)
+    (with-temp-buffer
+      (insert-file-contents p3/config-generated)
+      (should (search-forward "p3-config-loader-test--language" nil t))
+      (goto-char (point-min))
+      (should-not (search-forward "SHOULD_NOT_APPEAR" nil t)))))
+
+(ert-deftest p3-config-loader-tangle-failure-preserves-cache-and-cleans-stage ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (let ((directory (file-name-directory p3/config-generated)))
+      (cl-letf (((symbol-function 'org-babel-tangle-file)
+                 (lambda (&rest _) (error "synthetic tangle failure"))))
+        (should-error (p3/config-build)))
+      (should (equal (with-temp-buffer
+                       (insert-file-contents p3/config-generated)
+                       (buffer-string))
+                     "old-cache"))
+      (should-not (p3-config-loader-test--stage-files directory)))))
+
+(ert-deftest p3-config-loader-malformed-output-preserves-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(unclosed"))
+                 (list target))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+
+(ert-deftest p3-config-loader-rejects-unexpected-tangle-output ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test t)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(setq p3-test t)\n"))
+                 (list target
+                       (expand-file-name "unexpected.el"
+                                         (file-name-directory target)))))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+
+(ert-deftest p3-config-loader-source-change-during-build-preserves-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-test 'old)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (cl-letf (((symbol-function 'org-babel-tangle-file)
+               (lambda (_source target _language)
+                 (with-temp-file target (insert "(setq p3-test 'old)\n"))
+                 (with-temp-file p3/config-source
+                   (insert "#+begin_src emacs-lisp\n(setq p3-test 'new)\n#+end_src\n"))
+                 (list target))))
+      (should-error (p3/config-build)))
+    (should (equal (with-temp-buffer
+                     (insert-file-contents p3/config-generated)
+                     (buffer-string))
+                   "old-cache"))))
+
+(ert-deftest p3-config-loader-build-replaces-existing-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--replacement 'new)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert "old-cache"))
+    (let ((directory (file-name-directory p3/config-generated)))
+      (should (equal (p3/config-build) p3/config-generated))
+      (should (commandp #'p3/config-build))
+      (should-not (p3/config-cache-stale-p))
+      (with-temp-buffer
+        (insert-file-contents p3/config-generated)
+        (goto-char (point-min))
+        (should (looking-at ";; p3-config-source-sha256: [0-9a-f]\\{64\\}$"))
+        (should (search-forward "p3-config-loader-test--replacement" nil t)))
+      (should-not (p3-config-loader-test--stage-files directory)))))
+
+(ert-deftest p3-config-loader-missing-cache-rebuilds-before-load ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--loaded 'fresh)\n#+end_src\n"
+    (setq p3-config-loader-test--loaded nil)
+    (p3/config-load)
+    (should (eq p3-config-loader-test--loaded 'fresh))
+    (should-not (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-mismatched-cache-rebuilds-before-load ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--loaded 'fresh)\n#+end_src\n"
+    (with-temp-file p3/config-generated
+      (insert ";; p3-config-source-sha256: "
+              (make-string 64 ?0)
+              "\n(setq p3-config-loader-test--loaded 'stale)\n"))
+    (setq p3-config-loader-test--loaded nil)
+    (p3/config-load)
+    (should (eq p3-config-loader-test--loaded 'fresh))
+    (should-not (p3/config-cache-stale-p))))
+
+(ert-deftest p3-config-loader-explicit-build-rebuilds-current-cache ()
+  (p3-config-loader-test--with-files
+      "#+begin_src emacs-lisp\n(setq p3-config-loader-test--explicit-build t)\n#+end_src\n"
+    (p3/config-build)
+    (should-not (p3/config-cache-stale-p))
+    (let ((original-tangle (symbol-function 'org-babel-tangle-file))
+          (calls 0))
+      (cl-letf (((symbol-function 'org-babel-tangle-file)
+                 (lambda (&rest args)
+                   (setq calls (1+ calls))
+                   (apply original-tangle args))))
+        (p3/config-build))
+      (should (= calls 1)))))
+
+(provide 'p3-config-loader-test)
+
+;;; p3-config-loader-test.el ends here

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -1,14 +1,15 @@
 ;;; p3-config-test.el --- Smoke tests for the Emacs config -*- lexical-binding: t; -*-
 
 (require 'ert)
-(require 'org)
-(require 'ob-tangle)
 
 (defconst p3-config-test--root
   (file-name-directory
    (directory-file-name
     (file-name-directory (or load-file-name buffer-file-name))))
   "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-config-test--root))
+(require 'p3-config-loader)
 
 (defun p3-config-test--assert-readable-elisp (path)
   "Fail when PATH does not contain syntactically readable Emacs Lisp."
@@ -17,8 +18,6 @@
     (emacs-lisp-mode)
     (condition-case err
         (progn
-          ;; `check-parens' distinguishes an incomplete form from the normal
-          ;; end-of-file signal produced by repeatedly calling `read'.
           (check-parens)
           (goto-char (point-min))
           (condition-case nil
@@ -33,17 +32,24 @@
   (p3-config-test--assert-readable-elisp
    (expand-file-name "init.el" p3-config-test--root)))
 
-(ert-deftest p3-config-org-tangles-to-readable-elisp ()
-  (let ((target (make-temp-file "p3-config-test-" nil ".el")))
+(ert-deftest p3-config-org-builds-through-production-cache-contract ()
+  (let* ((directory (make-temp-file "p3-config-real-build-" t))
+         (p3/config-source
+          (expand-file-name "config.org" p3-config-test--root))
+         (p3/config-generated
+          (expand-file-name "config.el" directory)))
     (unwind-protect
         (progn
-          (org-babel-tangle-file
-           (expand-file-name "config.org" p3-config-test--root)
-           target
-           "emacs-lisp")
-          (should (> (file-attribute-size (file-attributes target)) 0))
-          (p3-config-test--assert-readable-elisp target))
-      (delete-file target))))
+          (should (equal (p3/config-build) p3/config-generated))
+          (should-not (p3/config-cache-stale-p))
+          (with-temp-buffer
+            (insert-file-contents p3/config-generated)
+            (goto-char (point-min))
+            (should
+             (looking-at
+              ";; p3-config-source-sha256: [0-9a-f]\\{64\\}$")))
+          (p3-config-test--assert-readable-elisp p3/config-generated))
+      (delete-directory directory t))))
 
 (ert-deftest p3-config-org-owns-org-export-integration ()
   (with-temp-buffer
@@ -63,11 +69,9 @@
                       "p3-ess" "p3-gptel"))
       (goto-char (point-min))
       (should (search-forward (format "(use-package %s" module) nil t)))
-    ;; Package declarations and wiring stay visible in the literate config.
     (dolist (package '("python" "eglot" "ess-r-mode" "vterm" "gptel"))
       (goto-char (point-min))
       (should (search-forward (format "(use-package %s" package) nil t)))
-    ;; Subsystem implementations belong to independently testable libraries.
     (dolist (implementation '("(defun p3/windows-rtools-version"
                                "(defun p3/windows-latest-r-program"
                                "(defun p3/project-root"
@@ -122,7 +126,7 @@
       (should (< terminal-position shell-position))
       (should (< shell-position shell-binding-position)))))
 
-(ert-deftest p3-init-loads-project-foundation-before-literate-config ()
+(ert-deftest p3-init-loads-project-and-loader-before-literate-config ()
   (with-temp-buffer
     (insert-file-contents (expand-file-name "init.el" p3-config-test--root))
     (let ((load-path-position
@@ -130,17 +134,32 @@
              (should (search-forward "(add-to-list 'load-path p3/lisp-directory)" nil t))
              (point)))
           project-position
+          loader-position
           config-position)
       (setq project-position
             (progn
               (should (search-forward "(require 'p3-project)" nil t))
               (point)))
+      (setq loader-position
+            (progn
+              (should (search-forward "(require 'p3-config-loader)" nil t))
+              (point)))
       (setq config-position
             (progn
-              (should (search-forward "(p3/load-config t)" nil t))
+              (should (search-forward "(p3/config-load)" nil t))
               (point)))
       (should (< load-path-position project-position))
-      (should (< project-position config-position)))))
+      (should (< project-position loader-position))
+      (should (< loader-position config-position)))))
+
+(ert-deftest p3-init-does-not-unconditionally-load-org-for-tangling ()
+  (with-temp-buffer
+    (insert-file-contents (expand-file-name "init.el" p3-config-test--root))
+    (should-not (search-forward "(require 'ob-tangle)" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(org-babel-tangle-file" nil t))
+    (goto-char (point-min))
+    (should-not (search-forward "(defun p3/load-config" nil t))))
 
 (ert-deftest p3-init-does-not-special-case-org-export ()
   (with-temp-buffer

--- a/test/p3-core-test.el
+++ b/test/p3-core-test.el
@@ -1,6 +1,7 @@
 ;;; p3-core-test.el --- Tests for p3-core -*- lexical-binding: t; -*-
 
 (require 'ert)
+(require 'cl-lib)
 
 (defconst p3-core-test--root
   (file-name-directory
@@ -15,6 +16,15 @@
 (ert-deftest p3-core-config-commands-remain-commands ()
   (should (commandp #'p3/config-visit))
   (should (commandp #'p3/config-reload)))
+
+(ert-deftest p3-core-config-reload-builds-once-then-loads-directly ()
+  (let (calls)
+    (cl-letf (((symbol-function 'p3/config-build)
+               (lambda () (push 'build calls)))
+              ((symbol-function 'p3/config-load-generated)
+               (lambda () (push 'load calls))))
+      (p3/config-reload))
+    (should (equal (nreverse calls) '(build load)))))
 
 (provide 'p3-core-test)
 


### PR DESCRIPTION
## Summary

Replace unconditional startup tangling with an ignored, content-validated `config.el` cache while keeping `config.org` authoritative.

- embed a SHA-256 fingerprint of the exact `config.org` contents in the generated cache
- rebuild only when the cache is missing or mismatched
- keep Org/Babel off the current-cache startup path
- stage, validate, and replace the cache through one same-directory rename
- reject alternate effective `:tangle` destinations and tangle only Emacs Lisp
- keep reload deterministic as one explicit build plus one direct `load-file`
- preserve project bootstrap ordering from PR #10
- keep noninteractive/startup rebuilds quiet unless they fail
- add Ubuntu and native-Windows regression coverage

## Verification

TDD was established red-first: the initial loader regression gate failed because `p3-config-loader.el` did not yet exist. Implementation then proceeded through targeted regressions and bounded debugging.

Exact final head: `d168e2a2e328490ff1eb88a43b8eb0f135d5146b`

- Ubuntu / Emacs 29: loader and extracted modules byte-compile with warnings as errors; full 97-test ERT suite passes.
- Native Windows / Emacs 30.1: loader byte-compilation passes; existing 14 platform/project tests pass; full config-loader ERT suite passes.
- The real `config.org` is exercised through the production cache-build contract and tangles to readable Emacs Lisp.

## Review

The implementation received an adversarial pass after the main test suite was green. The only remaining spec miss found was Babel success chatter during noninteractive rebuilds; that was corrected and both exact-head platform gates were rerun successfully.

## Deliberate non-goals

This PR does not track `config.el`, reorganize `config.org`, redesign package bootstrap, change project semantics, alter completion/ESS/Python/Org/terminal/window behavior, add background rebuilding, or introduce a new CI workflow.

Do not merge without explicit approval.