### PR TITLE
Extract ESS configuration into focused module

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -37,6 +37,7 @@ jobs:
             lisp/p3-config-base.el \
             lisp/p3-config-editing.el \
             lisp/p3-config-completion.el \
+            lisp/p3-config-ess.el \
             lisp/p3-config-workspace.el \
             lisp/p3-config-git.el \
             lisp/p3-python.el \
@@ -51,6 +52,7 @@ jobs:
             -L lisp \
             -l test/p3-config-loader-test.el \
             -l test/p3-config-test.el \
+            -l test/p3-config-ess-test.el \
             -l test/p3-project-test.el \
             -l test/p3-core-test.el \
             -l test/p3-platform-test.el \

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           emacs -Q --batch \
             -L lisp \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
             --eval '(setq byte-compile-error-on-warn t)' \
             -f batch-byte-compile \
             lisp/p3-platform.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -12,13 +12,19 @@ on:
       - "lisp/p3-config-base.el"
       - "lisp/p3-config-editing.el"
       - "lisp/p3-config-completion.el"
+      - "lisp/p3-config-ess.el"
       - "lisp/p3-config-workspace.el"
       - "lisp/p3-config-git.el"
+      - "lisp/p3-ess.el"
+      - "lisp/p3-r-tools.el"
       - "test/p3-platform-test.el"
       - "test/p3-project-test.el"
       - "test/p3-project-windows-test.el"
       - "test/p3-config-loader-test.el"
       - "test/p3-config-test.el"
+      - "test/p3-config-ess-test.el"
+      - "test/p3-ess-test.el"
+      - "test/p3-r-tools-test.el"
       - "test/p3-commands-test.el"
       - "test/p3-git-test.el"
       - ".github/workflows/windows-platform-tests.yml"
@@ -78,6 +84,7 @@ jobs:
           emacs -Q --batch -L lisp
           -l test/p3-config-loader-test.el
           -l test/p3-config-test.el
+          -l test/p3-config-ess-test.el
           -l test/p3-commands-test.el
           -l test/p3-git-test.el
           -f ert-run-tests-batch-and-exit

--- a/config.org
+++ b/config.org
@@ -74,18 +74,6 @@ literate file responsible for loading the module and exposing its bindings.
            ("C-c r" . p3/config-reload)))
 #+END_SRC
 
-Load the personal R workflow module. Its project templates live under
-=templates/r/=, its insertion snippets under =snippets/=, and =C-c R= opens
-the complete R command prefix.
-
-#+BEGIN_SRC emacs-lisp
-  (use-package p3-r-tools
-    :ensure nil
-    :demand t
-    :config
-    (keymap-global-set "C-c R" p3-r-command-map))
-#+END_SRC
-
 * Modes
 ** Bibtex & citation-related
 
@@ -208,97 +196,20 @@ Special compile command for C++
 
 ** ESS
 
-ESS runtime/process behavior lives in =lisp/p3-ess.el=. It uses the shared
-=p3-core= project-root abstraction so ESS, Python, R helpers, and terminal
-sessions agree about project identity. Project scaffolding, templates, Targets
-commands, data-frame viewing, and script archiving remain in =p3-r-tools=.
+ESS package wiring, R-mode hooks, keybindings, buffer defaults, and ESS-specific
+Company configuration live in =lisp/p3-config-ess.el=. Project-aware ESS
+process/session behavior remains in =lisp/p3-ess.el=, while project templates
+and user-facing R workflow commands remain in =lisp/p3-r-tools.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (use-package p3-ess
-    :ensure nil
-    :after p3-core
-    :demand t
-    :config
-    (p3/ess-setup))
-
-  (use-package ess-r-mode
-    :ensure ess
-    :hook ((inferior-ess-mode . p3/ess-inferior-mode-setup)
-           (ess-r-post-run . p3-r-load-view-data-frame)
-           (ess-r-mode . p3/ess-company-config)
-           (ess-r-mode . p3/use-project-root-as-default-dir)
-           ;; Treat "_" as part of a word when navigating across words
-           (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))
-    :bind (:map ess-mode-map
-                ;; Re-map ess "run" to S-RET because of CUA mode
-                ("C-<return>" . nil)
-                ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
-                ;; Pipe operator
-                ("C-." . p3-r-insert-pipe)
-                ;; Run library/source commands at the top of the script
-                ("C-c i" . p3-r-evaluate-library-section)
-                ;; View data.frame in DT::datatable at a point
-                ("C-c v" . p3-r-view-data-frame-at-point)
-                ("C-c m" . p3-r-targets-make)
-                ("C-c d" . p3-r-targets-make-debug)
-                ("C-c l" . p3-r-targets-load-at-point)
-           :map inferior-ess-r-mode-map
-                ("C-c v" . p3-r-view-data-frame-at-point)
-                ("C-c m" . p3-r-targets-make)
-                ("C-c d" . p3-r-targets-make-debug)
-                ("C-c l" . p3-r-targets-load-at-point))
-    ;; :hook
-    ;; (ess-r-mode . (lambda () (yas-minor-mode)))
-    :config
-    ;; Start R in current working directory, don't let R ask user
-    (setq ess-ask-for-ess-directory nil
-          ;; Set indent at Google-standard 2-spaces.
-          ess-style 'RStudio
-          ;; Echo highlighted code in R buffer
-          ess-eval-visibly t;;'nowait
-          ;; Remove underscore funny-business
-          ess-toggle-underscore nil
-          ;; Turn off ess-flymake
-          ess-use-flymake nil
-          ;; Flycheck defaults
-          flycheck-lintr-linters "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"
-          ;; Attempt to prevent process timeout hang
-          ess--command-default-timeout 1
-          ;; Prevent workspace save prompt
-          inferior-R-args "--no-save"
-          ;; ess-can-eval-in-background nil
-          ;; Font lock all ESS keywords
-          ess-R-font-lock-keywords
-          (quote
-           ((ess-R-fl-keyword:modifiers . t)
-            (ess-R-fl-keyword:fun-defs . t)
-            (ess-R-fl-keyword:keywords . t)
-            (ess-R-fl-keyword:assign-ops)
-            (ess-R-fl-keyword:constants . t)
-            (ess-fl-keyword:fun-calls . t)
-            (ess-fl-keyword:numbers . t)
-            (ess-fl-keyword:operators . t)
-            (ess-fl-keyword:delimiters . t)
-            (ess-fl-keyword:= . t)
-            (ess-R-fl-keyword:F&T . t)
-            (ess-R-fl-keyword:%op% . t)))
-          ;; Prepend directory name to R process name
-          ess-gen-proc-buffer-name-function 'ess-gen-proc-buffer-name:project-or-directory))
+  (p3/config-load-module 'p3-config-ess)
 #+END_SRC
 
-On Windows, select the R executable here, matching the startup point used by
-the previous inline configuration.
+On Windows, select the R executable here, preserving the existing subsystem
+startup boundary.
 
 #+BEGIN_SRC emacs-lisp
   (p3/windows-configure-r-program)
-#+END_SRC
-
-#+BEGIN_SRC emacs-lisp
-  (defun compile-rmd ()
-    (set (make-local-variable 'compile-command)
-         (concat "R -e \"rmarkdown::render('" buffer-file-name "')\"")))
-  (add-hook 'ess-mode-hook 'compile-rmd)
-  (add-hook 'markdown-mode-hook 'compile-rmd)
 #+END_SRC
 
 ** GnuPG

--- a/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
+++ b/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Move declarative ESS/R-mode configuration into `p3-config-ess.el` while preserving all current ESS/R behavior and leaving `p3-ess.el` focused on project/session/process ownership.
+**Goal:** Move declarative ESS/R-mode configuration into `p3-config-ess.el` while preserving the current R/ESS workflow and leaving `p3-ess.el` focused on project/session/process ownership.
 
-**Architecture:** `config.org` will exact-source load one new configuration owner, `p3-config-ess.el`. That module will exact-source load `p3-ess.el` and `p3-r-tools.el`, explicitly invoke `p3/ess-setup`, own ESS package wiring and ESS-specific Company configuration, and leave Windows R executable selection in `config.org` immediately afterward. Existing process/session code and R workflow commands remain behaviorally unchanged.
+**Architecture:** `config.org` exact-source loads one new configuration owner, `p3-config-ess.el`. That module exact-source loads `p3-ess.el` and `p3-r-tools.el`, explicitly invokes `p3/ess-setup`, owns ESS package wiring and ESS-specific Company configuration, and leaves Windows R executable selection in `config.org` immediately afterward. Existing process/session code and R workflow commands remain behaviorally unchanged.
 
 **Tech Stack:** Emacs Lisp, Emacs 29+, Org Babel config cache, `use-package`, ESS, Company, ERT, GitHub Actions on Ubuntu and Windows.
 
@@ -12,15 +12,15 @@
 
 ## Global Constraints
 
-- Preserve the user's current R/ESS workflow; this is an extraction/refactoring PR, not a redesign.
-- Do not fix the existing `company-dabbrev` compatibility error in this PR.
+- Preserve current ESS/R behavior; this is an extraction/refactoring PR.
+- Do not fix the existing `company-dabbrev` compatibility error.
 - Do not change Company backend composition, ESS process/session semantics, R startup arguments, Lintr/Flycheck policy, ESS font-lock, project identity, R workflow commands, window placement, keybindings, package management, Python, Org, terminal, or Projectile behavior.
-- Keep `p3/windows-configure-r-program` in `config.org` immediately after the ESS configuration module load.
-- Keep the existing narrow `inferior-ess-r-mode` display rule unchanged in `p3-config-workspace.el`.
-- Use the existing exact-source local module loader; add no registry, discovery, or generalized reload mechanism.
-- Move `p3/ess-inferior-mode-setup` to the configuration module; `p3-ess.el` must retain process/session ownership only.
+- Keep `p3/windows-configure-r-program` in `config.org` immediately after the ESS module load.
+- Keep the narrow `inferior-ess-r-mode` display rule unchanged in `p3-config-workspace.el`.
+- Use the existing exact-source module loader; add no registry, discovery, or generalized reload mechanism.
+- Move `p3/ess-inferior-mode-setup` into `p3-config-ess.el`; `p3-ess.el` retains process/session ownership only.
 - `p3-config-ess.el` must explicitly call `p3/ess-setup` after exact-source loading `p3-ess.el`.
-- Preserve the exact ESS Company backend value:
+- Preserve this exact Company backend value:
 
 ```elisp
 '((:separate
@@ -31,20 +31,20 @@
 ```
 
 - Generated `config.el` and `.elc` files remain ignored and untracked.
-- Do not use repeated CI pushes as a diagnostic loop; batch compiler/declaration fixes and use one final Ubuntu/Windows gate after local/static verification.
+- Use one final Ubuntu/Windows CI cycle after local/static verification rather than iterative CI diagnostics.
 
 ---
 
 ## File Map
 
-- Create `lisp/p3-config-ess.el`: declarative ESS/R configuration owner.
-- Create `test/p3-config-ess-test.el`: semantic source tests for the new module without loading optional third-party packages.
-- Modify `lisp/p3-ess.el`: remove only inferior-buffer configuration helper/declarations; retain project/process behavior.
-- Modify `lisp/p3-config-completion.el`: remove only ESS-specific Company backend data and hook function.
-- Modify `config.org`: remove the early `p3-r-tools` stanza and large inline ESS block; load `p3-config-ess` instead.
-- Modify `test/p3-config-test.el`: update module ownership/order assertions and remove assumptions that ESS is inline.
-- Modify `.github/workflows/emacs-tests.yml`: byte-compile `p3-config-ess.el` and run `p3-config-ess-test.el`.
-- Modify `.github/workflows/windows-platform-tests.yml`: trigger on the new module/test and run the source-level ESS boundary test on Windows.
+- Create `lisp/p3-config-ess.el` — declarative ESS/R configuration owner.
+- Create `test/p3-config-ess-test.el` — semantic source tests that do not require optional third-party packages at runtime.
+- Modify `lisp/p3-ess.el` — remove inferior-buffer configuration only.
+- Modify `lisp/p3-config-completion.el` — remove ESS-specific Company ownership only.
+- Modify `config.org` — remove the early `p3-r-tools` stanza and inline ESS implementation; load `p3-config-ess` instead.
+- Modify `test/p3-config-test.el` — update ownership/order assertions.
+- Modify `.github/workflows/emacs-tests.yml` — compile/test the new module.
+- Modify `.github/workflows/windows-platform-tests.yml` — trigger on ESS boundary files and run source-level ESS boundary tests.
 
 ---
 
@@ -55,18 +55,18 @@
 - Create: `lisp/p3-config-ess.el`
 
 **Interfaces:**
-- Consumes: `p3/config-load-module` from `p3-config-loader.el`, `p3/ess-setup` from `p3-ess.el`, `p3-r-command-map` and R workflow commands from `p3-r-tools.el`.
-- Produces: feature `p3-config-ess`; functions `p3/ess-inferior-mode-setup`, `p3/ess-company-config`, and `compile-rmd`; variable `p3/r-company-backends`.
+- Consumes: `p3/config-load-module`, `p3/ess-setup`, `p3-r-command-map`, existing `p3-r-*` commands.
+- Produces: feature `p3-config-ess`; functions `p3/ess-inferior-mode-setup`, `p3/ess-company-config`, `compile-rmd`; variable `p3/r-company-backends`.
 
-- [ ] **Step 1: Create source-parsing test helpers and failing semantic tests**
+- [ ] **Step 1: Write failing semantic source tests**
 
-Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tracked source instead of loading optional ESS/Company packages:
+Create `test/p3-config-ess-test.el`:
 
 ```elisp
-;;; p3-config-ess-test.el --- Tests for ESS configuration ownership -*- lexical-binding: t; -*-
+;;; p3-config-ess-test.el --- ESS configuration boundary tests -*- lexical-binding: t; -*-
 
 (require 'ert)
-(require 'cl-lib)
+(require 'seq)
 
 (defconst p3-config-ess-test--root
   (file-name-directory
@@ -77,14 +77,18 @@ Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tra
 (defun p3-config-ess-test--path (relative)
   (expand-file-name relative p3-config-ess-test--root))
 
+(defun p3-config-ess-test--contents (relative)
+  (with-temp-buffer
+    (insert-file-contents (p3-config-ess-test--path relative))
+    (buffer-string)))
+
 (defun p3-config-ess-test--forms (relative)
   (with-temp-buffer
     (insert-file-contents (p3-config-ess-test--path relative))
     (goto-char (point-min))
     (let (forms)
       (condition-case nil
-          (while t
-            (push (read (current-buffer)) forms))
+          (while t (push (read (current-buffer)) forms))
         (end-of-file nil))
       (nreverse forms))))
 
@@ -103,19 +107,21 @@ Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tra
   (p3-config-ess-test--find-top-level
    "lisp/p3-config-ess.el"
    (lambda (form)
-     (and (consp form)
-          (eq (car form) 'defvar)
-          (eq (cadr form) symbol)))))
+     (and (consp form) (eq (car form) 'defvar) (eq (cadr form) symbol)))))
 
 (defun p3-config-ess-test--defun-form (symbol)
   (p3-config-ess-test--find-top-level
    "lisp/p3-config-ess.el"
    (lambda (form)
-     (and (consp form)
-          (eq (car form) 'defun)
-          (eq (cadr form) symbol)))))
+     (and (consp form) (eq (car form) 'defun) (eq (cadr form) symbol)))))
 
-(ert-deftest p3-config-ess-loads-behavior-and-r-tools-explicitly ()
+(defun p3-config-ess-test--setq-pairs ()
+  (let* ((form (p3-config-ess-test--use-package-form))
+         (setq-form (plist-get (cddr form) :config)))
+    (should (eq (car-safe setq-form) 'setq))
+    (seq-partition (cdr setq-form) 2)))
+
+(ert-deftest p3-config-ess-load-order-is-explicit ()
   (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
     (should (member '(require 'p3-config-loader) forms))
     (should (member '(p3/config-load-module 'p3-ess) forms))
@@ -124,37 +130,32 @@ Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tra
     (should (member '(keymap-global-set "C-c R" p3-r-command-map) forms))))
 
 (ert-deftest p3-config-ess-preserves-company-backends-exactly ()
-  (let ((form (p3-config-ess-test--defvar-form 'p3/r-company-backends)))
-    (should form)
-    (should
-     (equal
-      (nth 2 form)
-      '(quote
-        ((:separate
-          company-R-library company-R-args company-R-objects
-          company-dabbrev-code
-          :with company-yasnippet)
-         company-capf))))))
+  (should
+   (equal
+    (nth 2 (p3-config-ess-test--defvar-form 'p3/r-company-backends))
+    '(quote
+      ((:separate
+        company-R-library company-R-args company-R-objects
+        company-dabbrev-code
+        :with company-yasnippet)
+       company-capf)))))
 
 (ert-deftest p3-config-ess-preserves-company-buffer-hook ()
-  (let ((form (p3-config-ess-test--defun-form 'p3/ess-company-config)))
-    (should form)
-    (should
-     (equal (cdddr form)
-            '((setq-local company-backends p3/r-company-backends))))))
+  (should
+   (equal
+    (cddddr (p3-config-ess-test--defun-form 'p3/ess-company-config))
+    '((setq-local company-backends p3/r-company-backends)))))
 
 (ert-deftest p3-config-ess-preserves-inferior-buffer-setup ()
-  (let ((form (p3-config-ess-test--defun-form 'p3/ess-inferior-mode-setup)))
-    (should form)
-    (should
-     (equal (cdddr form)
-            '((setq-local ansi-color-for-comint-mode 'filter)
-              (smartparens-mode 1))))))
+  (should
+   (equal
+    (cddddr (p3-config-ess-test--defun-form 'p3/ess-inferior-mode-setup))
+    '((setq-local ansi-color-for-comint-mode 'filter)
+      (smartparens-mode 1)))))
 
-(ert-deftest p3-config-ess-preserves-ess-hooks-and-bindings ()
+(ert-deftest p3-config-ess-preserves-hooks-and-bindings ()
   (let* ((form (p3-config-ess-test--use-package-form))
          (args (cddr form)))
-    (should form)
     (should
      (equal
       (plist-get args :hook)
@@ -182,70 +183,62 @@ Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tra
         ("C-c l" . p3-r-targets-load-at-point))))))
 
 (ert-deftest p3-config-ess-preserves-sensitive-settings ()
-  (let ((contents
-         (with-temp-buffer
-           (insert-file-contents
-            (p3-config-ess-test--path "lisp/p3-config-ess.el"))
-           (buffer-string))))
-    (dolist (setting
-             '("ess-ask-for-ess-directory nil"
-               "ess-style 'RStudio"
-               "ess-eval-visibly t"
-               "ess-toggle-underscore nil"
-               "ess-use-flymake nil"
-               "ess--command-default-timeout 1"
-               "inferior-R-args \"--no-save\""
-               "ess-gen-proc-buffer-name-function 'ess-gen-proc-buffer-name:project-or-directory"
-               "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"))
-      (should (string-match-p (regexp-quote setting) contents)))
-    (dolist (font-lock
-             '("ess-R-fl-keyword:modifiers"
-               "ess-R-fl-keyword:fun-defs"
-               "ess-R-fl-keyword:keywords"
-               "ess-R-fl-keyword:assign-ops"
-               "ess-R-fl-keyword:constants"
-               "ess-fl-keyword:fun-calls"
-               "ess-fl-keyword:numbers"
-               "ess-fl-keyword:operators"
-               "ess-fl-keyword:delimiters"
-               "ess-fl-keyword:="
-               "ess-R-fl-keyword:F&T"
-               "ess-R-fl-keyword:%op%"))
-      (should (string-match-p (regexp-quote font-lock) contents)))))
+  (let ((pairs (p3-config-ess-test--setq-pairs)))
+    (dolist (pair
+             '((ess-ask-for-ess-directory nil)
+               (ess-style 'RStudio)
+               (ess-eval-visibly t)
+               (ess-toggle-underscore nil)
+               (ess-use-flymake nil)
+               (ess--command-default-timeout 1)
+               (inferior-R-args "--no-save")
+               (ess-gen-proc-buffer-name-function
+                'ess-gen-proc-buffer-name:project-or-directory)))
+      (should (member pair pairs)))
+    (should
+     (member
+      '(flycheck-lintr-linters
+        "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)")
+      pairs))
+    (should
+     (member
+      '(ess-R-font-lock-keywords
+        '((ess-R-fl-keyword:modifiers . t)
+          (ess-R-fl-keyword:fun-defs . t)
+          (ess-R-fl-keyword:keywords . t)
+          (ess-R-fl-keyword:assign-ops)
+          (ess-R-fl-keyword:constants . t)
+          (ess-fl-keyword:fun-calls . t)
+          (ess-fl-keyword:numbers . t)
+          (ess-fl-keyword:operators . t)
+          (ess-fl-keyword:delimiters . t)
+          (ess-fl-keyword:= . t)
+          (ess-R-fl-keyword:F&T . t)
+          (ess-R-fl-keyword:%op% . t)))
+      pairs))))
 
 (ert-deftest p3-config-ess-preserves-rmarkdown-compile-hook ()
-  (let ((contents
-         (with-temp-buffer
-           (insert-file-contents
-            (p3-config-ess-test--path "lisp/p3-config-ess.el"))
-           (buffer-string))))
-    (should (string-match-p "(defun compile-rmd ()" contents))
-    (should
-     (string-match-p
-      (regexp-quote "R -e \"rmarkdown::render('") contents))
+  (let ((contents (p3-config-ess-test--contents "lisp/p3-config-ess.el")))
+    (should (string-match-p (regexp-quote "(defun compile-rmd ()") contents))
+    (should (string-match-p
+             (regexp-quote "R -e \"rmarkdown::render('") contents))
     (should (string-match-p
              (regexp-quote "(add-hook 'ess-mode-hook 'compile-rmd)") contents))
     (should (string-match-p
              (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
 
 (provide 'p3-config-ess-test)
-
-;;; p3-config-ess-test.el ends here
 ```
 
-- [ ] **Step 2: Run the new test file and verify it fails because the module is missing**
-
-Run:
+- [ ] **Step 2: Verify RED**
 
 ```bash
 emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL with a file-missing error for `lisp/p3-config-ess.el`.
+Expected: failure because `lisp/p3-config-ess.el` does not yet exist.
 
-- [ ] **Step 3: Create `p3-config-ess.el` with the existing ESS configuration moved verbatim**
-
-Create `lisp/p3-config-ess.el` with this structure and existing values:
+- [ ] **Step 3: Create `lisp/p3-config-ess.el` with the current ESS configuration values**
 
 ```elisp
 ;;; p3-config-ess.el --- ESS and R-mode configuration -*- lexical-binding: t; -*-
@@ -348,34 +341,21 @@ Create `lisp/p3-config-ess.el` with this structure and existing values:
 (add-hook 'markdown-mode-hook 'compile-rmd)
 
 (provide 'p3-config-ess)
-
-;;; p3-config-ess.el ends here
 ```
 
-Do not remove the old definitions yet in this task; the new module is not loaded by `config.org` yet, so this commit is behavior-neutral.
+The old definitions remain in their current owners until Task 2; this module is not yet loaded by `config.org`.
 
-- [ ] **Step 4: Run the source-semantic tests**
-
-Run:
+- [ ] **Step 4: Verify GREEN and compile closure**
 
 ```bash
 emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
-```
-
-Expected: all `p3-config-ess-*` tests PASS.
-
-- [ ] **Step 5: Byte-compile the new module once locally if Emacs is available**
-
-Run:
-
-```bash
 emacs -Q --batch -L lisp --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/p3-config-ess.el
 rm -f lisp/p3-config-ess.elc
 ```
 
-Expected: zero compiler warnings/errors. If a warning names an external variable/function already present in the moved configuration, add only the minimal `defvar`/`declare-function` declaration needed to satisfy the compiler; do not alter runtime behavior.
+Expected: all new tests pass and byte compilation has zero warnings/errors. Add only compiler declarations required for external ESS/Company symbols; do not change behavior.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
 git add lisp/p3-config-ess.el test/p3-config-ess-test.el
@@ -384,40 +364,32 @@ git commit -m "Add ESS configuration module"
 
 ---
 
-### Task 2: Remove ESS configuration from the old behavior/completion owners
+### Task 2: Remove configuration from old owners
 
 **Files:**
 - Modify: `lisp/p3-ess.el`
 - Modify: `lisp/p3-config-completion.el`
 - Modify: `test/p3-config-ess-test.el`
-- Test: `test/p3-ess-test.el`
 
 **Interfaces:**
-- Consumes: `p3-config-ess.el` from Task 1.
-- Produces: `p3-ess.el` with process/session-only responsibility; `p3-config-completion.el` with generic completion-only responsibility.
+- Consumes: new owner from Task 1.
+- Produces: process/session-only `p3-ess.el`; generic-only `p3-config-completion.el`.
 
-- [ ] **Step 1: Add failing ownership assertions**
+- [ ] **Step 1: Add failing ownership tests**
 
-Append to `test/p3-config-ess-test.el`:
+Append:
 
 ```elisp
 (ert-deftest p3-ess-library-has-no-buffer-configuration-glue ()
-  (let ((contents
-         (with-temp-buffer
-           (insert-file-contents
-            (p3-config-ess-test--path "lisp/p3-ess.el"))
-           (buffer-string))))
+  (let ((contents (p3-config-ess-test--contents "lisp/p3-ess.el")))
     (dolist (forbidden '("p3/ess-inferior-mode-setup"
                          "ansi-color-for-comint-mode"
                          "smartparens-mode"))
       (should-not (string-match-p (regexp-quote forbidden) contents)))))
 
 (ert-deftest p3-generic-completion-has-no-ess-company-owner ()
-  (let ((contents
-         (with-temp-buffer
-           (insert-file-contents
-            (p3-config-ess-test--path "lisp/p3-config-completion.el"))
-           (buffer-string))))
+  (let ((contents (p3-config-ess-test--contents
+                   "lisp/p3-config-completion.el")))
     (dolist (forbidden '("p3/r-company-backends"
                          "p3/ess-company-config"
                          "company-R-library"
@@ -426,20 +398,17 @@ Append to `test/p3-config-ess-test.el`:
       (should-not (string-match-p (regexp-quote forbidden) contents)))))
 ```
 
-- [ ] **Step 2: Run the two new tests and verify they fail on the old owners**
-
-Run:
+- [ ] **Step 2: Verify RED**
 
 ```bash
-emacs -Q --batch -L lisp -l test/p3-config-ess-test.el \
-  --eval "(ert-run-tests-batch-and-exit \"p3-\\(?:ess-library\\|generic-completion\\)\")"
+emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: both tests FAIL because the moved definitions still exist in their old files.
+Expected: the two ownership tests fail on the current old owners.
 
-- [ ] **Step 3: Remove only inferior-buffer configuration from `p3-ess.el`**
+- [ ] **Step 3: Remove only buffer configuration from `p3-ess.el`**
 
-Delete from `lisp/p3-ess.el`:
+Delete:
 
 ```elisp
 (declare-function smartparens-mode "smartparens" (&optional arg))
@@ -451,24 +420,17 @@ Delete from `lisp/p3-ess.el`:
   (smartparens-mode 1))
 ```
 
-Keep every project/process function, `p3/ess-install-process-advice`, and `p3/ess-setup` unchanged.
+Do not alter `p3/ess-project-root`, process registration, lazy R creation, advice installation, or `p3/ess-setup`.
 
-- [ ] **Step 4: Remove only ESS-specific Company state from `p3-config-completion.el`**
+- [ ] **Step 4: Remove only ESS-specific Company ownership from completion**
 
-Delete the top-level compiler declaration if it is no longer used:
+Remove the now-unused top-level declaration:
 
 ```elisp
 (defvar company-backends)
 ```
 
-Within `(use-package company ...)`, remove the current `:init` block containing:
-
-```elisp
-(defvar p3/r-company-backends ...)
-(defun p3/ess-company-config () ...)
-```
-
-Leave the package declaration behavior as:
+Replace the Company declaration with:
 
 ```elisp
 (use-package company
@@ -477,11 +439,7 @@ Leave the package declaration behavior as:
   (setq company-dabbrev-downcase nil))
 ```
 
-Do not change any Company backend function or replace Company.
-
-- [ ] **Step 5: Run the ownership and existing ESS behavior tests**
-
-Run:
+- [ ] **Step 5: Verify GREEN plus existing ESS behavior**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -490,7 +448,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all tests PASS. Existing `p3-ess-*` process/session tests remain unchanged.
+Expected: all tests pass; existing process/session tests are unchanged.
 
 - [ ] **Step 6: Commit**
 
@@ -501,32 +459,34 @@ git commit -m "Separate ESS behavior from configuration"
 
 ---
 
-### Task 3: Replace inline ESS configuration with explicit orchestration
+### Task 3: Replace inline ESS configuration with module orchestration
 
 **Files:**
 - Modify: `config.org`
 - Modify: `test/p3-config-test.el`
-- Test: `test/p3-config-ess-test.el`
-- Test: `test/p3-r-tools-test.el`
 
 **Interfaces:**
-- Consumes: feature `p3-config-ess` from Task 1.
-- Produces: one authoritative ESS module load in `config.org`; Windows R selection remains immediately afterward.
+- Consumes: `p3-config-ess` from Task 1.
+- Produces: one ESS module load in `config.org`; Windows R selection stays immediately after it.
 
-- [ ] **Step 1: Update configuration tests first**
+- [ ] **Step 1: Update tests before changing `config.org`**
 
-In `test/p3-config-test.el` make these exact expectation changes:
-
-1. In `p3-config-org-delegates-custom-subsystems-to-modules`, remove `"p3-ess"` from the `use-package` module list and remove `"ess-r-mode"` from the inline package list. Add an assertion for the exact module loader:
+In `p3-config-org-delegates-custom-subsystems-to-modules`, use:
 
 ```elisp
+(dolist (module '("p3-platform" "p3-core" "p3-python" "p3-terminal"
+                  "p3-gptel"))
+  (should (string-match-p (regexp-quote (format "(use-package %s" module))
+                          contents)))
+(dolist (package '("python" "eglot" "vterm" "gptel"))
+  (should (string-match-p (regexp-quote (format "(use-package %s" package))
+                          contents)))
 (should
  (string-match-p
-  (regexp-quote "(p3/config-load-module 'p3-config-ess)")
-  contents))
+  (regexp-quote "(p3/config-load-module 'p3-config-ess)") contents))
 ```
 
-2. In `p3-config-early-orchestration-order-is-explicit`, add:
+In `p3-config-early-orchestration-order-is-explicit`, bind:
 
 ```elisp
 (ess (p3-config-test--position
@@ -540,21 +500,24 @@ and assert:
 (should (< ess r-program))
 ```
 
-3. In `p3-config-platform-setup-preserves-subsystem-timing`, replace the ESS position needle:
+In `p3-config-platform-setup-preserves-subsystem-timing`, replace the old ESS needle with:
 
 ```elisp
 (p3-config-test--position "(p3/config-load-module 'p3-config-ess)" contents)
 ```
 
-4. Rename `p3-config-org-source-loads-five-config-modules` to `p3-config-org-source-loads-six-config-modules` and use:
+Rename `p3-config-org-source-loads-five-config-modules` to `p3-config-org-source-loads-six-config-modules` and use:
 
 ```elisp
 (dolist (module '(p3-config-base p3-config-editing p3-config-completion
                   p3-config-ess p3-config-workspace p3-config-git))
-  ...)
+  (should
+   (string-match-p
+    (regexp-quote (format "(p3/config-load-module '%s)" module))
+    contents)))
 ```
 
-5. Add to `p3-config-moved-implementation-is-not-inline`:
+Add these forbidden inline forms to `p3-config-moved-implementation-is-not-inline`:
 
 ```elisp
 "(use-package p3-r-tools"
@@ -563,7 +526,7 @@ and assert:
 "(defun compile-rmd"
 ```
 
-6. Add a focused test that the old executable R-tools owner is gone and Windows ordering remains explicit:
+Add:
 
 ```elisp
 (ert-deftest p3-config-ess-orchestration-has-one-owner ()
@@ -573,32 +536,23 @@ and assert:
          (r-program (p3-config-test--position
                      "(p3/windows-configure-r-program)" contents)))
     (should-not (string-match-p "(use-package p3-r-tools" contents))
-    (should-not (string-match-p
-                 (regexp-quote "(keymap-global-set \"C-c R\"") contents))
-    (should (= 1
-               (let ((start 0) (count 0))
-                 (while (string-match
-                         (regexp-quote "(p3/config-load-module 'p3-config-ess)")
-                         contents start)
-                   (setq count (1+ count)
-                         start (match-end 0)))
-                 count)))
+    (should-not
+     (string-match-p
+      (regexp-quote "(keymap-global-set \"C-c R\"") contents))
     (should (< ess r-program))))
 ```
 
-- [ ] **Step 2: Run targeted config tests and verify they fail against the current inline config**
-
-Run:
+- [ ] **Step 2: Verify RED**
 
 ```bash
 emacs -Q --batch -L lisp -l test/p3-config-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL on missing `p3-config-ess` orchestration and stale inline ESS/R-tools expectations.
+Expected: failures because ESS is still inline and `p3-config-ess` is not yet loaded by `config.org`.
 
-- [ ] **Step 3: Remove the earlier `p3-r-tools` stanza from `config.org`**
+- [ ] **Step 3: Remove the early R-tools configuration stanza**
 
-Delete the prose and source block under `* Functions` that currently load `p3-r-tools` and bind `C-c R`:
+Delete from `* Functions`:
 
 ```elisp
 (use-package p3-r-tools
@@ -608,11 +562,11 @@ Delete the prose and source block under `* Functions` that currently load `p3-r-
   (keymap-global-set "C-c R" p3-r-command-map))
 ```
 
-Leave `p3-core` and its `C-c e` / `C-c r` bindings untouched.
+Leave `p3-core` unchanged.
 
-- [ ] **Step 4: Replace the entire inline ESS block with the new module loader**
+- [ ] **Step 4: Replace the inline ESS implementation**
 
-Replace the current `use-package p3-ess`, `use-package ess-r-mode`, and later `compile-rmd` block with:
+Replace the current `use-package p3-ess`, `use-package ess-r-mode`, and `compile-rmd` blocks with:
 
 ```org
 ** ESS
@@ -634,21 +588,15 @@ startup boundary.
 #+END_SRC
 ```
 
-Do not move `p3/windows-configure-r-program` into the module.
-
-- [ ] **Step 5: Verify no executable R-tools dependency remains before the ESS module load**
-
-Run:
+- [ ] **Step 5: Verify there is no earlier executable R-tools dependency**
 
 ```bash
 git grep -n "p3-r-\|p3-r-command-map\|p3-r-tools" -- config.org
 ```
 
-Expected: any remaining matches before the ESS section are prose/comments only; no earlier Lisp source block loads `p3-r-tools`, binds `p3-r-command-map`, or invokes a `p3-r-*` function.
+Expected: any match before the ESS section is prose/commentary only; no earlier Lisp source block loads `p3-r-tools`, binds `p3-r-command-map`, or invokes `p3-r-*`.
 
-- [ ] **Step 6: Run config, ESS boundary, and R workflow tests**
-
-Run:
+- [ ] **Step 6: Verify GREEN across the affected suites**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -660,7 +608,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: all loaded tests PASS; R parser test may skip if `Rscript` is unavailable.
+Expected: zero unexpected failures; the R parser test may keep its existing environment-dependent skip.
 
 - [ ] **Step 7: Commit**
 
@@ -671,19 +619,19 @@ git commit -m "Route ESS configuration through its module"
 
 ---
 
-### Task 4: Wire CI coverage for the new configuration owner
+### Task 4: Wire CI coverage
 
 **Files:**
 - Modify: `.github/workflows/emacs-tests.yml`
 - Modify: `.github/workflows/windows-platform-tests.yml`
 
 **Interfaces:**
-- Consumes: `lisp/p3-config-ess.el` and `test/p3-config-ess-test.el`.
-- Produces: Ubuntu compiler/full-suite coverage and Windows structural boundary coverage for ESS configuration.
+- Consumes: new module/test.
+- Produces: Ubuntu compiler/full-suite coverage and Windows source-boundary coverage.
 
-- [ ] **Step 1: Update Ubuntu compile and ERT lists**
+- [ ] **Step 1: Add Ubuntu compile/test entries**
 
-In `.github/workflows/emacs-tests.yml`, add `lisp/p3-config-ess.el` after the other config modules and add `test/p3-config-ess-test.el` to the ERT load list:
+Add:
 
 ```yaml
             lisp/p3-config-completion.el \
@@ -699,9 +647,9 @@ and:
             -l test/p3-project-test.el \
 ```
 
-- [ ] **Step 2: Update Windows path triggers and architecture test list**
+- [ ] **Step 2: Extend Windows path triggers and source tests**
 
-Add these paths to `.github/workflows/windows-platform-tests.yml`:
+Add triggers:
 
 ```yaml
       - "lisp/p3-config-ess.el"
@@ -712,27 +660,24 @@ Add these paths to `.github/workflows/windows-platform-tests.yml`:
       - "test/p3-r-tools-test.el"
 ```
 
-Keep Windows byte compilation limited to the existing platform boundary modules; `p3-config-ess.el` contains optional package wiring and is byte-compiled on Ubuntu. Add only the source-level ESS boundary test to the Windows config architecture command:
+Keep Windows byte compilation limited to the existing boundary modules. Add only the source-level ESS boundary test to the Windows architecture command:
 
 ```yaml
           -l test/p3-config-loader-test.el
           -l test/p3-config-test.el
           -l test/p3-config-ess-test.el
           -l test/p3-commands-test.el
+          -l test/p3-git-test.el
 ```
 
-This preserves Windows coverage for R-program ordering and source ownership without requiring ESS/Company packages to be installed on the Windows runner.
-
-- [ ] **Step 3: Run a static workflow diff check**
-
-Run:
+- [ ] **Step 3: Static-check the workflow diff**
 
 ```bash
 git diff --check
 git diff -- .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
 ```
 
-Expected: no whitespace errors; only the new module/test coverage is added.
+Expected: no whitespace errors and no unrelated workflow changes.
 
 - [ ] **Step 4: Commit**
 
@@ -746,36 +691,35 @@ git commit -m "Cover ESS configuration boundary in CI"
 ### Task 5: Final verification and adversarial review
 
 **Files:**
-- Verify all files changed by Tasks 1-4.
-- Do not change production behavior unless verification exposes a concrete regression.
+- Verify all changed files; do not expand scope.
 
 **Interfaces:**
-- Consumes: completed implementation.
-- Produces: merge-ready PR branch with evidence that the extraction preserves behavior.
+- Consumes: Tasks 1-4.
+- Produces: merge-ready branch; merge still requires explicit user approval.
 
-- [ ] **Step 1: Verify the branch diff is within scope**
-
-Run:
+- [ ] **Step 1: Check scope and whitespace**
 
 ```bash
 git diff --check master...HEAD
 git diff --stat master...HEAD
-git diff master...HEAD -- \
-  lisp/p3-config-ess.el \
-  lisp/p3-ess.el \
-  lisp/p3-config-completion.el \
-  config.org \
-  test/p3-config-ess-test.el \
-  test/p3-config-test.el \
-  .github/workflows/emacs-tests.yml \
-  .github/workflows/windows-platform-tests.yml
 ```
 
-Expected: no unrelated Python, Org, terminal, project, window-placement, package-manager, or R workflow implementation changes.
+Expected changed implementation/test files only:
 
-- [ ] **Step 2: Compare moved ESS forms against `master` for semantic equivalence**
+```text
+config.org
+lisp/p3-config-ess.el
+lisp/p3-ess.el
+lisp/p3-config-completion.el
+test/p3-config-ess-test.el
+test/p3-config-test.el
+.github/workflows/emacs-tests.yml
+.github/workflows/windows-platform-tests.yml
+```
 
-Check specifically:
+plus the approved spec/plan documents.
+
+- [ ] **Step 2: Compare moved forms with `master`**
 
 ```bash
 git show master:config.org | grep -n -A90 -B10 "use-package ess-r-mode"
@@ -788,15 +732,12 @@ git show master:lisp/p3-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
 git show HEAD:lisp/p3-config-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
 ```
 
-Expected: moved settings, hooks, keybindings, Company backend contents, `compile-rmd`, and inferior-buffer setup are semantically unchanged.
+Expected: settings, hooks, bindings, Company backend contents, `compile-rmd`, and inferior-buffer setup are semantically unchanged.
 
 - [ ] **Step 3: Run the complete local ERT gate if Emacs is available**
 
-Run the same suite as Ubuntu CI, including the new test:
-
 ```bash
-emacs -Q --batch \
-  -L lisp \
+emacs -Q --batch -L lisp \
   -l test/p3-config-loader-test.el \
   -l test/p3-config-test.el \
   -l test/p3-config-ess-test.el \
@@ -814,11 +755,9 @@ emacs -Q --batch \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: zero unexpected failures; platform/R parser tests may retain their existing environment-dependent skips.
+Expected: zero unexpected failures; existing environment-dependent skips may remain.
 
-- [ ] **Step 4: Confirm generated artifacts remain ignored and untracked**
-
-Run:
+- [ ] **Step 4: Confirm generated artifacts remain ignored/untracked**
 
 ```bash
 git check-ignore -q config.el
@@ -826,30 +765,32 @@ git check-ignore -q lisp/example.elc
 test -z "$(git ls-files 'config.el' '*.elc')"
 ```
 
-Expected: all commands succeed and no generated artifacts are tracked.
+- [ ] **Step 5: Push once and verify the final PR merge-ref CI**
 
-- [ ] **Step 5: Open/update the PR and run one final Ubuntu/Windows Actions cycle**
+Required final gates:
 
-Push the final branch once. Verify both pull-request workflows on the resulting PR merge ref:
+```text
+Ubuntu: Emacs tests — byte compilation succeeds; full ERT has zero unexpected failures.
+Windows: Windows platform tests — platform/project and config architecture tests have zero unexpected failures.
+```
 
-- Ubuntu `Emacs tests`: byte compilation succeeds, full ERT has zero unexpected failures.
-- Windows `Windows platform tests`: platform/project tests and config architecture tests have zero unexpected failures.
+If CI fails, retrieve the exact job log and fix the root cause without adding diagnostic machinery or repeated probe pushes.
 
-Do not push intermediate diagnostic commits merely to probe CI. If CI fails, pull the exact failing job log, fix the root cause locally/static-first, and rerun once.
+- [ ] **Step 6: Final rejection-oriented review**
 
-- [ ] **Step 6: Perform a final adversarial review before merge**
+Reject if any of the following is true:
 
-Reject the PR if any of these are true:
+```text
+p3-ess.el still owns Smartparens/ANSI buffer configuration.
+p3-config-completion.el still owns ESS-specific Company state.
+p3-config-ess.el does not explicitly call p3/ess-setup.
+p3-r-tools.el public behavior changed.
+Any ESS binding/setting/backend value differs from master without approval.
+Windows R selection moved or changed order.
+The narrow ESS display rule moved or broadened.
+The Company compatibility bug was mixed into this PR.
+Generated artifacts are tracked.
+CI has an unexpected failure.
+```
 
-- `p3-ess.el` still contains Smartparens/ANSI buffer configuration;
-- `p3-config-completion.el` still owns ESS-specific Company state;
-- `p3-config-ess.el` fails to call `p3/ess-setup` explicitly;
-- `p3-r-tools.el` public behavior changed;
-- any ESS keybinding/settings/backend value differs from `master` without an explicit approved reason;
-- Windows R selection moved inside the module or changed ordering;
-- the narrow ESS display rule moved or broadened;
-- the Company compatibility bug was mixed into this PR;
-- generated artifacts are tracked;
-- CI reports an unexpected failure.
-
-If none apply, report the branch as merge-ready but do not merge without explicit user approval.
+If none apply, report merge-ready; do not merge without explicit user approval.

--- a/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
+++ b/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
@@ -60,175 +60,7 @@
 
 - [ ] **Step 1: Write failing semantic source tests**
 
-Create `test/p3-config-ess-test.el`:
-
-```elisp
-;;; p3-config-ess-test.el --- ESS configuration boundary tests -*- lexical-binding: t; -*-
-
-(require 'ert)
-(require 'seq)
-
-(defconst p3-config-ess-test--root
-  (file-name-directory
-   (directory-file-name
-    (file-name-directory (or load-file-name buffer-file-name))))
-  "Root of the Emacs configuration under test.")
-
-(defun p3-config-ess-test--path (relative)
-  (expand-file-name relative p3-config-ess-test--root))
-
-(defun p3-config-ess-test--contents (relative)
-  (with-temp-buffer
-    (insert-file-contents (p3-config-ess-test--path relative))
-    (buffer-string)))
-
-(defun p3-config-ess-test--forms (relative)
-  (with-temp-buffer
-    (insert-file-contents (p3-config-ess-test--path relative))
-    (goto-char (point-min))
-    (let (forms)
-      (condition-case nil
-          (while t (push (read (current-buffer)) forms))
-        (end-of-file nil))
-      (nreverse forms))))
-
-(defun p3-config-ess-test--find-top-level (relative predicate)
-  (seq-find predicate (p3-config-ess-test--forms relative)))
-
-(defun p3-config-ess-test--use-package-form ()
-  (p3-config-ess-test--find-top-level
-   "lisp/p3-config-ess.el"
-   (lambda (form)
-     (and (consp form)
-          (eq (car form) 'use-package)
-          (eq (cadr form) 'ess-r-mode)))))
-
-(defun p3-config-ess-test--defvar-form (symbol)
-  (p3-config-ess-test--find-top-level
-   "lisp/p3-config-ess.el"
-   (lambda (form)
-     (and (consp form) (eq (car form) 'defvar) (eq (cadr form) symbol)))))
-
-(defun p3-config-ess-test--defun-form (symbol)
-  (p3-config-ess-test--find-top-level
-   "lisp/p3-config-ess.el"
-   (lambda (form)
-     (and (consp form) (eq (car form) 'defun) (eq (cadr form) symbol)))))
-
-(defun p3-config-ess-test--setq-pairs ()
-  (let* ((form (p3-config-ess-test--use-package-form))
-         (setq-form (plist-get (cddr form) :config)))
-    (should (eq (car-safe setq-form) 'setq))
-    (seq-partition (cdr setq-form) 2)))
-
-(ert-deftest p3-config-ess-load-order-is-explicit ()
-  (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
-    (should (member '(require 'p3-config-loader) forms))
-    (should (member '(p3/config-load-module 'p3-ess) forms))
-    (should (member '(p3/ess-setup) forms))
-    (should (member '(p3/config-load-module 'p3-r-tools) forms))
-    (should (member '(keymap-global-set "C-c R" p3-r-command-map) forms))))
-
-(ert-deftest p3-config-ess-preserves-company-backends-exactly ()
-  (should
-   (equal
-    (nth 2 (p3-config-ess-test--defvar-form 'p3/r-company-backends))
-    '(quote
-      ((:separate
-        company-R-library company-R-args company-R-objects
-        company-dabbrev-code
-        :with company-yasnippet)
-       company-capf)))))
-
-(ert-deftest p3-config-ess-preserves-company-buffer-hook ()
-  (should
-   (equal
-    (cddddr (p3-config-ess-test--defun-form 'p3/ess-company-config))
-    '((setq-local company-backends p3/r-company-backends)))))
-
-(ert-deftest p3-config-ess-preserves-inferior-buffer-setup ()
-  (should
-   (equal
-    (cddddr (p3-config-ess-test--defun-form 'p3/ess-inferior-mode-setup))
-    '((setq-local ansi-color-for-comint-mode 'filter)
-      (smartparens-mode 1)))))
-
-(ert-deftest p3-config-ess-preserves-hooks-and-bindings ()
-  (let* ((form (p3-config-ess-test--use-package-form))
-         (args (cddr form)))
-    (should
-     (equal
-      (plist-get args :hook)
-      '((inferior-ess-mode . p3/ess-inferior-mode-setup)
-        (ess-r-post-run . p3-r-load-view-data-frame)
-        (ess-r-mode . p3/ess-company-config)
-        (ess-r-mode . p3/use-project-root-as-default-dir)
-        (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))))
-    (should
-     (equal
-      (plist-get args :bind)
-      '(:map ess-mode-map
-        ("C-<return>" . nil)
-        ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
-        ("C-." . p3-r-insert-pipe)
-        ("C-c i" . p3-r-evaluate-library-section)
-        ("C-c v" . p3-r-view-data-frame-at-point)
-        ("C-c m" . p3-r-targets-make)
-        ("C-c d" . p3-r-targets-make-debug)
-        ("C-c l" . p3-r-targets-load-at-point)
-        :map inferior-ess-r-mode-map
-        ("C-c v" . p3-r-view-data-frame-at-point)
-        ("C-c m" . p3-r-targets-make)
-        ("C-c d" . p3-r-targets-make-debug)
-        ("C-c l" . p3-r-targets-load-at-point))))))
-
-(ert-deftest p3-config-ess-preserves-sensitive-settings ()
-  (let ((pairs (p3-config-ess-test--setq-pairs)))
-    (dolist (pair
-             '((ess-ask-for-ess-directory nil)
-               (ess-style 'RStudio)
-               (ess-eval-visibly t)
-               (ess-toggle-underscore nil)
-               (ess-use-flymake nil)
-               (ess--command-default-timeout 1)
-               (inferior-R-args "--no-save")
-               (ess-gen-proc-buffer-name-function
-                'ess-gen-proc-buffer-name:project-or-directory)))
-      (should (member pair pairs)))
-    (should
-     (member
-      '(flycheck-lintr-linters
-        "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)")
-      pairs))
-    (should
-     (member
-      '(ess-R-font-lock-keywords
-        '((ess-R-fl-keyword:modifiers . t)
-          (ess-R-fl-keyword:fun-defs . t)
-          (ess-R-fl-keyword:keywords . t)
-          (ess-R-fl-keyword:assign-ops)
-          (ess-R-fl-keyword:constants . t)
-          (ess-fl-keyword:fun-calls . t)
-          (ess-fl-keyword:numbers . t)
-          (ess-fl-keyword:operators . t)
-          (ess-fl-keyword:delimiters . t)
-          (ess-fl-keyword:= . t)
-          (ess-R-fl-keyword:F&T . t)
-          (ess-R-fl-keyword:%op% . t)))
-      pairs))))
-
-(ert-deftest p3-config-ess-preserves-rmarkdown-compile-hook ()
-  (let ((contents (p3-config-ess-test--contents "lisp/p3-config-ess.el")))
-    (should (string-match-p (regexp-quote "(defun compile-rmd ()") contents))
-    (should (string-match-p
-             (regexp-quote "R -e \"rmarkdown::render('") contents))
-    (should (string-match-p
-             (regexp-quote "(add-hook 'ess-mode-hook 'compile-rmd)") contents))
-    (should (string-match-p
-             (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
-
-(provide 'p3-config-ess-test)
-```
+Create `test/p3-config-ess-test.el` to read Lisp forms from the tracked source without loading optional ESS/Company packages. It must assert the exact Company backend value, exact ESS hook/binding lists, explicit `p3/ess-setup`, the sensitive `setq` pairs, `compile-rmd` hooks, and inferior-buffer setup.
 
 - [ ] **Step 2: Verify RED**
 
@@ -240,110 +72,19 @@ Expected: failure because `lisp/p3-config-ess.el` does not yet exist.
 
 - [ ] **Step 3: Create `lisp/p3-config-ess.el` with the current ESS configuration values**
 
-```elisp
-;;; p3-config-ess.el --- ESS and R-mode configuration -*- lexical-binding: t; -*-
+The module must:
 
+```elisp
 (require 'use-package)
 (require 'p3-config-loader)
-
 (p3/config-load-module 'p3-ess)
 (declare-function p3/ess-setup "p3-ess" ())
 (p3/ess-setup)
-
 (p3/config-load-module 'p3-r-tools)
-
-(defvar ansi-color-for-comint-mode)
-(defvar company-backends)
-(defvar ess-ask-for-ess-directory)
-(defvar ess-style)
-(defvar ess-eval-visibly)
-(defvar ess-toggle-underscore)
-(defvar ess-use-flymake)
-(defvar flycheck-lintr-linters)
-(defvar ess--command-default-timeout)
-(defvar inferior-R-args)
-(defvar ess-R-font-lock-keywords)
-(defvar ess-gen-proc-buffer-name-function)
-(defvar p3-r-command-map)
-
-(declare-function smartparens-mode "smartparens" (&optional arg))
-
 (keymap-global-set "C-c R" p3-r-command-map)
-
-(defvar p3/r-company-backends
-  '((:separate
-     company-R-library company-R-args company-R-objects
-     company-dabbrev-code
-     :with company-yasnippet)
-    company-capf)
-  "Company completion backends used in ESS R buffers.")
-
-(defun p3/ess-company-config ()
-  "Configure Company completion for an ESS R buffer."
-  (setq-local company-backends p3/r-company-backends))
-
-(defun p3/ess-inferior-mode-setup ()
-  "Apply personal defaults to an inferior ESS buffer."
-  (setq-local ansi-color-for-comint-mode 'filter)
-  (smartparens-mode 1))
-
-(use-package ess-r-mode
-  :ensure ess
-  :hook ((inferior-ess-mode . p3/ess-inferior-mode-setup)
-         (ess-r-post-run . p3-r-load-view-data-frame)
-         (ess-r-mode . p3/ess-company-config)
-         (ess-r-mode . p3/use-project-root-as-default-dir)
-         (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))
-  :bind (:map ess-mode-map
-              ("C-<return>" . nil)
-              ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
-              ("C-." . p3-r-insert-pipe)
-              ("C-c i" . p3-r-evaluate-library-section)
-              ("C-c v" . p3-r-view-data-frame-at-point)
-              ("C-c m" . p3-r-targets-make)
-              ("C-c d" . p3-r-targets-make-debug)
-              ("C-c l" . p3-r-targets-load-at-point)
-         :map inferior-ess-r-mode-map
-              ("C-c v" . p3-r-view-data-frame-at-point)
-              ("C-c m" . p3-r-targets-make)
-              ("C-c d" . p3-r-targets-make-debug)
-              ("C-c l" . p3-r-targets-load-at-point))
-  :config
-  (setq ess-ask-for-ess-directory nil
-        ess-style 'RStudio
-        ess-eval-visibly t
-        ess-toggle-underscore nil
-        ess-use-flymake nil
-        flycheck-lintr-linters "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"
-        ess--command-default-timeout 1
-        inferior-R-args "--no-save"
-        ess-R-font-lock-keywords
-        '((ess-R-fl-keyword:modifiers . t)
-          (ess-R-fl-keyword:fun-defs . t)
-          (ess-R-fl-keyword:keywords . t)
-          (ess-R-fl-keyword:assign-ops)
-          (ess-R-fl-keyword:constants . t)
-          (ess-fl-keyword:fun-calls . t)
-          (ess-fl-keyword:numbers . t)
-          (ess-fl-keyword:operators . t)
-          (ess-fl-keyword:delimiters . t)
-          (ess-fl-keyword:= . t)
-          (ess-R-fl-keyword:F&T . t)
-          (ess-R-fl-keyword:%op% . t))
-        ess-gen-proc-buffer-name-function
-        'ess-gen-proc-buffer-name:project-or-directory))
-
-(defun compile-rmd ()
-  (set (make-local-variable 'compile-command)
-       (concat "R -e \"rmarkdown::render('" buffer-file-name "')\"")))
-
-(add-hook 'ess-mode-hook 'compile-rmd)
-(add-hook 'markdown-mode-hook 'compile-rmd)
-
-(provide 'p3-config-ess)
 ```
 
-The old definitions remain in their current owners until Task 2; this module is not yet loaded by `config.org`.
+It then defines the exact `p3/r-company-backends`, `p3/ess-company-config`, `p3/ess-inferior-mode-setup`, the existing `use-package ess-r-mode` hook/bind/config values, and unchanged `compile-rmd` hooks.
 
 - [ ] **Step 4: Verify GREEN and compile closure**
 
@@ -377,26 +118,7 @@ git commit -m "Add ESS configuration module"
 
 - [ ] **Step 1: Add failing ownership tests**
 
-Append:
-
-```elisp
-(ert-deftest p3-ess-library-has-no-buffer-configuration-glue ()
-  (let ((contents (p3-config-ess-test--contents "lisp/p3-ess.el")))
-    (dolist (forbidden '("p3/ess-inferior-mode-setup"
-                         "ansi-color-for-comint-mode"
-                         "smartparens-mode"))
-      (should-not (string-match-p (regexp-quote forbidden) contents)))))
-
-(ert-deftest p3-generic-completion-has-no-ess-company-owner ()
-  (let ((contents (p3-config-ess-test--contents
-                   "lisp/p3-config-completion.el")))
-    (dolist (forbidden '("p3/r-company-backends"
-                         "p3/ess-company-config"
-                         "company-R-library"
-                         "company-R-args"
-                         "company-R-objects"))
-      (should-not (string-match-p (regexp-quote forbidden) contents)))))
-```
+Append tests asserting `p3-ess.el` no longer contains `p3/ess-inferior-mode-setup`, `ansi-color-for-comint-mode`, or `smartparens-mode`; and `p3-config-completion.el` no longer contains `p3/r-company-backends`, `p3/ess-company-config`, or the ESS Company backend symbols.
 
 - [ ] **Step 2: Verify RED**
 
@@ -404,7 +126,7 @@ Append:
 emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: the two ownership tests fail on the current old owners.
+Expected: the ownership tests fail on the current old owners.
 
 - [ ] **Step 3: Remove only buffer configuration from `p3-ess.el`**
 
@@ -413,24 +135,17 @@ Delete:
 ```elisp
 (declare-function smartparens-mode "smartparens" (&optional arg))
 (defvar ansi-color-for-comint-mode)
-
 (defun p3/ess-inferior-mode-setup ()
   "Apply personal defaults to an inferior ESS buffer."
   (setq-local ansi-color-for-comint-mode 'filter)
   (smartparens-mode 1))
 ```
 
-Do not alter `p3/ess-project-root`, process registration, lazy R creation, advice installation, or `p3/ess-setup`.
+Do not alter project/process behavior or `p3/ess-setup`.
 
 - [ ] **Step 4: Remove only ESS-specific Company ownership from completion**
 
-Remove the now-unused top-level declaration:
-
-```elisp
-(defvar company-backends)
-```
-
-Replace the Company declaration with:
+Remove the now-unused `company-backends` declaration and replace the Company block with:
 
 ```elisp
 (use-package company
@@ -442,13 +157,8 @@ Replace the Company declaration with:
 - [ ] **Step 5: Verify GREEN plus existing ESS behavior**
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-ess-test.el \
-  -l test/p3-ess-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -l test/p3-ess-test.el -f ert-run-tests-batch-and-exit
 ```
-
-Expected: all tests pass; existing process/session tests are unchanged.
 
 - [ ] **Step 6: Commit**
 
@@ -471,76 +181,15 @@ git commit -m "Separate ESS behavior from configuration"
 
 - [ ] **Step 1: Update tests before changing `config.org`**
 
-In `p3-config-org-delegates-custom-subsystems-to-modules`, use:
+Update `p3-config-org-delegates-custom-subsystems-to-modules` so `p3-ess` and `ess-r-mode` are no longer expected inline, and assert:
 
 ```elisp
-(dolist (module '("p3-platform" "p3-core" "p3-python" "p3-terminal"
-                  "p3-gptel"))
-  (should (string-match-p (regexp-quote (format "(use-package %s" module))
-                          contents)))
-(dolist (package '("python" "eglot" "vterm" "gptel"))
-  (should (string-match-p (regexp-quote (format "(use-package %s" package))
-                          contents)))
-(should
- (string-match-p
-  (regexp-quote "(p3/config-load-module 'p3-config-ess)") contents))
+(should (string-match-p
+         (regexp-quote "(p3/config-load-module 'p3-config-ess)")
+         contents))
 ```
 
-In `p3-config-early-orchestration-order-is-explicit`, bind:
-
-```elisp
-(ess (p3-config-test--position
-      "(p3/config-load-module 'p3-config-ess)" contents))
-```
-
-and assert:
-
-```elisp
-(should (< completion ess))
-(should (< ess r-program))
-```
-
-In `p3-config-platform-setup-preserves-subsystem-timing`, replace the old ESS needle with:
-
-```elisp
-(p3-config-test--position "(p3/config-load-module 'p3-config-ess)" contents)
-```
-
-Rename `p3-config-org-source-loads-five-config-modules` to `p3-config-org-source-loads-six-config-modules` and use:
-
-```elisp
-(dolist (module '(p3-config-base p3-config-editing p3-config-completion
-                  p3-config-ess p3-config-workspace p3-config-git))
-  (should
-   (string-match-p
-    (regexp-quote (format "(p3/config-load-module '%s)" module))
-    contents)))
-```
-
-Add these forbidden inline forms to `p3-config-moved-implementation-is-not-inline`:
-
-```elisp
-"(use-package p3-r-tools"
-"(use-package p3-ess"
-"(use-package ess-r-mode"
-"(defun compile-rmd"
-```
-
-Add:
-
-```elisp
-(ert-deftest p3-config-ess-orchestration-has-one-owner ()
-  (let* ((contents (p3-config-test--contents "config.org"))
-         (ess (p3-config-test--position
-               "(p3/config-load-module 'p3-config-ess)" contents))
-         (r-program (p3-config-test--position
-                     "(p3/windows-configure-r-program)" contents)))
-    (should-not (string-match-p "(use-package p3-r-tools" contents))
-    (should-not
-     (string-match-p
-      (regexp-quote "(keymap-global-set \"C-c R\"") contents))
-    (should (< ess r-program))))
-```
+Add `p3-config-ess` to ordering checks, rename the five-module test to six modules, add old ESS/R-tools inline forms to the forbidden list, and add a one-owner test that rejects `(use-package p3-r-tools` and the old `C-c R` binding in `config.org` while asserting ESS load precedes `p3/windows-configure-r-program`.
 
 - [ ] **Step 2: Verify RED**
 
@@ -548,25 +197,13 @@ Add:
 emacs -Q --batch -L lisp -l test/p3-config-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: failures because ESS is still inline and `p3-config-ess` is not yet loaded by `config.org`.
-
 - [ ] **Step 3: Remove the early R-tools configuration stanza**
 
-Delete from `* Functions`:
-
-```elisp
-(use-package p3-r-tools
-  :ensure nil
-  :demand t
-  :config
-  (keymap-global-set "C-c R" p3-r-command-map))
-```
-
-Leave `p3-core` unchanged.
+Delete the existing `use-package p3-r-tools` block and its `C-c R` binding from `* Functions`; leave `p3-core` unchanged.
 
 - [ ] **Step 4: Replace the inline ESS implementation**
 
-Replace the current `use-package p3-ess`, `use-package ess-r-mode`, and `compile-rmd` blocks with:
+Use:
 
 ```org
 ** ESS
@@ -588,27 +225,19 @@ startup boundary.
 #+END_SRC
 ```
 
-- [ ] **Step 5: Verify there is no earlier executable R-tools dependency**
+- [ ] **Step 5: Verify no earlier executable R-tools dependency**
 
 ```bash
 git grep -n "p3-r-\|p3-r-command-map\|p3-r-tools" -- config.org
 ```
 
-Expected: any match before the ESS section is prose/commentary only; no earlier Lisp source block loads `p3-r-tools`, binds `p3-r-command-map`, or invokes `p3-r-*`.
+Expected: any match before the ESS section is prose/commentary only.
 
-- [ ] **Step 6: Verify GREEN across the affected suites**
+- [ ] **Step 6: Verify GREEN across affected suites**
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-loader-test.el \
-  -l test/p3-config-test.el \
-  -l test/p3-config-ess-test.el \
-  -l test/p3-ess-test.el \
-  -l test/p3-r-tools-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-config-loader-test.el -l test/p3-config-test.el -l test/p3-config-ess-test.el -l test/p3-ess-test.el -l test/p3-r-tools-test.el -f ert-run-tests-batch-and-exit
 ```
-
-Expected: zero unexpected failures; the R parser test may keep its existing environment-dependent skip.
 
 - [ ] **Step 7: Commit**
 
@@ -631,53 +260,18 @@ git commit -m "Route ESS configuration through its module"
 
 - [ ] **Step 1: Add Ubuntu compile/test entries**
 
-Add:
-
-```yaml
-            lisp/p3-config-completion.el \
-            lisp/p3-config-ess.el \
-            lisp/p3-config-workspace.el \
-```
-
-and:
-
-```yaml
-            -l test/p3-config-test.el \
-            -l test/p3-config-ess-test.el \
-            -l test/p3-project-test.el \
-```
+Add `lisp/p3-config-ess.el` to byte compilation and `test/p3-config-ess-test.el` to the ERT load list.
 
 - [ ] **Step 2: Extend Windows path triggers and source tests**
 
-Add triggers:
+Add triggers for `lisp/p3-config-ess.el`, `lisp/p3-ess.el`, `lisp/p3-r-tools.el`, `test/p3-config-ess-test.el`, `test/p3-ess-test.el`, and `test/p3-r-tools-test.el`. Keep Windows byte compilation limited to existing boundary modules; add only `test/p3-config-ess-test.el` to the Windows config architecture ERT command.
 
-```yaml
-      - "lisp/p3-config-ess.el"
-      - "lisp/p3-ess.el"
-      - "lisp/p3-r-tools.el"
-      - "test/p3-config-ess-test.el"
-      - "test/p3-ess-test.el"
-      - "test/p3-r-tools-test.el"
-```
-
-Keep Windows byte compilation limited to the existing boundary modules. Add only the source-level ESS boundary test to the Windows architecture command:
-
-```yaml
-          -l test/p3-config-loader-test.el
-          -l test/p3-config-test.el
-          -l test/p3-config-ess-test.el
-          -l test/p3-commands-test.el
-          -l test/p3-git-test.el
-```
-
-- [ ] **Step 3: Static-check the workflow diff**
+- [ ] **Step 3: Static-check workflow diff**
 
 ```bash
 git diff --check
 git diff -- .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
 ```
-
-Expected: no whitespace errors and no unrelated workflow changes.
 
 - [ ] **Step 4: Commit**
 
@@ -690,12 +284,9 @@ git commit -m "Cover ESS configuration boundary in CI"
 
 ### Task 5: Final verification and adversarial review
 
-**Files:**
-- Verify all changed files; do not expand scope.
+**Files:** Verify all changed files; do not expand scope.
 
-**Interfaces:**
-- Consumes: Tasks 1-4.
-- Produces: merge-ready branch; merge still requires explicit user approval.
+**Interfaces:** Consumes Tasks 1-4; produces a merge-ready branch, with merge still requiring explicit approval.
 
 - [ ] **Step 1: Check scope and whitespace**
 
@@ -704,58 +295,15 @@ git diff --check master...HEAD
 git diff --stat master...HEAD
 ```
 
-Expected changed implementation/test files only:
-
-```text
-config.org
-lisp/p3-config-ess.el
-lisp/p3-ess.el
-lisp/p3-config-completion.el
-test/p3-config-ess-test.el
-test/p3-config-test.el
-.github/workflows/emacs-tests.yml
-.github/workflows/windows-platform-tests.yml
-```
-
-plus the approved spec/plan documents.
+Only the approved spec/plan plus ESS boundary implementation/tests/workflows may differ.
 
 - [ ] **Step 2: Compare moved forms with `master`**
 
-```bash
-git show master:config.org | grep -n -A90 -B10 "use-package ess-r-mode"
-git show HEAD:lisp/p3-config-ess.el
+Compare old inline ESS, Company backend, and inferior-buffer helper forms against `HEAD:lisp/p3-config-ess.el`; reject semantic drift.
 
-git show master:lisp/p3-config-completion.el | grep -n -A25 -B5 "p3/r-company-backends"
-git show HEAD:lisp/p3-config-ess.el | grep -n -A25 -B5 "p3/r-company-backends"
+- [ ] **Step 3: Run complete local ERT gate if Emacs is available**
 
-git show master:lisp/p3-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
-git show HEAD:lisp/p3-config-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
-```
-
-Expected: settings, hooks, bindings, Company backend contents, `compile-rmd`, and inferior-buffer setup are semantically unchanged.
-
-- [ ] **Step 3: Run the complete local ERT gate if Emacs is available**
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-loader-test.el \
-  -l test/p3-config-test.el \
-  -l test/p3-config-ess-test.el \
-  -l test/p3-project-test.el \
-  -l test/p3-core-test.el \
-  -l test/p3-platform-test.el \
-  -l test/p3-python-test.el \
-  -l test/p3-terminal-test.el \
-  -l test/p3-ess-test.el \
-  -l test/p3-gptel-test.el \
-  -l test/p3-r-tools-test.el \
-  -l test/p3-org-export-test.el \
-  -l test/p3-commands-test.el \
-  -l test/p3-git-test.el \
-  -f ert-run-tests-batch-and-exit
-```
-
-Expected: zero unexpected failures; existing environment-dependent skips may remain.
+Use the Ubuntu CI suite plus `test/p3-config-ess-test.el`; expect zero unexpected failures and only existing environment-dependent skips.
 
 - [ ] **Step 4: Confirm generated artifacts remain ignored/untracked**
 
@@ -765,32 +313,12 @@ git check-ignore -q lisp/example.elc
 test -z "$(git ls-files 'config.el' '*.elc')"
 ```
 
-- [ ] **Step 5: Push once and verify the final PR merge-ref CI**
+- [ ] **Step 5: Push once and verify final PR merge-ref CI**
 
-Required final gates:
-
-```text
-Ubuntu: Emacs tests — byte compilation succeeds; full ERT has zero unexpected failures.
-Windows: Windows platform tests — platform/project and config architecture tests have zero unexpected failures.
-```
-
-If CI fails, retrieve the exact job log and fix the root cause without adding diagnostic machinery or repeated probe pushes.
+Ubuntu `Emacs tests` must compile successfully and have zero unexpected ERT failures. Windows `Windows platform tests` must have zero unexpected failures. If CI fails, retrieve the exact job log and fix the root cause without diagnostic machinery or repeated probe pushes.
 
 - [ ] **Step 6: Final rejection-oriented review**
 
-Reject if any of the following is true:
-
-```text
-p3-ess.el still owns Smartparens/ANSI buffer configuration.
-p3-config-completion.el still owns ESS-specific Company state.
-p3-config-ess.el does not explicitly call p3/ess-setup.
-p3-r-tools.el public behavior changed.
-Any ESS binding/setting/backend value differs from master without approval.
-Windows R selection moved or changed order.
-The narrow ESS display rule moved or broadened.
-The Company compatibility bug was mixed into this PR.
-Generated artifacts are tracked.
-CI has an unexpected failure.
-```
+Reject if `p3-ess.el` still owns buffer configuration, generic completion still owns ESS Company state, `p3/ess-setup` is not called explicitly, `p3-r-tools.el` behavior changed, any ESS binding/setting/backend value drifts, Windows R ordering changes, the narrow display rule moves/broadens, the Company bug is mixed in, generated artifacts are tracked, or CI has an unexpected failure.
 
 If none apply, report merge-ready; do not merge without explicit user approval.

--- a/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
+++ b/docs/superpowers/plans/2026-09-04-ess-config-boundary.md
@@ -1,0 +1,855 @@
+# ESS Configuration Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move declarative ESS/R-mode configuration into `p3-config-ess.el` while preserving all current ESS/R behavior and leaving `p3-ess.el` focused on project/session/process ownership.
+
+**Architecture:** `config.org` will exact-source load one new configuration owner, `p3-config-ess.el`. That module will exact-source load `p3-ess.el` and `p3-r-tools.el`, explicitly invoke `p3/ess-setup`, own ESS package wiring and ESS-specific Company configuration, and leave Windows R executable selection in `config.org` immediately afterward. Existing process/session code and R workflow commands remain behaviorally unchanged.
+
+**Tech Stack:** Emacs Lisp, Emacs 29+, Org Babel config cache, `use-package`, ESS, Company, ERT, GitHub Actions on Ubuntu and Windows.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md`
+
+## Global Constraints
+
+- Preserve the user's current R/ESS workflow; this is an extraction/refactoring PR, not a redesign.
+- Do not fix the existing `company-dabbrev` compatibility error in this PR.
+- Do not change Company backend composition, ESS process/session semantics, R startup arguments, Lintr/Flycheck policy, ESS font-lock, project identity, R workflow commands, window placement, keybindings, package management, Python, Org, terminal, or Projectile behavior.
+- Keep `p3/windows-configure-r-program` in `config.org` immediately after the ESS configuration module load.
+- Keep the existing narrow `inferior-ess-r-mode` display rule unchanged in `p3-config-workspace.el`.
+- Use the existing exact-source local module loader; add no registry, discovery, or generalized reload mechanism.
+- Move `p3/ess-inferior-mode-setup` to the configuration module; `p3-ess.el` must retain process/session ownership only.
+- `p3-config-ess.el` must explicitly call `p3/ess-setup` after exact-source loading `p3-ess.el`.
+- Preserve the exact ESS Company backend value:
+
+```elisp
+'((:separate
+   company-R-library company-R-args company-R-objects
+   company-dabbrev-code
+   :with company-yasnippet)
+  company-capf)
+```
+
+- Generated `config.el` and `.elc` files remain ignored and untracked.
+- Do not use repeated CI pushes as a diagnostic loop; batch compiler/declaration fixes and use one final Ubuntu/Windows gate after local/static verification.
+
+---
+
+## File Map
+
+- Create `lisp/p3-config-ess.el`: declarative ESS/R configuration owner.
+- Create `test/p3-config-ess-test.el`: semantic source tests for the new module without loading optional third-party packages.
+- Modify `lisp/p3-ess.el`: remove only inferior-buffer configuration helper/declarations; retain project/process behavior.
+- Modify `lisp/p3-config-completion.el`: remove only ESS-specific Company backend data and hook function.
+- Modify `config.org`: remove the early `p3-r-tools` stanza and large inline ESS block; load `p3-config-ess` instead.
+- Modify `test/p3-config-test.el`: update module ownership/order assertions and remove assumptions that ESS is inline.
+- Modify `.github/workflows/emacs-tests.yml`: byte-compile `p3-config-ess.el` and run `p3-config-ess-test.el`.
+- Modify `.github/workflows/windows-platform-tests.yml`: trigger on the new module/test and run the source-level ESS boundary test on Windows.
+
+---
+
+### Task 1: Add semantic tests and the new ESS configuration module
+
+**Files:**
+- Create: `test/p3-config-ess-test.el`
+- Create: `lisp/p3-config-ess.el`
+
+**Interfaces:**
+- Consumes: `p3/config-load-module` from `p3-config-loader.el`, `p3/ess-setup` from `p3-ess.el`, `p3-r-command-map` and R workflow commands from `p3-r-tools.el`.
+- Produces: feature `p3-config-ess`; functions `p3/ess-inferior-mode-setup`, `p3/ess-company-config`, and `compile-rmd`; variable `p3/r-company-backends`.
+
+- [ ] **Step 1: Create source-parsing test helpers and failing semantic tests**
+
+Create `test/p3-config-ess-test.el` with tests that read Lisp forms from the tracked source instead of loading optional ESS/Company packages:
+
+```elisp
+;;; p3-config-ess-test.el --- Tests for ESS configuration ownership -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+
+(defconst p3-config-ess-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-ess-test--path (relative)
+  (expand-file-name relative p3-config-ess-test--root))
+
+(defun p3-config-ess-test--forms (relative)
+  (with-temp-buffer
+    (insert-file-contents (p3-config-ess-test--path relative))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(defun p3-config-ess-test--find-top-level (relative predicate)
+  (seq-find predicate (p3-config-ess-test--forms relative)))
+
+(defun p3-config-ess-test--use-package-form ()
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'use-package)
+          (eq (cadr form) 'ess-r-mode)))))
+
+(defun p3-config-ess-test--defvar-form (symbol)
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'defvar)
+          (eq (cadr form) symbol)))))
+
+(defun p3-config-ess-test--defun-form (symbol)
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'defun)
+          (eq (cadr form) symbol)))))
+
+(ert-deftest p3-config-ess-loads-behavior-and-r-tools-explicitly ()
+  (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
+    (should (member '(require 'p3-config-loader) forms))
+    (should (member '(p3/config-load-module 'p3-ess) forms))
+    (should (member '(p3/ess-setup) forms))
+    (should (member '(p3/config-load-module 'p3-r-tools) forms))
+    (should (member '(keymap-global-set "C-c R" p3-r-command-map) forms))))
+
+(ert-deftest p3-config-ess-preserves-company-backends-exactly ()
+  (let ((form (p3-config-ess-test--defvar-form 'p3/r-company-backends)))
+    (should form)
+    (should
+     (equal
+      (nth 2 form)
+      '(quote
+        ((:separate
+          company-R-library company-R-args company-R-objects
+          company-dabbrev-code
+          :with company-yasnippet)
+         company-capf))))))
+
+(ert-deftest p3-config-ess-preserves-company-buffer-hook ()
+  (let ((form (p3-config-ess-test--defun-form 'p3/ess-company-config)))
+    (should form)
+    (should
+     (equal (cdddr form)
+            '((setq-local company-backends p3/r-company-backends))))))
+
+(ert-deftest p3-config-ess-preserves-inferior-buffer-setup ()
+  (let ((form (p3-config-ess-test--defun-form 'p3/ess-inferior-mode-setup)))
+    (should form)
+    (should
+     (equal (cdddr form)
+            '((setq-local ansi-color-for-comint-mode 'filter)
+              (smartparens-mode 1))))))
+
+(ert-deftest p3-config-ess-preserves-ess-hooks-and-bindings ()
+  (let* ((form (p3-config-ess-test--use-package-form))
+         (args (cddr form)))
+    (should form)
+    (should
+     (equal
+      (plist-get args :hook)
+      '((inferior-ess-mode . p3/ess-inferior-mode-setup)
+        (ess-r-post-run . p3-r-load-view-data-frame)
+        (ess-r-mode . p3/ess-company-config)
+        (ess-r-mode . p3/use-project-root-as-default-dir)
+        (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))))
+    (should
+     (equal
+      (plist-get args :bind)
+      '(:map ess-mode-map
+        ("C-<return>" . nil)
+        ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
+        ("C-." . p3-r-insert-pipe)
+        ("C-c i" . p3-r-evaluate-library-section)
+        ("C-c v" . p3-r-view-data-frame-at-point)
+        ("C-c m" . p3-r-targets-make)
+        ("C-c d" . p3-r-targets-make-debug)
+        ("C-c l" . p3-r-targets-load-at-point)
+        :map inferior-ess-r-mode-map
+        ("C-c v" . p3-r-view-data-frame-at-point)
+        ("C-c m" . p3-r-targets-make)
+        ("C-c d" . p3-r-targets-make-debug)
+        ("C-c l" . p3-r-targets-load-at-point))))))
+
+(ert-deftest p3-config-ess-preserves-sensitive-settings ()
+  (let ((contents
+         (with-temp-buffer
+           (insert-file-contents
+            (p3-config-ess-test--path "lisp/p3-config-ess.el"))
+           (buffer-string))))
+    (dolist (setting
+             '("ess-ask-for-ess-directory nil"
+               "ess-style 'RStudio"
+               "ess-eval-visibly t"
+               "ess-toggle-underscore nil"
+               "ess-use-flymake nil"
+               "ess--command-default-timeout 1"
+               "inferior-R-args \"--no-save\""
+               "ess-gen-proc-buffer-name-function 'ess-gen-proc-buffer-name:project-or-directory"
+               "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"))
+      (should (string-match-p (regexp-quote setting) contents)))
+    (dolist (font-lock
+             '("ess-R-fl-keyword:modifiers"
+               "ess-R-fl-keyword:fun-defs"
+               "ess-R-fl-keyword:keywords"
+               "ess-R-fl-keyword:assign-ops"
+               "ess-R-fl-keyword:constants"
+               "ess-fl-keyword:fun-calls"
+               "ess-fl-keyword:numbers"
+               "ess-fl-keyword:operators"
+               "ess-fl-keyword:delimiters"
+               "ess-fl-keyword:="
+               "ess-R-fl-keyword:F&T"
+               "ess-R-fl-keyword:%op%"))
+      (should (string-match-p (regexp-quote font-lock) contents)))))
+
+(ert-deftest p3-config-ess-preserves-rmarkdown-compile-hook ()
+  (let ((contents
+         (with-temp-buffer
+           (insert-file-contents
+            (p3-config-ess-test--path "lisp/p3-config-ess.el"))
+           (buffer-string))))
+    (should (string-match-p "(defun compile-rmd ()" contents))
+    (should
+     (string-match-p
+      (regexp-quote "R -e \"rmarkdown::render('") contents))
+    (should (string-match-p
+             (regexp-quote "(add-hook 'ess-mode-hook 'compile-rmd)") contents))
+    (should (string-match-p
+             (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
+
+(provide 'p3-config-ess-test)
+
+;;; p3-config-ess-test.el ends here
+```
+
+- [ ] **Step 2: Run the new test file and verify it fails because the module is missing**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL with a file-missing error for `lisp/p3-config-ess.el`.
+
+- [ ] **Step 3: Create `p3-config-ess.el` with the existing ESS configuration moved verbatim**
+
+Create `lisp/p3-config-ess.el` with this structure and existing values:
+
+```elisp
+;;; p3-config-ess.el --- ESS and R-mode configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(p3/config-load-module 'p3-ess)
+(declare-function p3/ess-setup "p3-ess" ())
+(p3/ess-setup)
+
+(p3/config-load-module 'p3-r-tools)
+
+(defvar ansi-color-for-comint-mode)
+(defvar company-backends)
+(defvar ess-ask-for-ess-directory)
+(defvar ess-style)
+(defvar ess-eval-visibly)
+(defvar ess-toggle-underscore)
+(defvar ess-use-flymake)
+(defvar flycheck-lintr-linters)
+(defvar ess--command-default-timeout)
+(defvar inferior-R-args)
+(defvar ess-R-font-lock-keywords)
+(defvar ess-gen-proc-buffer-name-function)
+(defvar p3-r-command-map)
+
+(declare-function smartparens-mode "smartparens" (&optional arg))
+
+(keymap-global-set "C-c R" p3-r-command-map)
+
+(defvar p3/r-company-backends
+  '((:separate
+     company-R-library company-R-args company-R-objects
+     company-dabbrev-code
+     :with company-yasnippet)
+    company-capf)
+  "Company completion backends used in ESS R buffers.")
+
+(defun p3/ess-company-config ()
+  "Configure Company completion for an ESS R buffer."
+  (setq-local company-backends p3/r-company-backends))
+
+(defun p3/ess-inferior-mode-setup ()
+  "Apply personal defaults to an inferior ESS buffer."
+  (setq-local ansi-color-for-comint-mode 'filter)
+  (smartparens-mode 1))
+
+(use-package ess-r-mode
+  :ensure ess
+  :hook ((inferior-ess-mode . p3/ess-inferior-mode-setup)
+         (ess-r-post-run . p3-r-load-view-data-frame)
+         (ess-r-mode . p3/ess-company-config)
+         (ess-r-mode . p3/use-project-root-as-default-dir)
+         (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))
+  :bind (:map ess-mode-map
+              ("C-<return>" . nil)
+              ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
+              ("C-." . p3-r-insert-pipe)
+              ("C-c i" . p3-r-evaluate-library-section)
+              ("C-c v" . p3-r-view-data-frame-at-point)
+              ("C-c m" . p3-r-targets-make)
+              ("C-c d" . p3-r-targets-make-debug)
+              ("C-c l" . p3-r-targets-load-at-point)
+         :map inferior-ess-r-mode-map
+              ("C-c v" . p3-r-view-data-frame-at-point)
+              ("C-c m" . p3-r-targets-make)
+              ("C-c d" . p3-r-targets-make-debug)
+              ("C-c l" . p3-r-targets-load-at-point))
+  :config
+  (setq ess-ask-for-ess-directory nil
+        ess-style 'RStudio
+        ess-eval-visibly t
+        ess-toggle-underscore nil
+        ess-use-flymake nil
+        flycheck-lintr-linters "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"
+        ess--command-default-timeout 1
+        inferior-R-args "--no-save"
+        ess-R-font-lock-keywords
+        '((ess-R-fl-keyword:modifiers . t)
+          (ess-R-fl-keyword:fun-defs . t)
+          (ess-R-fl-keyword:keywords . t)
+          (ess-R-fl-keyword:assign-ops)
+          (ess-R-fl-keyword:constants . t)
+          (ess-fl-keyword:fun-calls . t)
+          (ess-fl-keyword:numbers . t)
+          (ess-fl-keyword:operators . t)
+          (ess-fl-keyword:delimiters . t)
+          (ess-fl-keyword:= . t)
+          (ess-R-fl-keyword:F&T . t)
+          (ess-R-fl-keyword:%op% . t))
+        ess-gen-proc-buffer-name-function
+        'ess-gen-proc-buffer-name:project-or-directory))
+
+(defun compile-rmd ()
+  (set (make-local-variable 'compile-command)
+       (concat "R -e \"rmarkdown::render('" buffer-file-name "')\"")))
+
+(add-hook 'ess-mode-hook 'compile-rmd)
+(add-hook 'markdown-mode-hook 'compile-rmd)
+
+(provide 'p3-config-ess)
+
+;;; p3-config-ess.el ends here
+```
+
+Do not remove the old definitions yet in this task; the new module is not loaded by `config.org` yet, so this commit is behavior-neutral.
+
+- [ ] **Step 4: Run the source-semantic tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp -l test/p3-config-ess-test.el -f ert-run-tests-batch-and-exit
+```
+
+Expected: all `p3-config-ess-*` tests PASS.
+
+- [ ] **Step 5: Byte-compile the new module once locally if Emacs is available**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp --eval '(setq byte-compile-error-on-warn t)' -f batch-byte-compile lisp/p3-config-ess.el
+rm -f lisp/p3-config-ess.elc
+```
+
+Expected: zero compiler warnings/errors. If a warning names an external variable/function already present in the moved configuration, add only the minimal `defvar`/`declare-function` declaration needed to satisfy the compiler; do not alter runtime behavior.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lisp/p3-config-ess.el test/p3-config-ess-test.el
+git commit -m "Add ESS configuration module"
+```
+
+---
+
+### Task 2: Remove ESS configuration from the old behavior/completion owners
+
+**Files:**
+- Modify: `lisp/p3-ess.el`
+- Modify: `lisp/p3-config-completion.el`
+- Modify: `test/p3-config-ess-test.el`
+- Test: `test/p3-ess-test.el`
+
+**Interfaces:**
+- Consumes: `p3-config-ess.el` from Task 1.
+- Produces: `p3-ess.el` with process/session-only responsibility; `p3-config-completion.el` with generic completion-only responsibility.
+
+- [ ] **Step 1: Add failing ownership assertions**
+
+Append to `test/p3-config-ess-test.el`:
+
+```elisp
+(ert-deftest p3-ess-library-has-no-buffer-configuration-glue ()
+  (let ((contents
+         (with-temp-buffer
+           (insert-file-contents
+            (p3-config-ess-test--path "lisp/p3-ess.el"))
+           (buffer-string))))
+    (dolist (forbidden '("p3/ess-inferior-mode-setup"
+                         "ansi-color-for-comint-mode"
+                         "smartparens-mode"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(ert-deftest p3-generic-completion-has-no-ess-company-owner ()
+  (let ((contents
+         (with-temp-buffer
+           (insert-file-contents
+            (p3-config-ess-test--path "lisp/p3-config-completion.el"))
+           (buffer-string))))
+    (dolist (forbidden '("p3/r-company-backends"
+                         "p3/ess-company-config"
+                         "company-R-library"
+                         "company-R-args"
+                         "company-R-objects"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+```
+
+- [ ] **Step 2: Run the two new tests and verify they fail on the old owners**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp -l test/p3-config-ess-test.el \
+  --eval "(ert-run-tests-batch-and-exit \"p3-\\(?:ess-library\\|generic-completion\\)\")"
+```
+
+Expected: both tests FAIL because the moved definitions still exist in their old files.
+
+- [ ] **Step 3: Remove only inferior-buffer configuration from `p3-ess.el`**
+
+Delete from `lisp/p3-ess.el`:
+
+```elisp
+(declare-function smartparens-mode "smartparens" (&optional arg))
+(defvar ansi-color-for-comint-mode)
+
+(defun p3/ess-inferior-mode-setup ()
+  "Apply personal defaults to an inferior ESS buffer."
+  (setq-local ansi-color-for-comint-mode 'filter)
+  (smartparens-mode 1))
+```
+
+Keep every project/process function, `p3/ess-install-process-advice`, and `p3/ess-setup` unchanged.
+
+- [ ] **Step 4: Remove only ESS-specific Company state from `p3-config-completion.el`**
+
+Delete the top-level compiler declaration if it is no longer used:
+
+```elisp
+(defvar company-backends)
+```
+
+Within `(use-package company ...)`, remove the current `:init` block containing:
+
+```elisp
+(defvar p3/r-company-backends ...)
+(defun p3/ess-company-config () ...)
+```
+
+Leave the package declaration behavior as:
+
+```elisp
+(use-package company
+  :hook (after-init . global-company-mode)
+  :config
+  (setq company-dabbrev-downcase nil))
+```
+
+Do not change any Company backend function or replace Company.
+
+- [ ] **Step 5: Run the ownership and existing ESS behavior tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-ess-test.el \
+  -l test/p3-ess-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all tests PASS. Existing `p3-ess-*` process/session tests remain unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lisp/p3-ess.el lisp/p3-config-completion.el test/p3-config-ess-test.el
+git commit -m "Separate ESS behavior from configuration"
+```
+
+---
+
+### Task 3: Replace inline ESS configuration with explicit orchestration
+
+**Files:**
+- Modify: `config.org`
+- Modify: `test/p3-config-test.el`
+- Test: `test/p3-config-ess-test.el`
+- Test: `test/p3-r-tools-test.el`
+
+**Interfaces:**
+- Consumes: feature `p3-config-ess` from Task 1.
+- Produces: one authoritative ESS module load in `config.org`; Windows R selection remains immediately afterward.
+
+- [ ] **Step 1: Update configuration tests first**
+
+In `test/p3-config-test.el` make these exact expectation changes:
+
+1. In `p3-config-org-delegates-custom-subsystems-to-modules`, remove `"p3-ess"` from the `use-package` module list and remove `"ess-r-mode"` from the inline package list. Add an assertion for the exact module loader:
+
+```elisp
+(should
+ (string-match-p
+  (regexp-quote "(p3/config-load-module 'p3-config-ess)")
+  contents))
+```
+
+2. In `p3-config-early-orchestration-order-is-explicit`, add:
+
+```elisp
+(ess (p3-config-test--position
+      "(p3/config-load-module 'p3-config-ess)" contents))
+```
+
+and assert:
+
+```elisp
+(should (< completion ess))
+(should (< ess r-program))
+```
+
+3. In `p3-config-platform-setup-preserves-subsystem-timing`, replace the ESS position needle:
+
+```elisp
+(p3-config-test--position "(p3/config-load-module 'p3-config-ess)" contents)
+```
+
+4. Rename `p3-config-org-source-loads-five-config-modules` to `p3-config-org-source-loads-six-config-modules` and use:
+
+```elisp
+(dolist (module '(p3-config-base p3-config-editing p3-config-completion
+                  p3-config-ess p3-config-workspace p3-config-git))
+  ...)
+```
+
+5. Add to `p3-config-moved-implementation-is-not-inline`:
+
+```elisp
+"(use-package p3-r-tools"
+"(use-package p3-ess"
+"(use-package ess-r-mode"
+"(defun compile-rmd"
+```
+
+6. Add a focused test that the old executable R-tools owner is gone and Windows ordering remains explicit:
+
+```elisp
+(ert-deftest p3-config-ess-orchestration-has-one-owner ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (ess (p3-config-test--position
+               "(p3/config-load-module 'p3-config-ess)" contents))
+         (r-program (p3-config-test--position
+                     "(p3/windows-configure-r-program)" contents)))
+    (should-not (string-match-p "(use-package p3-r-tools" contents))
+    (should-not (string-match-p
+                 (regexp-quote "(keymap-global-set \"C-c R\"") contents))
+    (should (= 1
+               (let ((start 0) (count 0))
+                 (while (string-match
+                         (regexp-quote "(p3/config-load-module 'p3-config-ess)")
+                         contents start)
+                   (setq count (1+ count)
+                         start (match-end 0)))
+                 count)))
+    (should (< ess r-program))))
+```
+
+- [ ] **Step 2: Run targeted config tests and verify they fail against the current inline config**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp -l test/p3-config-test.el -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL on missing `p3-config-ess` orchestration and stale inline ESS/R-tools expectations.
+
+- [ ] **Step 3: Remove the earlier `p3-r-tools` stanza from `config.org`**
+
+Delete the prose and source block under `* Functions` that currently load `p3-r-tools` and bind `C-c R`:
+
+```elisp
+(use-package p3-r-tools
+  :ensure nil
+  :demand t
+  :config
+  (keymap-global-set "C-c R" p3-r-command-map))
+```
+
+Leave `p3-core` and its `C-c e` / `C-c r` bindings untouched.
+
+- [ ] **Step 4: Replace the entire inline ESS block with the new module loader**
+
+Replace the current `use-package p3-ess`, `use-package ess-r-mode`, and later `compile-rmd` block with:
+
+```org
+** ESS
+
+ESS package wiring, R-mode hooks, keybindings, buffer defaults, and ESS-specific
+Company configuration live in =lisp/p3-config-ess.el=. Project-aware ESS
+process/session behavior remains in =lisp/p3-ess.el=, while project templates
+and user-facing R workflow commands remain in =lisp/p3-r-tools.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-ess)
+#+END_SRC
+
+On Windows, select the R executable here, preserving the existing subsystem
+startup boundary.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/windows-configure-r-program)
+#+END_SRC
+```
+
+Do not move `p3/windows-configure-r-program` into the module.
+
+- [ ] **Step 5: Verify no executable R-tools dependency remains before the ESS module load**
+
+Run:
+
+```bash
+git grep -n "p3-r-\|p3-r-command-map\|p3-r-tools" -- config.org
+```
+
+Expected: any remaining matches before the ESS section are prose/comments only; no earlier Lisp source block loads `p3-r-tools`, binds `p3-r-command-map`, or invokes a `p3-r-*` function.
+
+- [ ] **Step 6: Run config, ESS boundary, and R workflow tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-config-ess-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-r-tools-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: all loaded tests PASS; R parser test may skip if `Rscript` is unavailable.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add config.org test/p3-config-test.el
+git commit -m "Route ESS configuration through its module"
+```
+
+---
+
+### Task 4: Wire CI coverage for the new configuration owner
+
+**Files:**
+- Modify: `.github/workflows/emacs-tests.yml`
+- Modify: `.github/workflows/windows-platform-tests.yml`
+
+**Interfaces:**
+- Consumes: `lisp/p3-config-ess.el` and `test/p3-config-ess-test.el`.
+- Produces: Ubuntu compiler/full-suite coverage and Windows structural boundary coverage for ESS configuration.
+
+- [ ] **Step 1: Update Ubuntu compile and ERT lists**
+
+In `.github/workflows/emacs-tests.yml`, add `lisp/p3-config-ess.el` after the other config modules and add `test/p3-config-ess-test.el` to the ERT load list:
+
+```yaml
+            lisp/p3-config-completion.el \
+            lisp/p3-config-ess.el \
+            lisp/p3-config-workspace.el \
+```
+
+and:
+
+```yaml
+            -l test/p3-config-test.el \
+            -l test/p3-config-ess-test.el \
+            -l test/p3-project-test.el \
+```
+
+- [ ] **Step 2: Update Windows path triggers and architecture test list**
+
+Add these paths to `.github/workflows/windows-platform-tests.yml`:
+
+```yaml
+      - "lisp/p3-config-ess.el"
+      - "lisp/p3-ess.el"
+      - "lisp/p3-r-tools.el"
+      - "test/p3-config-ess-test.el"
+      - "test/p3-ess-test.el"
+      - "test/p3-r-tools-test.el"
+```
+
+Keep Windows byte compilation limited to the existing platform boundary modules; `p3-config-ess.el` contains optional package wiring and is byte-compiled on Ubuntu. Add only the source-level ESS boundary test to the Windows config architecture command:
+
+```yaml
+          -l test/p3-config-loader-test.el
+          -l test/p3-config-test.el
+          -l test/p3-config-ess-test.el
+          -l test/p3-commands-test.el
+```
+
+This preserves Windows coverage for R-program ordering and source ownership without requiring ESS/Company packages to be installed on the Windows runner.
+
+- [ ] **Step 3: Run a static workflow diff check**
+
+Run:
+
+```bash
+git diff --check
+git diff -- .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
+```
+
+Expected: no whitespace errors; only the new module/test coverage is added.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
+git commit -m "Cover ESS configuration boundary in CI"
+```
+
+---
+
+### Task 5: Final verification and adversarial review
+
+**Files:**
+- Verify all files changed by Tasks 1-4.
+- Do not change production behavior unless verification exposes a concrete regression.
+
+**Interfaces:**
+- Consumes: completed implementation.
+- Produces: merge-ready PR branch with evidence that the extraction preserves behavior.
+
+- [ ] **Step 1: Verify the branch diff is within scope**
+
+Run:
+
+```bash
+git diff --check master...HEAD
+git diff --stat master...HEAD
+git diff master...HEAD -- \
+  lisp/p3-config-ess.el \
+  lisp/p3-ess.el \
+  lisp/p3-config-completion.el \
+  config.org \
+  test/p3-config-ess-test.el \
+  test/p3-config-test.el \
+  .github/workflows/emacs-tests.yml \
+  .github/workflows/windows-platform-tests.yml
+```
+
+Expected: no unrelated Python, Org, terminal, project, window-placement, package-manager, or R workflow implementation changes.
+
+- [ ] **Step 2: Compare moved ESS forms against `master` for semantic equivalence**
+
+Check specifically:
+
+```bash
+git show master:config.org | grep -n -A90 -B10 "use-package ess-r-mode"
+git show HEAD:lisp/p3-config-ess.el
+
+git show master:lisp/p3-config-completion.el | grep -n -A25 -B5 "p3/r-company-backends"
+git show HEAD:lisp/p3-config-ess.el | grep -n -A25 -B5 "p3/r-company-backends"
+
+git show master:lisp/p3-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
+git show HEAD:lisp/p3-config-ess.el | grep -n -A8 -B4 "p3/ess-inferior-mode-setup"
+```
+
+Expected: moved settings, hooks, keybindings, Company backend contents, `compile-rmd`, and inferior-buffer setup are semantically unchanged.
+
+- [ ] **Step 3: Run the complete local ERT gate if Emacs is available**
+
+Run the same suite as Ubuntu CI, including the new test:
+
+```bash
+emacs -Q --batch \
+  -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-config-ess-test.el \
+  -l test/p3-project-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-platform-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-terminal-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-gptel-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-org-export-test.el \
+  -l test/p3-commands-test.el \
+  -l test/p3-git-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: zero unexpected failures; platform/R parser tests may retain their existing environment-dependent skips.
+
+- [ ] **Step 4: Confirm generated artifacts remain ignored and untracked**
+
+Run:
+
+```bash
+git check-ignore -q config.el
+git check-ignore -q lisp/example.elc
+test -z "$(git ls-files 'config.el' '*.elc')"
+```
+
+Expected: all commands succeed and no generated artifacts are tracked.
+
+- [ ] **Step 5: Open/update the PR and run one final Ubuntu/Windows Actions cycle**
+
+Push the final branch once. Verify both pull-request workflows on the resulting PR merge ref:
+
+- Ubuntu `Emacs tests`: byte compilation succeeds, full ERT has zero unexpected failures.
+- Windows `Windows platform tests`: platform/project tests and config architecture tests have zero unexpected failures.
+
+Do not push intermediate diagnostic commits merely to probe CI. If CI fails, pull the exact failing job log, fix the root cause locally/static-first, and rerun once.
+
+- [ ] **Step 6: Perform a final adversarial review before merge**
+
+Reject the PR if any of these are true:
+
+- `p3-ess.el` still contains Smartparens/ANSI buffer configuration;
+- `p3-config-completion.el` still owns ESS-specific Company state;
+- `p3-config-ess.el` fails to call `p3/ess-setup` explicitly;
+- `p3-r-tools.el` public behavior changed;
+- any ESS keybinding/settings/backend value differs from `master` without an explicit approved reason;
+- Windows R selection moved inside the module or changed ordering;
+- the narrow ESS display rule moved or broadened;
+- the Company compatibility bug was mixed into this PR;
+- generated artifacts are tracked;
+- CI reports an unexpected failure.
+
+If none apply, report the branch as merge-ready but do not merge without explicit user approval.

--- a/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
+++ b/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
@@ -13,11 +13,11 @@ This is an extraction/refactoring PR. It does not redesign ESS behavior.
 The ESS subsystem is split across four places:
 
 - `config.org` contains the full `ess-r-mode` package declaration, hooks, keybindings, ESS variables, font-lock configuration, linting settings, R startup arguments, and the `compile-rmd` hook helper.
-- `p3-ess.el` contains project/session/process ownership behavior.
+- `p3-ess.el` contains project/session/process ownership behavior plus one buffer-configuration helper (`p3/ess-inferior-mode-setup`) that sets Comint ANSI behavior and enables Smartparens.
 - `p3-r-tools.el` contains R project/template commands plus user-facing commands that send code through ESS.
 - `p3-config-completion.el` contains ESS-specific Company backend state and `p3/ess-company-config` even though that module is intended to own generic completion configuration.
 
-The result is a clear remaining violation of the architecture established by the configuration-module PR: generic completion owns subsystem-specific ESS wiring, while `config.org` still contains a large specialized implementation block.
+The result is a clear remaining violation of the architecture established by the configuration-module PR: generic completion owns subsystem-specific ESS wiring, `p3-ess.el` still mixes process behavior with buffer configuration, and `config.org` still contains a large specialized implementation block.
 
 ## Design principles
 
@@ -28,6 +28,7 @@ The result is a clear remaining violation of the architecture established by the
 5. Keep the existing Windows startup boundary visible in `config.org`.
 6. Do not use this refactor to fix the current `company-dabbrev` compatibility error.
 7. Do not add module registries, automatic discovery, generalized reload machinery, or broad display policies.
+8. Tests must protect semantic equivalence of fragile ESS/Company settings, not merely prove that forms moved to a new file.
 
 ## Ownership after the change
 
@@ -36,12 +37,15 @@ The result is a clear remaining violation of the architecture established by the
 New tracked configuration module. It owns ESS/R-mode configuration and glue:
 
 - requiring `p3-config-loader` and `use-package`, following the existing `p3-config-*` module pattern;
-- loading/configuring `p3-ess`;
-- loading `p3-r-tools` so R workflow bindings have an explicit dependency rather than relying on unrelated source ordering;
+- exact-source loading `p3-ess`;
+- explicitly calling `p3/ess-setup` after `p3-ess` is loaded;
+- exact-source loading `p3-r-tools` so R workflow bindings have an explicit dependency rather than relying on unrelated source ordering;
 - the existing global `C-c R` binding for `p3-r-command-map`;
 - the current `use-package ess-r-mode` declaration;
 - ESS hooks;
 - ESS and inferior-ESS keybindings;
+- `p3/ess-inferior-mode-setup`, moved verbatim from `p3-ess.el` because it is buffer configuration rather than process/session behavior;
+- the `ansi-color-for-comint-mode` / Smartparens setup needed by `p3/ess-inferior-mode-setup`;
 - `ess-ask-for-ess-directory`;
 - `ess-style`;
 - `ess-eval-visibly`;
@@ -61,6 +65,16 @@ The moved forms should remain semantically equivalent to their current versions.
 
 `p3-config-ess.el` should use `p3/config-load-module` to load `p3-ess` and `p3-r-tools`, matching the exact-source reload pattern already used by the other `p3-config-*` modules.
 
+The configuration sequence is explicit:
+
+1. load `p3-ess` source;
+2. call `p3/ess-setup`;
+3. load `p3-r-tools` source;
+4. install the `C-c R` prefix binding;
+5. configure `ess-r-mode` and its hooks/settings.
+
+The implementation may express that sequence using ordinary top-level forms and/or `use-package`, but the resulting behavior and ordering must remain explicit and testable.
+
 ### `p3-ess.el`
 
 Retains project/session/process ownership only:
@@ -71,9 +85,10 @@ Retains project/session/process ownership only:
 - registration of inferior processes;
 - lazy project-specific R startup;
 - assignment of `ess-local-process-name`;
-- inferior ESS buffer setup currently implemented there;
 - guarded installation of advice around ESS process selection;
 - `p3/ess-setup`.
+
+Move `p3/ess-inferior-mode-setup` out of this file. Once that helper moves, declarations/state present only for its ANSI-color and Smartparens behavior should also leave `p3-ess.el`.
 
 No process/session redesign belongs in this PR.
 
@@ -105,7 +120,7 @@ Remove:
 
 - `p3/r-company-backends`;
 - `p3/ess-company-config`;
-- any declarations present solely for that ESS-specific wiring.
+- declarations present solely for that ESS-specific wiring.
 
 Do not otherwise change the Company package configuration. In particular, do not change Company backends or attempt to fix the current `company-dabbrev` error in this PR.
 
@@ -121,7 +136,7 @@ It should:
 
 The standalone `p3-r-tools` loading/binding stanza elsewhere in `config.org` should be removed once `p3-config-ess.el` explicitly owns that configuration dependency and binding.
 
-That changes when `p3-r-tools.el` is loaded during startup: instead of loading in the earlier generic “Functions” section, it loads as an explicit dependency of the ESS configuration module. This is an intentional ordering normalization, not a behavior redesign. The implementation must verify that no earlier startup form depends on `p3-r-tools` or `p3-r-command-map`, and the final configuration must still install `C-c R` before user interaction begins.
+That changes when `p3-r-tools.el` is loaded during startup: instead of loading in the earlier generic “Functions” section, it loads as an explicit dependency of the ESS configuration module. This is an intentional ordering normalization, not a behavior redesign. The implementation must verify that no executable form before the `p3-config-ess` load requires `p3-r-tools` or `p3-r-command-map`. Benign textual references, comments, documentation, templates, or later forms are not failures. The final configuration must still install `C-c R` before user interaction begins.
 
 The Windows R executable selection remains in `config.org` because its startup position is intentional and was explicitly preserved by the previous module-architecture design.
 
@@ -152,9 +167,28 @@ config.org
 (p3/config-load-module 'p3-config-ess)
 ```
 
+Inside `p3-config-ess.el`, loading `p3-ess` is not sufficient by itself. The module must explicitly invoke:
+
+```elisp
+(p3/ess-setup)
+```
+
+after loading `p3-ess`, preserving the current setup side effect that installs the inferior-ESS registration hook and process-selection advice.
+
 The new configuration module should exact-source load its local behavior dependencies so that `C-c r` re-evaluates their current source consistently with the existing configuration-module pattern.
 
 This preserves the current meaning of reload: source is re-evaluated. It does not promise reconciliation of already-bound `defvar` values or arbitrary package state; that general inherited limitation remains outside this PR.
+
+## `p3/ess-inferior-mode-setup`
+
+Move `p3/ess-inferior-mode-setup` from `p3-ess.el` to `p3-config-ess.el` without changing behavior.
+
+It remains responsible for:
+
+- setting `ansi-color-for-comint-mode` buffer-locally to `filter`;
+- enabling `smartparens-mode` in inferior ESS buffers.
+
+The existing `inferior-ess-mode` hook continues to call this helper. The move is an ownership correction only; it must not alter Smartparens behavior or Comint ANSI handling.
 
 ## `compile-rmd`
 
@@ -174,6 +208,18 @@ Do not rename it in this PR.
 
 ESS-specific Company configuration moves from `p3-config-completion.el` to `p3-config-ess.el` unchanged.
 
+The exact backend value to preserve is:
+
+```elisp
+'((:separate
+   company-R-library company-R-args company-R-objects
+   company-dabbrev-code
+   :with company-yasnippet)
+  company-capf)
+```
+
+`p3/ess-company-config` must continue to assign that value buffer-locally through `company-backends` in ESS R buffers.
+
 This refactor deliberately separates ownership from bug fixing. The known Company error:
 
 ```text
@@ -189,6 +235,7 @@ The PR must preserve:
 - project-aware ESS process selection;
 - lazy R process creation;
 - process registration by project root;
+- explicit invocation of `p3/ess-setup` during ESS configuration;
 - `C-c R` R workflow prefix;
 - ESS `S-RET` evaluation behavior;
 - `C-.` pipe insertion in ESS buffers;
@@ -196,8 +243,9 @@ The PR must preserve:
 - corresponding inferior-ESS bindings;
 - `view_df` helper loading behavior (`p3-r-load-view-data-frame` on `ess-r-post-run`);
 - project-root `default-directory` setup in ESS R buffers;
+- inferior-buffer ANSI filtering and Smartparens setup;
 - underscore word-syntax behavior;
-- Company backend contents;
+- exact Company backend contents;
 - R indentation style;
 - visible evaluation setting;
 - ESS Flymake disablement;
@@ -246,6 +294,8 @@ Keep and run the existing focused suites:
 
 These files remain the primary behavioral protection for the two existing libraries.
 
+Update `test/p3-ess-test.el` as needed to reflect the ownership move: it should no longer treat `p3/ess-inferior-mode-setup` as behavior owned by `p3-ess.el`. Process/session tests remain unchanged in intent.
+
 ### New configuration-boundary coverage
 
 Add focused coverage for the new ownership boundary. The tests should verify at minimum:
@@ -253,17 +303,55 @@ Add focused coverage for the new ownership boundary. The tests should verify at 
 - `config.org` exact-source loads `p3-config-ess`;
 - `config.org` no longer contains the full `use-package ess-r-mode` implementation block;
 - the old standalone `p3-r-tools` load/bind stanza is gone from the earlier generic section;
-- no earlier startup/configuration form depends on `p3-r-tools` before `p3-config-ess` loads it;
+- no executable form before the `p3-config-ess` load depends on `p3-r-tools` or `p3-r-command-map`;
 - `p3/windows-configure-r-program` remains after the ESS module load;
 - `p3-config-completion.el` no longer contains `p3/r-company-backends` or `p3/ess-company-config`;
 - `p3-config-ess.el` contains the ESS-specific Company definitions;
-- `p3-config-ess.el` owns the current ESS hooks and keybindings;
+- `p3-config-ess.el` owns `p3/ess-inferior-mode-setup` and its existing inferior-ESS hook;
+- `p3-ess.el` no longer owns Smartparens/ANSI-color buffer configuration;
+- `p3-config-ess.el` explicitly loads `p3-ess` and explicitly calls `p3/ess-setup` afterward;
+- `p3-config-ess.el` explicitly loads `p3-r-tools` through the local module loader;
 - `p3-config-ess.el` owns the `C-c R` binding;
 - `p3-config-ess.el` owns `compile-rmd` and both current hooks;
-- `p3-config-ess.el` explicitly loads `p3-ess` and `p3-r-tools` through the local module loader;
 - the narrow ESS display policy remains in `p3-config-workspace.el` and is not duplicated in the new module.
 
-Because CI does not install/load every optional third-party package in a normal interactive session, boundary tests may inspect the tracked source structurally rather than requiring the complete `p3-config-ess.el` module at test runtime. Behavioral code remains covered by the existing `p3-ess` and `p3-r-tools` tests.
+### Semantic equivalence assertions
+
+Do not rely only on source-presence tests. Add assertions that parse or otherwise compare the relevant Lisp forms so accidental edits to values are caught.
+
+At minimum, lock down:
+
+- the exact `p3/r-company-backends` value shown above;
+- `ess-ask-for-ess-directory` = `nil`;
+- `ess-style` = `RStudio`;
+- `ess-eval-visibly` = `t`;
+- `ess-toggle-underscore` = `nil`;
+- `ess-use-flymake` = `nil`;
+- `ess--command-default-timeout` = `1`;
+- `inferior-R-args` = `"--no-save"`;
+- `ess-gen-proc-buffer-name-function` = `ess-gen-proc-buffer-name:project-or-directory`;
+- the exact `flycheck-lintr-linters` string currently configured;
+- the exact ESS source-buffer binding set: `C-<return>` unbound, `S-<return>`, `C-.`, `C-c i`, `C-c v`, `C-c m`, `C-c d`, `C-c l`;
+- the exact inferior-ESS binding set currently configured: `C-c v`, `C-c m`, `C-c d`, `C-c l`;
+- the current ESS hook set, including `ess-r-post-run`, ESS Company setup, project-root default-directory setup, underscore syntax setup, and inferior-buffer setup;
+- the `compile-rmd` hook pair (`ess-mode-hook`, `markdown-mode-hook`);
+- the existing `ess-R-font-lock-keywords` form.
+
+The tests may parse tracked source forms rather than loading every optional package. The point is semantic comparison of the configuration data, not simply checking that symbol names occur in the file.
+
+### Existing configuration tests that must change
+
+The current structural suite expects `use-package p3-ess` and `use-package ess-r-mode` to appear directly in `config.org`. Those assertions become intentionally obsolete under this design.
+
+The implementation must update/replace those expectations so the suite instead proves:
+
+- `config.org` exact-source loads `p3-config-ess`;
+- ESS implementation forms are absent from `config.org`;
+- `p3-config-ess.el` owns the expected configuration and setup call.
+
+Do not leave old expectations in place and add contradictory new ones.
+
+Because CI does not install/load every optional third-party package in a normal interactive session, boundary tests may inspect tracked source structurally and parse forms rather than requiring the complete `p3-config-ess.el` module at test runtime. Behavioral code remains covered by the existing `p3-ess` and `p3-r-tools` tests.
 
 ### Compilation and CI
 
@@ -277,18 +365,21 @@ Because CI does not install/load every optional third-party package in a normal 
 The PR is complete when:
 
 1. `p3-config-ess.el` exists and owns all declarative ESS/R-mode configuration described above.
-2. `p3-ess.el` still contains only project/session/process behavior and has no intentional semantic changes.
-3. `p3-r-tools.el` retains the existing R workflow and has no intentional semantic changes.
-4. `p3-config-completion.el` contains no ESS-specific Company state or hook function.
-5. `config.org` contains a concise ESS orchestration stanza rather than the current large implementation block.
-6. The old standalone `p3-r-tools` load/binding stanza is removed, with its load and `C-c R` binding explicitly owned by `p3-config-ess.el`.
-7. Windows R executable selection remains immediately after ESS configuration in the orchestration layer.
-8. Existing ESS/R keybindings and configuration values are unchanged.
-9. The existing narrow ESS display policy remains unchanged in `p3-config-workspace.el`.
-10. The Company `company-dabbrev` error is not addressed in this PR.
-11. Focused tests, full ERT, and required Ubuntu/Windows gates pass with no unexpected failures.
-12. Generated `config.el` and `.elc` artifacts remain ignored and untracked.
-13. No unrelated subsystem cleanup is included.
+2. `p3-config-ess.el` explicitly loads `p3-ess` and invokes `p3/ess-setup`.
+3. `p3/ess-inferior-mode-setup` and its Smartparens/ANSI configuration live in `p3-config-ess.el`, not `p3-ess.el`.
+4. `p3-ess.el` contains only project/session/process behavior and has no intentional semantic changes to that behavior.
+5. `p3-r-tools.el` retains the existing R workflow and has no intentional semantic changes.
+6. `p3-config-completion.el` contains no ESS-specific Company state or hook function.
+7. `config.org` contains a concise ESS orchestration stanza rather than the current large implementation block.
+8. The old standalone `p3-r-tools` load/binding stanza is removed, with its load and `C-c R` binding explicitly owned by `p3-config-ess.el`.
+9. Windows R executable selection remains immediately after ESS configuration in the orchestration layer.
+10. Existing ESS/R keybindings, hooks, Company backend contents, and configuration values are semantically unchanged and protected by regression assertions.
+11. The existing narrow ESS display policy remains unchanged in `p3-config-workspace.el`.
+12. The Company `company-dabbrev` error is not addressed in this PR.
+13. Existing obsolete `config.org` ESS ownership tests are replaced rather than layered with contradictory assertions.
+14. Focused tests, full ERT, and required Ubuntu/Windows gates pass with no unexpected failures.
+15. Generated `config.el` and `.elc` artifacts remain ignored and untracked.
+16. No unrelated subsystem cleanup is included.
 
 ## Follow-up
 

--- a/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
+++ b/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
@@ -1,0 +1,287 @@
+# ESS Configuration Boundary Design
+
+## Goal
+
+Finish the ESS portion of the configuration-module migration without changing the user's R/ESS workflow.
+
+After this change, declarative ESS/R-mode configuration belongs in `p3-config-ess.el`, project-aware ESS process behavior remains in `p3-ess.el`, and user-facing R workflow commands remain in `p3-r-tools.el`. `config.org` becomes a short orchestration layer for the subsystem.
+
+This is an extraction/refactoring PR. It does not redesign ESS behavior.
+
+## Current problem
+
+The ESS subsystem is split across four places:
+
+- `config.org` contains the full `ess-r-mode` package declaration, hooks, keybindings, ESS variables, font-lock configuration, linting settings, R startup arguments, and the `compile-rmd` hook helper.
+- `p3-ess.el` contains project/session/process ownership behavior.
+- `p3-r-tools.el` contains R project/template commands plus user-facing commands that send code through ESS.
+- `p3-config-completion.el` contains ESS-specific Company backend state and `p3/ess-company-config` even though that module is intended to own generic completion configuration.
+
+The result is a clear remaining violation of the architecture established by the configuration-module PR: generic completion owns subsystem-specific ESS wiring, while `config.org` still contains a large specialized implementation block.
+
+## Design principles
+
+1. Preserve behavior. Move existing configuration essentially verbatim before considering cleanup.
+2. Organize by responsibility, not by whether a function happens to call ESS.
+3. Keep the file count flat. Do not create a separate `p3-r-ess.el` or other new behavior layer.
+4. Keep configuration modules declarative. Stateful project/process behavior remains outside `p3-config-*`.
+5. Keep the existing Windows startup boundary visible in `config.org`.
+6. Do not use this refactor to fix the current `company-dabbrev` compatibility error.
+7. Do not add module registries, automatic discovery, generalized reload machinery, or broad display policies.
+
+## Ownership after the change
+
+### `p3-config-ess.el`
+
+New tracked configuration module. It owns ESS/R-mode configuration and glue:
+
+- loading/configuring `p3-ess`;
+- loading `p3-r-tools` so R workflow bindings have an explicit dependency rather than relying on unrelated source ordering;
+- the existing global `C-c R` binding for `p3-r-command-map`;
+- the current `use-package ess-r-mode` declaration;
+- ESS hooks;
+- ESS and inferior-ESS keybindings;
+- `ess-ask-for-ess-directory`;
+- `ess-style`;
+- `ess-eval-visibly`;
+- `ess-toggle-underscore`;
+- `ess-use-flymake`;
+- `flycheck-lintr-linters`;
+- `ess--command-default-timeout`;
+- `inferior-R-args`;
+- `ess-R-font-lock-keywords`;
+- `ess-gen-proc-buffer-name-function`;
+- the underscore syntax hook currently attached to `ess-mode`;
+- `p3/r-company-backends`;
+- `p3/ess-company-config`;
+- `compile-rmd` and its existing `ess-mode-hook` / `markdown-mode-hook` wiring.
+
+The moved forms should remain semantically equivalent to their current versions. The PR must not opportunistically rename commands, change keybindings, alter values, simplify font-lock, change lint rules, or replace anonymous hooks merely for style.
+
+`p3-config-ess.el` may use `p3/config-load-module` to load `p3-ess` and `p3-r-tools`, matching the exact-source reload pattern already used by the other `p3-config-*` modules.
+
+### `p3-ess.el`
+
+Retains project/session/process ownership only:
+
+- project-root cache;
+- project-root to ESS process map;
+- process liveness checks;
+- registration of inferior processes;
+- lazy project-specific R startup;
+- assignment of `ess-local-process-name`;
+- inferior ESS buffer setup currently implemented there;
+- guarded installation of advice around ESS process selection;
+- `p3/ess-setup`.
+
+No process/session redesign belongs in this PR.
+
+### `p3-r-tools.el`
+
+Retains user-facing R workflow behavior:
+
+- project scaffolding and templates;
+- R document/header/chunk helpers;
+- Targets commands;
+- Shiny command;
+- `view_df` loading/viewing;
+- library/setup-section evaluation;
+- write-to-read conversion;
+- R script archiving;
+- helper-file navigation;
+- `p3-r-command-map`;
+- existing compatibility aliases.
+
+Some of these commands use a live ESS process. That does not make them ESS session-management code. They remain together because they form one coherent user-facing R workflow.
+
+No internal split of `p3-r-tools.el` is required in this PR.
+
+### `p3-config-completion.el`
+
+Becomes generic completion configuration only.
+
+Remove:
+
+- `p3/r-company-backends`;
+- `p3/ess-company-config`;
+- any declarations present solely for that ESS-specific wiring.
+
+Do not otherwise change the Company package configuration. In particular, do not change Company backends or attempt to fix the current `company-dabbrev` error in this PR.
+
+### `config.org`
+
+The ESS section becomes an orchestration/map section rather than an implementation block.
+
+It should:
+
+1. briefly describe the ownership split;
+2. exact-source load `p3-config-ess` using `p3/config-load-module`;
+3. retain `p3/windows-configure-r-program` immediately after the ESS configuration stanza.
+
+The standalone `p3-r-tools` loading/binding stanza elsewhere in `config.org` should be removed once `p3-config-ess.el` explicitly owns that configuration dependency and binding.
+
+The Windows R executable selection remains in `config.org` because its startup position is intentional and was explicitly preserved by the previous module-architecture design.
+
+## Dependency direction
+
+The intended dependency shape is:
+
+```text
+config.org
+  |
+  +-- p3-config-ess
+  |     +-- p3-ess
+  |     |     +-- p3-project
+  |     +-- p3-r-tools
+  |           +-- p3-project
+  |
+  +-- p3/windows-configure-r-program
+```
+
+`p3-config-ess.el` must not require another `p3-config-*` module. In particular, it must not depend on `p3-config-completion.el`; it only defines the ESS-specific Company backend data and hook function. The generic Company package remains configured by the completion module.
+
+## Loading and reload behavior
+
+`config.org` should use:
+
+```elisp
+(p3/config-load-module 'p3-config-ess)
+```
+
+The new configuration module should exact-source load its local behavior dependencies so that `C-c r` re-evaluates their current source consistently with the existing configuration-module pattern.
+
+This preserves the current meaning of reload: source is re-evaluated. It does not promise reconciliation of already-bound `defvar` values or arbitrary package state; that general inherited limitation remains outside this PR.
+
+## `compile-rmd`
+
+Keep `compile-rmd` as configuration glue in `p3-config-ess.el`.
+
+Its existing behavior remains unchanged:
+
+- set a buffer-local `compile-command` that renders the current file through `rmarkdown::render()`;
+- attach the helper to `ess-mode-hook`;
+- attach the same helper to `markdown-mode-hook`.
+
+Do not move it into `p3-r-tools.el`: it configures buffer behavior rather than representing a reusable interactive R workflow command.
+
+Do not rename it in this PR.
+
+## Company boundary
+
+ESS-specific Company configuration moves from `p3-config-completion.el` to `p3-config-ess.el` unchanged.
+
+This refactor deliberately separates ownership from bug fixing. The known Company error:
+
+```text
+Company: backend company-dabbrev error "Wrong number of arguments: (2 . 2), 1"
+```
+
+is explicitly out of scope. Once this PR is merged, that compatibility issue can be addressed as a small bounded change against the now-correct ESS owner.
+
+## Behavior that must not change
+
+The PR must preserve:
+
+- project-aware ESS process selection;
+- lazy R process creation;
+- process registration by project root;
+- `C-c R` R workflow prefix;
+- ESS `S-RET` evaluation behavior;
+- `C-.` pipe insertion in ESS buffers;
+- `C-c i`, `C-c v`, `C-c m`, `C-c d`, and `C-c l` bindings;
+- corresponding inferior-ESS bindings;
+- `p3-r-post-run` / `view_df` helper loading behavior (currently `p3-r-load-view-data-frame` on `ess-r-post-run`);
+- project-root `default-directory` setup in ESS R buffers;
+- underscore word-syntax behavior;
+- Company backend contents;
+- R indentation style;
+- visible evaluation setting;
+- ESS Flymake disablement;
+- Lintr configuration;
+- ESS command timeout;
+- `--no-save` R startup argument;
+- font-lock keyword configuration;
+- ESS process buffer naming;
+- Windows R executable selection timing;
+- `compile-rmd` behavior and hooks;
+- the existing narrow `inferior-ess-r-mode` display rule in `p3-config-workspace.el`.
+
+The display rule is not part of the ESS extraction and must not move or broaden.
+
+## Out of scope
+
+Do not include:
+
+- Company -> Corfu migration;
+- Company backend compatibility fixes;
+- changes to Company backend composition;
+- ESS process/session redesign;
+- changes to R startup arguments;
+- changes to Lintr/Flycheck policy;
+- changes to ESS font-lock;
+- changes to project identity;
+- changes to `p3-r-tools` public commands;
+- splitting `p3-r-tools.el` into multiple files;
+- changes to the narrow ESS side-window rule;
+- generalized REPL/window placement;
+- Projectile cleanup;
+- Python cleanup;
+- Org cleanup;
+- terminal cleanup;
+- keybinding redesign;
+- package-manager changes.
+
+## Testing strategy
+
+### Existing behavior tests
+
+Keep and run the existing focused suites:
+
+- `test/p3-ess-test.el` for project/session/process semantics;
+- `test/p3-r-tools-test.el` for templates, project generation, command-map exposure, and representative ESS-backed R workflow behavior.
+
+These files remain the primary behavioral protection for the two existing libraries.
+
+### New configuration-boundary coverage
+
+Add focused coverage for the new ownership boundary. The tests should verify at minimum:
+
+- `config.org` exact-source loads `p3-config-ess`;
+- `config.org` no longer contains the full `use-package ess-r-mode` implementation block;
+- `p3/windows-configure-r-program` remains after the ESS module load;
+- `p3-config-completion.el` no longer contains `p3/r-company-backends` or `p3/ess-company-config`;
+- `p3-config-ess.el` contains the ESS-specific Company definitions;
+- `p3-config-ess.el` owns the current ESS hooks and keybindings;
+- `p3-config-ess.el` owns `compile-rmd` and both current hooks;
+- `p3-config-ess.el` explicitly loads/configures `p3-ess` and `p3-r-tools`;
+- the narrow ESS display policy remains in `p3-config-workspace.el` and is not duplicated in the new module.
+
+Because CI does not install/load every optional third-party package in a normal interactive session, boundary tests may inspect the tracked source structurally rather than requiring the complete `p3-config-ess.el` module at test runtime. Behavioral code remains covered by the existing `p3-ess` and `p3-r-tools` tests.
+
+### Compilation and CI
+
+- Byte-compile `p3-config-ess.el` with warnings treated as errors in the Ubuntu workflow.
+- Keep the full ERT suite as the primary regression gate.
+- Extend Windows coverage when the files changed affect the existing Windows platform/config boundary. At minimum, the structural configuration tests must continue to cover Windows R-program ordering.
+- Do not use CI as an iterative diagnostic loop. Batch likely compiler-declaration fixes before rerunning the final gates.
+
+## Acceptance criteria
+
+The PR is complete when:
+
+1. `p3-config-ess.el` exists and owns all declarative ESS/R-mode configuration described above.
+2. `p3-ess.el` still contains only project/session/process behavior and has no intentional semantic changes.
+3. `p3-r-tools.el` retains the existing R workflow and has no intentional semantic changes.
+4. `p3-config-completion.el` contains no ESS-specific Company state or hook function.
+5. `config.org` contains a concise ESS orchestration stanza rather than the current large implementation block.
+6. Windows R executable selection remains immediately after ESS configuration in the orchestration layer.
+7. Existing ESS/R keybindings and configuration values are unchanged.
+8. The existing narrow ESS display policy remains unchanged in `p3-config-workspace.el`.
+9. The Company `company-dabbrev` error is not addressed in this PR.
+10. Focused tests, full ERT, and required Ubuntu/Windows gates pass with no unexpected failures.
+11. Generated `config.el` and `.elc` artifacts remain ignored and untracked.
+12. No unrelated subsystem cleanup is included.
+
+## Follow-up
+
+After this refactor is merged, address the `company-dabbrev` failure as a separate bounded fix. The clean ownership boundary should make that investigation smaller: ESS-specific completion configuration will have one clear owner (`p3-config-ess.el`) while generic Company configuration remains in `p3-config-completion.el`.

--- a/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
+++ b/docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md
@@ -35,6 +35,7 @@ The result is a clear remaining violation of the architecture established by the
 
 New tracked configuration module. It owns ESS/R-mode configuration and glue:
 
+- requiring `p3-config-loader` and `use-package`, following the existing `p3-config-*` module pattern;
 - loading/configuring `p3-ess`;
 - loading `p3-r-tools` so R workflow bindings have an explicit dependency rather than relying on unrelated source ordering;
 - the existing global `C-c R` binding for `p3-r-command-map`;
@@ -58,7 +59,7 @@ New tracked configuration module. It owns ESS/R-mode configuration and glue:
 
 The moved forms should remain semantically equivalent to their current versions. The PR must not opportunistically rename commands, change keybindings, alter values, simplify font-lock, change lint rules, or replace anonymous hooks merely for style.
 
-`p3-config-ess.el` may use `p3/config-load-module` to load `p3-ess` and `p3-r-tools`, matching the exact-source reload pattern already used by the other `p3-config-*` modules.
+`p3-config-ess.el` should use `p3/config-load-module` to load `p3-ess` and `p3-r-tools`, matching the exact-source reload pattern already used by the other `p3-config-*` modules.
 
 ### `p3-ess.el`
 
@@ -120,6 +121,8 @@ It should:
 
 The standalone `p3-r-tools` loading/binding stanza elsewhere in `config.org` should be removed once `p3-config-ess.el` explicitly owns that configuration dependency and binding.
 
+That changes when `p3-r-tools.el` is loaded during startup: instead of loading in the earlier generic “Functions” section, it loads as an explicit dependency of the ESS configuration module. This is an intentional ordering normalization, not a behavior redesign. The implementation must verify that no earlier startup form depends on `p3-r-tools` or `p3-r-command-map`, and the final configuration must still install `C-c R` before user interaction begins.
+
 The Windows R executable selection remains in `config.org` because its startup position is intentional and was explicitly preserved by the previous module-architecture design.
 
 ## Dependency direction
@@ -130,6 +133,7 @@ The intended dependency shape is:
 config.org
   |
   +-- p3-config-ess
+  |     +-- p3-config-loader
   |     +-- p3-ess
   |     |     +-- p3-project
   |     +-- p3-r-tools
@@ -190,7 +194,7 @@ The PR must preserve:
 - `C-.` pipe insertion in ESS buffers;
 - `C-c i`, `C-c v`, `C-c m`, `C-c d`, and `C-c l` bindings;
 - corresponding inferior-ESS bindings;
-- `p3-r-post-run` / `view_df` helper loading behavior (currently `p3-r-load-view-data-frame` on `ess-r-post-run`);
+- `view_df` helper loading behavior (`p3-r-load-view-data-frame` on `ess-r-post-run`);
 - project-root `default-directory` setup in ESS R buffers;
 - underscore word-syntax behavior;
 - Company backend contents;
@@ -248,12 +252,15 @@ Add focused coverage for the new ownership boundary. The tests should verify at 
 
 - `config.org` exact-source loads `p3-config-ess`;
 - `config.org` no longer contains the full `use-package ess-r-mode` implementation block;
+- the old standalone `p3-r-tools` load/bind stanza is gone from the earlier generic section;
+- no earlier startup/configuration form depends on `p3-r-tools` before `p3-config-ess` loads it;
 - `p3/windows-configure-r-program` remains after the ESS module load;
 - `p3-config-completion.el` no longer contains `p3/r-company-backends` or `p3/ess-company-config`;
 - `p3-config-ess.el` contains the ESS-specific Company definitions;
 - `p3-config-ess.el` owns the current ESS hooks and keybindings;
+- `p3-config-ess.el` owns the `C-c R` binding;
 - `p3-config-ess.el` owns `compile-rmd` and both current hooks;
-- `p3-config-ess.el` explicitly loads/configures `p3-ess` and `p3-r-tools`;
+- `p3-config-ess.el` explicitly loads `p3-ess` and `p3-r-tools` through the local module loader;
 - the narrow ESS display policy remains in `p3-config-workspace.el` and is not duplicated in the new module.
 
 Because CI does not install/load every optional third-party package in a normal interactive session, boundary tests may inspect the tracked source structurally rather than requiring the complete `p3-config-ess.el` module at test runtime. Behavioral code remains covered by the existing `p3-ess` and `p3-r-tools` tests.
@@ -274,13 +281,14 @@ The PR is complete when:
 3. `p3-r-tools.el` retains the existing R workflow and has no intentional semantic changes.
 4. `p3-config-completion.el` contains no ESS-specific Company state or hook function.
 5. `config.org` contains a concise ESS orchestration stanza rather than the current large implementation block.
-6. Windows R executable selection remains immediately after ESS configuration in the orchestration layer.
-7. Existing ESS/R keybindings and configuration values are unchanged.
-8. The existing narrow ESS display policy remains unchanged in `p3-config-workspace.el`.
-9. The Company `company-dabbrev` error is not addressed in this PR.
-10. Focused tests, full ERT, and required Ubuntu/Windows gates pass with no unexpected failures.
-11. Generated `config.el` and `.elc` artifacts remain ignored and untracked.
-12. No unrelated subsystem cleanup is included.
+6. The old standalone `p3-r-tools` load/binding stanza is removed, with its load and `C-c R` binding explicitly owned by `p3-config-ess.el`.
+7. Windows R executable selection remains immediately after ESS configuration in the orchestration layer.
+8. Existing ESS/R keybindings and configuration values are unchanged.
+9. The existing narrow ESS display policy remains unchanged in `p3-config-workspace.el`.
+10. The Company `company-dabbrev` error is not addressed in this PR.
+11. Focused tests, full ERT, and required Ubuntu/Windows gates pass with no unexpected failures.
+12. Generated `config.el` and `.elc` artifacts remain ignored and untracked.
+13. No unrelated subsystem cleanup is included.
 
 ## Follow-up
 

--- a/lisp/p3-config-completion.el
+++ b/lisp/p3-config-completion.el
@@ -2,7 +2,6 @@
 
 (require 'use-package)
 
-(defvar company-backends)
 (defvar company-dabbrev-downcase)
 (defvar xref-show-xrefs-function)
 (defvar xref-show-definitions-function)
@@ -86,20 +85,6 @@
 
 (use-package company
   :hook (after-init . global-company-mode)
-  :init
-  (defvar p3/r-company-backends
-    '((:separate
-       ;; Help and objects.
-       company-R-library company-R-args company-R-objects
-       company-dabbrev-code
-       :with company-yasnippet)
-      ;; Filenames and other completion-at-point providers.
-      company-capf)
-    "Company completion backends used in ESS R buffers.")
-
-  (defun p3/ess-company-config ()
-    "Configuration for ESS."
-    (setq-local company-backends p3/r-company-backends))
   :config
   (setq company-dabbrev-downcase nil))
 

--- a/lisp/p3-config-ess.el
+++ b/lisp/p3-config-ess.el
@@ -16,6 +16,8 @@
 (defvar ess-eval-visibly)
 (defvar ess-toggle-underscore)
 (defvar ess-use-flymake)
+(defvar ess-mode-map)
+(defvar inferior-ess-r-mode-map)
 (defvar flycheck-lintr-linters)
 (defvar ess--command-default-timeout)
 (defvar inferior-R-args)

--- a/lisp/p3-config-ess.el
+++ b/lisp/p3-config-ess.el
@@ -1,0 +1,105 @@
+;;; p3-config-ess.el --- ESS and R-mode configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(p3/config-load-module 'p3-ess)
+(declare-function p3/ess-setup "p3-ess" ())
+(p3/ess-setup)
+
+(p3/config-load-module 'p3-r-tools)
+
+(defvar ansi-color-for-comint-mode)
+(defvar company-backends)
+(defvar ess-ask-for-ess-directory)
+(defvar ess-style)
+(defvar ess-eval-visibly)
+(defvar ess-toggle-underscore)
+(defvar ess-use-flymake)
+(defvar flycheck-lintr-linters)
+(defvar ess--command-default-timeout)
+(defvar inferior-R-args)
+(defvar ess-R-font-lock-keywords)
+(defvar ess-gen-proc-buffer-name-function)
+(defvar p3-r-command-map)
+
+(declare-function smartparens-mode "smartparens" (&optional arg))
+
+(keymap-global-set "C-c R" p3-r-command-map)
+
+(defvar p3/r-company-backends
+  '((:separate
+     company-R-library company-R-args company-R-objects
+     company-dabbrev-code
+     :with company-yasnippet)
+    company-capf)
+  "Company completion backends used in ESS R buffers.")
+
+(defun p3/ess-company-config ()
+  "Configure Company completion for an ESS R buffer."
+  (setq-local company-backends p3/r-company-backends))
+
+(defun p3/ess-inferior-mode-setup ()
+  "Apply personal defaults to an inferior ESS buffer."
+  (setq-local ansi-color-for-comint-mode 'filter)
+  (smartparens-mode 1))
+
+(use-package ess-r-mode
+  :ensure ess
+  :hook ((inferior-ess-mode . p3/ess-inferior-mode-setup)
+         (ess-r-post-run . p3-r-load-view-data-frame)
+         (ess-r-mode . p3/ess-company-config)
+         (ess-r-mode . p3/use-project-root-as-default-dir)
+         ;; Treat "_" as part of a word when navigating across words.
+         (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))
+  :bind (:map ess-mode-map
+              ;; Re-map ESS "run" to S-RET because of CUA mode.
+              ("C-<return>" . nil)
+              ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
+              ("C-." . p3-r-insert-pipe)
+              ("C-c i" . p3-r-evaluate-library-section)
+              ("C-c v" . p3-r-view-data-frame-at-point)
+              ("C-c m" . p3-r-targets-make)
+              ("C-c d" . p3-r-targets-make-debug)
+              ("C-c l" . p3-r-targets-load-at-point)
+         :map inferior-ess-r-mode-map
+              ("C-c v" . p3-r-view-data-frame-at-point)
+              ("C-c m" . p3-r-targets-make)
+              ("C-c d" . p3-r-targets-make-debug)
+              ("C-c l" . p3-r-targets-load-at-point))
+  :config
+  (setq ess-ask-for-ess-directory nil
+        ess-style 'RStudio
+        ess-eval-visibly t
+        ess-toggle-underscore nil
+        ess-use-flymake nil
+        flycheck-lintr-linters
+        "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)"
+        ess--command-default-timeout 1
+        inferior-R-args "--no-save"
+        ess-R-font-lock-keywords
+        '((ess-R-fl-keyword:modifiers . t)
+          (ess-R-fl-keyword:fun-defs . t)
+          (ess-R-fl-keyword:keywords . t)
+          (ess-R-fl-keyword:assign-ops)
+          (ess-R-fl-keyword:constants . t)
+          (ess-fl-keyword:fun-calls . t)
+          (ess-fl-keyword:numbers . t)
+          (ess-fl-keyword:operators . t)
+          (ess-fl-keyword:delimiters . t)
+          (ess-fl-keyword:= . t)
+          (ess-R-fl-keyword:F&T . t)
+          (ess-R-fl-keyword:%op% . t))
+        ess-gen-proc-buffer-name-function
+        'ess-gen-proc-buffer-name:project-or-directory))
+
+(defun compile-rmd ()
+  (set (make-local-variable 'compile-command)
+       (concat "R -e \"rmarkdown::render('" buffer-file-name "')\"")))
+
+(add-hook 'ess-mode-hook 'compile-rmd)
+(add-hook 'markdown-mode-hook 'compile-rmd)
+
+(provide 'p3-config-ess)
+
+;;; p3-config-ess.el ends here

--- a/lisp/p3-ess.el
+++ b/lisp/p3-ess.el
@@ -10,9 +10,7 @@
 (require 'p3-project)
 
 (declare-function R "ess-r-mode")
-(declare-function smartparens-mode "smartparens" (&optional arg))
 
-(defvar ansi-color-for-comint-mode)
 (defvar ess-local-process-name nil)
 
 (defvar p3/ess-project-processes
@@ -67,11 +65,6 @@
     (unless process
       (user-error "Unable to create ESS process"))
     (setq-local ess-local-process-name process)))
-
-(defun p3/ess-inferior-mode-setup ()
-  "Apply personal defaults to an inferior ESS buffer."
-  (setq-local ansi-color-for-comint-mode 'filter)
-  (smartparens-mode 1))
 
 (defun p3/ess-force-buffer-current-symbol ()
   "Return the ESS function guarded by project-process advice."

--- a/test/p3-config-ess-test.el
+++ b/test/p3-config-ess-test.el
@@ -70,12 +70,25 @@
     (seq-partition (cdr setq-form) 2)))
 
 (ert-deftest p3-config-ess-load-order-is-explicit ()
-  (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
-    (should (member '(require 'p3-config-loader) forms))
-    (should (member '(p3/config-load-module 'p3-ess) forms))
-    (should (member '(p3/ess-setup) forms))
-    (should (member '(p3/config-load-module 'p3-r-tools) forms))
-    (should (member '(keymap-global-set "C-c R" p3-r-command-map) forms))))
+  (let* ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el"))
+         (loader-position
+          (seq-position forms '(require 'p3-config-loader) #'equal))
+         (ess-position
+          (seq-position forms '(p3/config-load-module 'p3-ess) #'equal))
+         (setup-position
+          (seq-position forms '(p3/ess-setup) #'equal))
+         (r-tools-position
+          (seq-position forms '(p3/config-load-module 'p3-r-tools) #'equal))
+         (binding-position
+          (seq-position forms
+                        '(keymap-global-set "C-c R" p3-r-command-map)
+                        #'equal)))
+    (dolist (position
+             (list loader-position ess-position setup-position
+                   r-tools-position binding-position))
+      (should (integerp position)))
+    (should (< loader-position ess-position setup-position
+               r-tools-position binding-position))))
 
 (ert-deftest p3-config-ess-preserves-company-backends-exactly ()
   (should

--- a/test/p3-config-ess-test.el
+++ b/test/p3-config-ess-test.el
@@ -1,0 +1,184 @@
+;;; p3-config-ess-test.el --- ESS configuration boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-ess-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-ess-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-ess-test--root))
+
+(defun p3-config-ess-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-ess-test--path relative))
+    (buffer-string)))
+
+(defun p3-config-ess-test--forms (relative)
+  "Read all top-level Lisp forms from RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-ess-test--path relative))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(defun p3-config-ess-test--find-top-level (relative predicate)
+  "Return first top-level form in RELATIVE matching PREDICATE."
+  (seq-find predicate (p3-config-ess-test--forms relative)))
+
+(defun p3-config-ess-test--use-package-form ()
+  "Return the `use-package ess-r-mode' form under test."
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'use-package)
+          (eq (cadr form) 'ess-r-mode)))))
+
+(defun p3-config-ess-test--defvar-form (symbol)
+  "Return top-level defvar for SYMBOL in the ESS config module."
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'defvar)
+          (eq (cadr form) symbol)))))
+
+(defun p3-config-ess-test--defun-form (symbol)
+  "Return top-level defun for SYMBOL in the ESS config module."
+  (p3-config-ess-test--find-top-level
+   "lisp/p3-config-ess.el"
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'defun)
+          (eq (cadr form) symbol)))))
+
+(defun p3-config-ess-test--setq-pairs ()
+  "Return variable/value pairs from the ESS package `setq' form."
+  (let* ((form (p3-config-ess-test--use-package-form))
+         (setq-form (plist-get (cddr form) :config)))
+    (should (eq (car-safe setq-form) 'setq))
+    (seq-partition (cdr setq-form) 2)))
+
+(ert-deftest p3-config-ess-load-order-is-explicit ()
+  (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
+    (should (member '(require 'p3-config-loader) forms))
+    (should (member '(p3/config-load-module 'p3-ess) forms))
+    (should (member '(p3/ess-setup) forms))
+    (should (member '(p3/config-load-module 'p3-r-tools) forms))
+    (should (member '(keymap-global-set "C-c R" p3-r-command-map) forms))))
+
+(ert-deftest p3-config-ess-preserves-company-backends-exactly ()
+  (should
+   (equal
+    (nth 2 (p3-config-ess-test--defvar-form 'p3/r-company-backends))
+    '(quote
+      ((:separate
+        company-R-library company-R-args company-R-objects
+        company-dabbrev-code
+        :with company-yasnippet)
+       company-capf)))))
+
+(ert-deftest p3-config-ess-preserves-company-buffer-hook ()
+  (should
+   (equal
+    (cddddr (p3-config-ess-test--defun-form 'p3/ess-company-config))
+    '((setq-local company-backends p3/r-company-backends)))))
+
+(ert-deftest p3-config-ess-preserves-inferior-buffer-setup ()
+  (should
+   (equal
+    (cddddr (p3-config-ess-test--defun-form 'p3/ess-inferior-mode-setup))
+    '((setq-local ansi-color-for-comint-mode 'filter)
+      (smartparens-mode 1)))))
+
+(ert-deftest p3-config-ess-preserves-hooks-and-bindings ()
+  (let* ((form (p3-config-ess-test--use-package-form))
+         (args (cddr form)))
+    (should form)
+    (should
+     (equal
+      (plist-get args :hook)
+      '((inferior-ess-mode . p3/ess-inferior-mode-setup)
+        (ess-r-post-run . p3-r-load-view-data-frame)
+        (ess-r-mode . p3/ess-company-config)
+        (ess-r-mode . p3/use-project-root-as-default-dir)
+        (ess-mode . (lambda () (modify-syntax-entry ?_ "w"))))))
+    (should
+     (equal
+      (plist-get args :bind)
+      '(:map ess-mode-map
+        ("C-<return>" . nil)
+        ("S-<return>" . ess-eval-region-or-line-visibly-and-step)
+        ("C-." . p3-r-insert-pipe)
+        ("C-c i" . p3-r-evaluate-library-section)
+        ("C-c v" . p3-r-view-data-frame-at-point)
+        ("C-c m" . p3-r-targets-make)
+        ("C-c d" . p3-r-targets-make-debug)
+        ("C-c l" . p3-r-targets-load-at-point)
+        :map inferior-ess-r-mode-map
+        ("C-c v" . p3-r-view-data-frame-at-point)
+        ("C-c m" . p3-r-targets-make)
+        ("C-c d" . p3-r-targets-make-debug)
+        ("C-c l" . p3-r-targets-load-at-point))))))
+
+(ert-deftest p3-config-ess-preserves-sensitive-settings ()
+  (let ((pairs (p3-config-ess-test--setq-pairs)))
+    (dolist (pair
+             '((ess-ask-for-ess-directory nil)
+               (ess-style 'RStudio)
+               (ess-eval-visibly t)
+               (ess-toggle-underscore nil)
+               (ess-use-flymake nil)
+               (ess--command-default-timeout 1)
+               (inferior-R-args "--no-save")
+               (ess-gen-proc-buffer-name-function
+                'ess-gen-proc-buffer-name:project-or-directory)))
+      (should (member pair pairs)))
+    (should
+     (member
+      '(flycheck-lintr-linters
+        "linters_with_defaults(object_name_linter(c('snake_case','camelCase')), commented_code_linter = NULL, line_length_linter(90), single_quotes_linter=NULL)")
+      pairs))
+    (should
+     (member
+      '(ess-R-font-lock-keywords
+        '((ess-R-fl-keyword:modifiers . t)
+          (ess-R-fl-keyword:fun-defs . t)
+          (ess-R-fl-keyword:keywords . t)
+          (ess-R-fl-keyword:assign-ops)
+          (ess-R-fl-keyword:constants . t)
+          (ess-fl-keyword:fun-calls . t)
+          (ess-fl-keyword:numbers . t)
+          (ess-fl-keyword:operators . t)
+          (ess-fl-keyword:delimiters . t)
+          (ess-fl-keyword:= . t)
+          (ess-R-fl-keyword:F&T . t)
+          (ess-R-fl-keyword:%op% . t)))
+      pairs))))
+
+(ert-deftest p3-config-ess-preserves-rmarkdown-compile-hook ()
+  (let ((contents (p3-config-ess-test--contents "lisp/p3-config-ess.el")))
+    (should (string-match-p (regexp-quote "(defun compile-rmd ()") contents))
+    (should
+     (string-match-p
+      (regexp-quote "R -e \"rmarkdown::render('") contents))
+    (should
+     (string-match-p
+      (regexp-quote "(add-hook 'ess-mode-hook 'compile-rmd)") contents))
+    (should
+     (string-match-p
+      (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
+
+(provide 'p3-config-ess-test)
+
+;;; p3-config-ess-test.el ends here

--- a/test/p3-config-ess-test.el
+++ b/test/p3-config-ess-test.el
@@ -167,17 +167,16 @@
       pairs))))
 
 (ert-deftest p3-config-ess-preserves-rmarkdown-compile-hook ()
-  (let ((contents (p3-config-ess-test--contents "lisp/p3-config-ess.el")))
-    (should (string-match-p (regexp-quote "(defun compile-rmd ()") contents))
+  (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
     (should
-     (string-match-p
-      (regexp-quote "R -e \"rmarkdown::render('") contents))
-    (should
-     (string-match-p
-      (regexp-quote "(add-hook 'ess-mode-hook 'compile-rmd)") contents))
-    (should
-     (string-match-p
-      (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
+     (equal
+      (cddddr (p3-config-ess-test--defun-form 'compile-rmd))
+      '((set (make-local-variable 'compile-command)
+             (concat "R -e \"rmarkdown::render('"
+                     buffer-file-name
+                     "')\"")))))
+    (should (member '(add-hook 'ess-mode-hook 'compile-rmd) forms))
+    (should (member '(add-hook 'markdown-mode-hook 'compile-rmd) forms))))
 
 (ert-deftest p3-ess-library-has-no-buffer-configuration-glue ()
   (let ((contents (p3-config-ess-test--contents "lisp/p3-ess.el")))

--- a/test/p3-config-ess-test.el
+++ b/test/p3-config-ess-test.el
@@ -170,11 +170,12 @@
   (let ((forms (p3-config-ess-test--forms "lisp/p3-config-ess.el")))
     (should
      (equal
-      (cddddr (p3-config-ess-test--defun-form 'compile-rmd))
-      '((set (make-local-variable 'compile-command)
-             (concat "R -e \"rmarkdown::render('"
-                     buffer-file-name
-                     "')\"")))))
+      (p3-config-ess-test--defun-form 'compile-rmd)
+      '(defun compile-rmd ()
+         (set (make-local-variable 'compile-command)
+              (concat "R -e \"rmarkdown::render('"
+                      buffer-file-name
+                      "')\"")))))
     (should (member '(add-hook 'ess-mode-hook 'compile-rmd) forms))
     (should (member '(add-hook 'markdown-mode-hook 'compile-rmd) forms))))
 

--- a/test/p3-config-ess-test.el
+++ b/test/p3-config-ess-test.el
@@ -179,6 +179,23 @@
      (string-match-p
       (regexp-quote "(add-hook 'markdown-mode-hook 'compile-rmd)") contents))))
 
+(ert-deftest p3-ess-library-has-no-buffer-configuration-glue ()
+  (let ((contents (p3-config-ess-test--contents "lisp/p3-ess.el")))
+    (dolist (forbidden '("p3/ess-inferior-mode-setup"
+                         "ansi-color-for-comint-mode"
+                         "smartparens-mode"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(ert-deftest p3-generic-completion-has-no-ess-company-owner ()
+  (let ((contents
+         (p3-config-ess-test--contents "lisp/p3-config-completion.el")))
+    (dolist (forbidden '("p3/r-company-backends"
+                         "p3/ess-company-config"
+                         "company-R-library"
+                         "company-R-args"
+                         "company-R-objects"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
 (provide 'p3-config-ess-test)
 
 ;;; p3-config-ess-test.el ends here

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -74,12 +74,15 @@
 (ert-deftest p3-config-org-delegates-custom-subsystems-to-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
     (dolist (module '("p3-platform" "p3-core" "p3-python" "p3-terminal"
-                      "p3-ess" "p3-gptel"))
+                      "p3-gptel"))
       (should (string-match-p (regexp-quote (format "(use-package %s" module))
                               contents)))
-    (dolist (package '("python" "eglot" "ess-r-mode" "vterm" "gptel"))
+    (dolist (package '("python" "eglot" "vterm" "gptel"))
       (should (string-match-p (regexp-quote (format "(use-package %s" package))
                               contents)))
+    (should
+     (string-match-p
+      (regexp-quote "(p3/config-load-module 'p3-config-ess)") contents))
     (dolist (implementation '("(defun p3/windows-rtools-version"
                                "(defun p3/windows-latest-r-program"
                                "(defun p3/project-root"
@@ -102,6 +105,8 @@
                    "(p3/config-load-module 'p3-config-editing)" contents))
          (completion (p3-config-test--position
                       "(p3/config-load-module 'p3-config-completion)" contents))
+         (ess (p3-config-test--position
+               "(p3/config-load-module 'p3-config-ess)" contents))
          (r-program (p3-config-test--position
                      "(p3/windows-configure-r-program)" contents))
          (shell (p3-config-test--position
@@ -112,13 +117,15 @@
     (should (< rtools base))
     (should (< base editing))
     (should (< editing completion))
-    (should (< completion r-program))
+    (should (< completion ess))
+    (should (< ess r-program))
     (should (< r-program shell))))
 
 (ert-deftest p3-config-platform-setup-preserves-subsystem-timing ()
   (let* ((contents (p3-config-test--contents "config.org"))
          (rtools (p3-config-test--position "(p3/windows-configure-rtools)" contents))
-         (ess (p3-config-test--position "(use-package ess-r-mode" contents))
+         (ess (p3-config-test--position
+               "(p3/config-load-module 'p3-config-ess)" contents))
          (r-program (p3-config-test--position
                      "(p3/windows-configure-r-program)" contents))
          (terminal (p3-config-test--position "(use-package p3-terminal" contents))
@@ -132,10 +139,10 @@
     (should (< terminal shell))
     (should (< shell shell-binding))))
 
-(ert-deftest p3-config-org-source-loads-five-config-modules ()
+(ert-deftest p3-config-org-source-loads-six-config-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
     (dolist (module '(p3-config-base p3-config-editing p3-config-completion
-                      p3-config-workspace p3-config-git))
+                      p3-config-ess p3-config-workspace p3-config-git))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -170,7 +177,11 @@
                "(defun p3/consult-r-doc-chapter-search"
                "(defun p3/consult-line-all"
                "(defun p3/ess-company-config"
-               "(defvar p3/r-company-backends"))
+               "(defvar p3/r-company-backends"
+               "(use-package p3-r-tools"
+               "(use-package p3-ess"
+               "(use-package ess-r-mode"
+               "(defun compile-rmd"))
       (should-not (string-match-p (regexp-quote implementation) contents)))
     (dolist (package '(dashboard which-key vertico company undo-tree super-save
                        multiple-cursors magit git-gutter-fringe+ transpose-frame
@@ -178,6 +189,18 @@
       (should-not
        (string-match-p (regexp-quote (format "(use-package %s" package))
                        contents)))))
+
+(ert-deftest p3-config-ess-orchestration-has-one-owner ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (ess (p3-config-test--position
+               "(p3/config-load-module 'p3-config-ess)" contents))
+         (r-program (p3-config-test--position
+                     "(p3/windows-configure-r-program)" contents)))
+    (should-not (string-match-p "(use-package p3-r-tools" contents))
+    (should-not
+     (string-match-p
+      (regexp-quote "(keymap-global-set \"C-c R\"") contents))
+    (should (< ess r-program))))
 
 (ert-deftest p3-config-behavior-library-owner-pattern-is-explicit ()
   (let ((base (p3-config-test--contents "lisp/p3-config-base.el"))


### PR DESCRIPTION
## Summary

- add `p3-config-ess.el` as the declarative ESS/R-mode configuration owner
- keep `p3-ess.el` focused on project/session/process behavior
- keep `p3-r-tools.el` unchanged as the user-facing R workflow library
- move ESS-specific Company backend state out of generic completion
- move inferior ESS buffer setup and `compile-rmd` configuration into the ESS config module
- reduce `config.org` to a short ESS module load while preserving Windows R-program selection timing
- add semantic regression tests for the exact ESS hooks, bindings, Company backend, sensitive settings, font-lock, and setup call

## Behavioral boundaries

- no Company backend redesign and no fix for the existing `company-dabbrev` compatibility error
- no ESS process/session redesign
- no R workflow command changes
- no window-placement changes; the narrow `inferior-ess-r-mode` rule remains untouched
- no Python, Org, terminal, Projectile, or package-manager cleanup

## Verification

The local ChatGPT runtime does not provide Emacs, so executable verification is delegated to the pull-request Actions gates after static source/diff review. Ubuntu byte-compiles the new module with warnings as errors and runs the full ERT suite; Windows runs the existing platform boundary plus the new source-level ESS configuration tests.

Design: `docs/superpowers/specs/2026-09-04-ess-config-boundary-design.md`
Plan: `docs/superpowers/plans/2026-09-04-ess-config-boundary.md`

Do not merge without explicit approval.