### PR TITLE
Spike: visual PPTX editing from Emacs

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -48,8 +48,7 @@ jobs:
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
             lisp/p3-gptel.el \
-            spikes/pptx-editor/p3-pptx-spike.el \
-            spikes/pptx-editor/p3-pptx-spike-fast.el
+            spikes/pptx-editor/p3-pptx-spike.el
 
       - name: Run ERT test suite
         run: |

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           emacs -Q --batch \
             -L lisp \
+            -L spikes/pptx-editor \
             --eval '(require (quote use-package-ensure))' \
             --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
             --eval '(setq byte-compile-error-on-warn t)' \
@@ -54,6 +55,7 @@ jobs:
         run: |
           emacs -Q --batch \
             -L lisp \
+            -L spikes/pptx-editor \
             -l test/p3-config-loader-test.el \
             -l test/p3-config-test.el \
             -l test/p3-config-ess-test.el \

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -65,6 +65,7 @@ jobs:
             -l test/p3-gptel-test.el \
             -l test/p3-r-tools-test.el \
             -l test/p3-org-export-test.el \
+            -l test/p3-pptx-spike-test.el \
             -l test/p3-commands-test.el \
             -l test/p3-git-test.el \
             -f ert-run-tests-batch-and-exit

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -47,7 +47,8 @@ jobs:
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
             lisp/p3-gptel.el \
-            spikes/pptx-editor/p3-pptx-spike.el
+            spikes/pptx-editor/p3-pptx-spike.el \
+            spikes/pptx-editor/p3-pptx-spike-fast.el
 
       - name: Run ERT test suite
         run: |

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -46,7 +46,8 @@ jobs:
             lisp/p3-terminal.el \
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
-            lisp/p3-gptel.el
+            lisp/p3-gptel.el \
+            spikes/pptx-editor/p3-pptx-spike.el
 
       - name: Run ERT test suite
         run: |

--- a/spikes/pptx-editor/README.md
+++ b/spikes/pptx-editor/README.md
@@ -1,0 +1,51 @@
+# PPTX visual editor spike
+
+This is a throwaway feasibility spike, not a supported part of the Emacs configuration yet.
+
+The goal is deliberately narrow: open an existing PPTX, render a real slide inside Emacs, select ordinary top-level slide objects, move them with the mouse or arrow keys, and save a revised PPTX without rewriting the rest of the Office package.
+
+## Why the bridge patches OOXML directly
+
+A first prototype used `python-pptx` to save a modified deck. Although the rendered result was correct, that save rewrote many untouched package parts, including chart, master, and layout XML. That is too risky for arbitrary decks received from other people.
+
+The bridge here instead reads PPTX geometry and changes only the target shape's `<a:off>` geometry in the target `ppt/slides/slideN.xml` member. Every other ZIP member is copied byte-for-byte.
+
+The proof test used a deck containing text, an embedded raster image, a native chart object, and other shapes, then passed it through LibreOffice before editing. Moving the picture changed only `ppt/slides/slide1.xml`; all other package members were byte-identical. A before/after LibreOffice render changed only the region occupied by the moved picture.
+
+## Requirements
+
+- Emacs with SVG image support
+- Python 3 (stdlib only; no `python-pptx` dependency)
+- LibreOffice / `soffice`
+- Poppler `pdftoppm`
+
+## Try it
+
+From this branch, evaluate:
+
+```elisp
+(load-file "~/path/to/dotfiles/spikes/pptx-editor/p3-pptx-spike.el")
+```
+
+Then run:
+
+```text
+M-x p3/pptx-spike-open
+```
+
+Choose a `.pptx` and slide number. The command makes a disposable working copy; it never edits the source file directly.
+
+Controls:
+
+- click: select a shape
+- drag: move a shape and rerender the actual PPTX
+- arrow keys: nudge the selected shape by 0.05 inch
+- `g`: rerender
+- `s`: save the edited working copy as a new PPTX
+- `q`: quit and delete the temporary working directory
+
+## Scope of this spike
+
+Recognized top-level object types are ordinary shapes/text boxes (`sp`), pictures (`pic`), charts and other graphic frames (`graphicFrame`), and connectors (`cxnSp`). The spike does not attempt to edit SmartArt internals, grouped-object internals, animations, embedded Office objects, or arbitrary PowerPoint behavior.
+
+The Python bridge has been exercised against LibreOffice in the spike environment. The Emacs file is included in the repository's byte-compile gate on this branch so the PR can validate it with a real Emacs runtime before this experiment is promoted further.

--- a/spikes/pptx-editor/p3-pptx-spike-fast.el
+++ b/spikes/pptx-editor/p3-pptx-spike-fast.el
@@ -1,0 +1,434 @@
+;;; p3-pptx-spike-fast.el --- Nonblocking interaction layer for PPTX spike -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'dom)
+(require 'seq)
+(require 'svg)
+
+(defconst p3-pptx-spike-fast--module-directory
+  (file-name-directory
+   (or load-file-name byte-compile-current-file buffer-file-name default-directory)))
+
+(add-to-list 'load-path p3-pptx-spike-fast--module-directory)
+(require 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-persist-delay 0.20
+  "Seconds of editing idle time before persisting geometry to the working PPTX."
+  :type 'number
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-preview-frame-rate 30.0
+  "Maximum live-preview redraw rate in frames per second."
+  :type 'number
+  :group 'p3-pptx-spike)
+
+(defvar-local p3-pptx-spike--pending-edits nil)
+(defvar-local p3-pptx-spike--persist-timer nil)
+(defvar-local p3-pptx-spike--persist-process nil)
+(defvar-local p3-pptx-spike--persist-error nil)
+(defvar-local p3-pptx-spike--preview-timer nil)
+(defvar-local p3-pptx-spike--preview-last-draw nil)
+
+(defalias 'p3-pptx-spike-fast--original-start-render
+  (symbol-function 'p3-pptx-spike--start-render))
+(defalias 'p3-pptx-spike-fast--original-cancel-background-work
+  (symbol-function 'p3-pptx-spike--cancel-background-work))
+
+(defun p3-pptx-spike--ensure-fast-state ()
+  "Initialize buffer-local state used by the nonblocking interaction layer."
+  (unless (hash-table-p p3-pptx-spike--pending-edits)
+    (setq p3-pptx-spike--pending-edits (make-hash-table :test #'eql))))
+
+(defun p3-pptx-spike--pending-count ()
+  "Return the number of shapes with unpersisted geometry edits."
+  (p3-pptx-spike--ensure-fast-state)
+  (hash-table-count p3-pptx-spike--pending-edits))
+
+(defun p3-pptx-spike--accumulate-pending (shape-id dx dy &optional dw dh)
+  "Accumulate SHAPE-ID geometry delta DX/DY and optional DW/DH in memory."
+  (p3-pptx-spike--ensure-fast-state)
+  (let ((current (gethash shape-id p3-pptx-spike--pending-edits)))
+    (puthash
+     shape-id
+     (list :dx (+ (or (plist-get current :dx) 0.0) dx)
+           :dy (+ (or (plist-get current :dy) 0.0) dy)
+           :dw (+ (or (plist-get current :dw) 0.0) (or dw 0.0))
+           :dh (+ (or (plist-get current :dh) 0.0) (or dh 0.0)))
+     p3-pptx-spike--pending-edits)))
+
+(defun p3-pptx-spike--preview-timer-fire (buffer)
+  "Redraw BUFFER once when a coalesced preview timer fires."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq p3-pptx-spike--preview-timer nil
+            p3-pptx-spike--preview-last-draw (float-time))
+      (p3-pptx-spike--redisplay))))
+
+(defun p3-pptx-spike--request-preview (&optional force)
+  "Request a live preview redraw, capped by the configured frame rate.
+With FORCE, redraw immediately."
+  (let* ((now (float-time))
+         (interval (/ 1.0 (max 1.0 p3-pptx-spike-preview-frame-rate)))
+         (last (or p3-pptx-spike--preview-last-draw 0.0))
+         (elapsed (- now last)))
+    (cond
+     ((or force (>= elapsed interval))
+      (when (timerp p3-pptx-spike--preview-timer)
+        (cancel-timer p3-pptx-spike--preview-timer)
+        (setq p3-pptx-spike--preview-timer nil))
+      (setq p3-pptx-spike--preview-last-draw now)
+      (p3-pptx-spike--redisplay))
+     ((not (timerp p3-pptx-spike--preview-timer))
+      (setq p3-pptx-spike--preview-timer
+            (run-with-timer
+             (max 0.001 (- interval elapsed)) nil
+             #'p3-pptx-spike--preview-timer-fire (current-buffer)))))))
+
+(defun p3-pptx-spike--commit-edit (dx dy &optional dw dh model-already-updated)
+  "Apply selected-shape DX/DY and optional DW/DH to the live model only.
+The resulting delta is queued for asynchronous persistence.  When
+MODEL-ALREADY-UPDATED is non-nil, the live model is not changed again."
+  (unless p3-pptx-spike--selected-id
+    (user-error "No PPTX shape is selected"))
+  (let ((shape (p3-pptx-spike--shape-by-id p3-pptx-spike--selected-id)))
+    (unless shape
+      (user-error "Selected PPTX shape no longer exists"))
+    (unless model-already-updated
+      (setf (alist-get 'left shape) (+ (p3-pptx-spike--get 'left shape) dx)
+            (alist-get 'top shape) (+ (p3-pptx-spike--get 'top shape) dy)
+            (alist-get 'width shape)
+            (+ (p3-pptx-spike--get 'width shape) (or dw 0.0))
+            (alist-get 'height shape)
+            (+ (p3-pptx-spike--get 'height shape) (or dh 0.0))))
+    (p3-pptx-spike--accumulate-pending
+     p3-pptx-spike--selected-id dx dy dw dh)
+    (setq p3-pptx-spike--edit-generation
+          (1+ p3-pptx-spike--edit-generation))
+    (p3-pptx-spike--request-preview)
+    (p3-pptx-spike--schedule-persist)))
+
+(defun p3-pptx-spike--edit (dx dy &optional dw dh)
+  "Preview selected-shape DX/DY and optional DW/DH without process or file I/O."
+  (p3-pptx-spike--commit-edit dx dy dw dh nil))
+
+(defun p3-pptx-spike--persist-command (shape-id edit)
+  "Return an asynchronous bridge command for SHAPE-ID and accumulated EDIT."
+  (unless (file-readable-p p3-pptx-spike-bridge)
+    (user-error "PPTX bridge is not readable: %s" p3-pptx-spike-bridge))
+  (list (p3-pptx-spike--program p3-pptx-spike-python "Python")
+        p3-pptx-spike-bridge
+        "edit" p3-pptx-spike--working
+        "--slide" (number-to-string p3-pptx-spike--slide)
+        "--shape-id" (number-to-string shape-id)
+        "--dx" (number-to-string (plist-get edit :dx))
+        "--dy" (number-to-string (plist-get edit :dy))
+        "--dw" (number-to-string (plist-get edit :dw))
+        "--dh" (number-to-string (plist-get edit :dh))))
+
+(defun p3-pptx-spike--take-pending-edit ()
+  "Remove and return one pending edit as (SHAPE-ID . EDIT), or nil."
+  (p3-pptx-spike--ensure-fast-state)
+  (let (item)
+    (maphash
+     (lambda (shape-id edit)
+       (unless item
+         (setq item (cons shape-id edit))))
+     p3-pptx-spike--pending-edits)
+    (when item
+      (remhash (car item) p3-pptx-spike--pending-edits))
+    item))
+
+(defun p3-pptx-spike--persist-timer-fire (buffer)
+  "Begin deferred persistence for BUFFER when its idle timer fires."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq p3-pptx-spike--persist-timer nil)
+      (p3-pptx-spike--start-persist))))
+
+(defun p3-pptx-spike--schedule-persist (&optional delay)
+  "Debounce persistence of accumulated edits by DELAY seconds."
+  (when (timerp p3-pptx-spike--persist-timer)
+    (cancel-timer p3-pptx-spike--persist-timer))
+  (setq p3-pptx-spike--persist-timer
+        (run-with-timer
+         (or delay p3-pptx-spike-persist-delay) nil
+         #'p3-pptx-spike--persist-timer-fire (current-buffer))))
+
+(defun p3-pptx-spike--persist-sentinel (process _event)
+  "Continue the persistence queue when PROCESS finishes."
+  (when (memq (process-status process) '(exit signal))
+    (let ((editor (process-get process 'editor-buffer))
+          (shape-id (process-get process 'shape-id))
+          (edit (process-get process 'edit))
+          (process-buffer (process-buffer process))
+          (status (process-exit-status process)))
+      (when (buffer-live-p editor)
+        (with-current-buffer editor
+          (when (eq process p3-pptx-spike--persist-process)
+            (setq p3-pptx-spike--persist-process nil))
+          (if (= status 0)
+              (progn
+                (setq p3-pptx-spike--persist-error nil)
+                (if (> (p3-pptx-spike--pending-count) 0)
+                    (p3-pptx-spike--start-persist)
+                  (p3-pptx-spike--schedule-render 0.0)))
+            (p3-pptx-spike--accumulate-pending
+             shape-id
+             (plist-get edit :dx) (plist-get edit :dy)
+             (plist-get edit :dw) (plist-get edit :dh))
+            (setq p3-pptx-spike--persist-error
+                  (when (buffer-live-p process-buffer)
+                    (with-current-buffer process-buffer
+                      (string-trim (buffer-string)))))
+            (message "PPTX persistence failed: %s"
+                     (or p3-pptx-spike--persist-error
+                         (format "status %s" status))))))
+      (when (buffer-live-p process-buffer)
+        (kill-buffer process-buffer)))))
+
+(defun p3-pptx-spike--start-persist ()
+  "Start one asynchronous persistence operation if one is needed."
+  (p3-pptx-spike--ensure-fast-state)
+  (unless (and p3-pptx-spike--persist-process
+               (process-live-p p3-pptx-spike--persist-process))
+    (when-let ((item (p3-pptx-spike--take-pending-edit)))
+      (let* ((shape-id (car item))
+             (edit (cdr item))
+             (process-buffer (generate-new-buffer " *p3-pptx-persist*"))
+             (process
+              (make-process
+               :name (format "p3-pptx-persist-%s" shape-id)
+               :buffer process-buffer
+               :command (p3-pptx-spike--persist-command shape-id edit)
+               :connection-type 'pipe
+               :noquery t
+               :sentinel nil)))
+        (process-put process 'editor-buffer (current-buffer))
+        (process-put process 'shape-id shape-id)
+        (process-put process 'edit edit)
+        (setq p3-pptx-spike--persist-process process)
+        (set-process-sentinel process #'p3-pptx-spike--persist-sentinel)))))
+
+(defun p3-pptx-spike--persistence-busy-p ()
+  "Return non-nil when memory edits have not fully reached the working PPTX."
+  (or (> (p3-pptx-spike--pending-count) 0)
+      (and p3-pptx-spike--persist-process
+           (process-live-p p3-pptx-spike--persist-process))))
+
+(defun p3-pptx-spike--start-render ()
+  "Start fidelity rendering only after all queued geometry has been persisted."
+  (if (p3-pptx-spike--persistence-busy-p)
+      (p3-pptx-spike--schedule-persist 0.0)
+    (p3-pptx-spike-fast--original-start-render)))
+
+(defun p3-pptx-spike--flush-persistence ()
+  "Synchronously drain pending persistence for explicit save operations only."
+  (when (timerp p3-pptx-spike--persist-timer)
+    (cancel-timer p3-pptx-spike--persist-timer)
+    (setq p3-pptx-spike--persist-timer nil))
+  (setq p3-pptx-spike--persist-error nil)
+  (let ((iterations 0))
+    (while (and (< iterations 100)
+                (or (p3-pptx-spike--persistence-busy-p)
+                    (> (p3-pptx-spike--pending-count) 0)))
+      (setq iterations (1+ iterations))
+      (unless (and p3-pptx-spike--persist-process
+                   (process-live-p p3-pptx-spike--persist-process))
+        (p3-pptx-spike--start-persist))
+      (when (and p3-pptx-spike--persist-process
+                 (process-live-p p3-pptx-spike--persist-process))
+        (accept-process-output p3-pptx-spike--persist-process 0.1))
+      (when p3-pptx-spike--persist-error
+        (user-error "PPTX persistence failed: %s" p3-pptx-spike--persist-error)))
+    (when (p3-pptx-spike--persistence-busy-p)
+      (user-error "PPTX persistence did not finish"))))
+
+(defun p3-pptx-spike--canvas-image-map ()
+  "Return one whole-canvas image map used for mouse selection and dragging."
+  (pcase-let ((`(,width . ,height) (p3-pptx-spike--canvas-size)))
+    (list
+     (list (cons 'rect (cons (cons 0 0) (cons width height)))
+           'pptx-canvas
+           (list 'help-echo "PPTX slide canvas" 'pointer 'hand)))))
+
+(defun p3-pptx-spike--draw-fast-preview-ghost (svg shape width height normal)
+  "Draw SHAPE from the existing raster by reusing its single SVG image node."
+  (when-let* ((render-model p3-pptx-spike--render-model)
+              (render-shape
+               (p3-pptx-spike--shape-by-id
+                (p3-pptx-spike--get 'id shape) render-model)))
+    (pcase-let* ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape))
+                 (`(,old-x ,old-y ,old-w ,old-h)
+                  (p3-pptx-spike--shape-rect-in-model render-shape render-model))
+                 (dx (- x old-x))
+                 (dy (- y old-y)))
+      (unless (and (= dx 0) (= dy 0) (= w old-w) (= h old-h))
+        (let* ((clip-id (format "pptx-preview-%s" (p3-pptx-spike--get 'id shape)))
+               (clip (svg-clip-path svg :id clip-id)))
+          (svg-rectangle clip x y w h)
+          (svg-use svg "pptx-slide-raster"
+                   :x dx :y dy
+                   :clip-path (format "url(#%s)" clip-id)
+                   :opacity 0.78)
+          (svg-rectangle svg old-x old-y old-w old-h
+                         :fill-color "none"
+                         :stroke-color normal
+                         :stroke-width 1
+                         :stroke-dasharray "6 4"))))))
+
+(defun p3-pptx-spike--redisplay ()
+  "Redraw using an external raster reference instead of base64-embedding PNG data."
+  (let* ((inhibit-read-only t)
+         (size (p3-pptx-spike--canvas-size))
+         (width (car size))
+         (height (cdr size))
+         (svg (svg-create width height))
+         (normal (face-foreground 'shadow nil t))
+         (selected (face-foreground 'font-lock-keyword-face nil t))
+         (base-uri (expand-file-name "canvas.svg" p3-pptx-spike--temp-directory))
+         (render-name (file-name-nondirectory p3-pptx-spike--render-file)))
+    (erase-buffer)
+    (svg-embed-base-uri-image
+     svg render-name
+     :id "pptx-slide-raster"
+     :x 0 :y 0 :width width :height height)
+    (dolist (shape (p3-pptx-spike--get 'shapes p3-pptx-spike--model))
+      (p3-pptx-spike--draw-fast-preview-ghost svg shape width height normal))
+    (dolist (shape (p3-pptx-spike--get 'shapes p3-pptx-spike--model))
+      (pcase-let ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape)))
+        (svg-rectangle
+         svg x y w h
+         :fill-color "none"
+         :stroke-color
+         (if (equal (p3-pptx-spike--get 'id shape) p3-pptx-spike--selected-id)
+             selected normal)
+         :stroke-width
+         (if (equal (p3-pptx-spike--get 'id shape) p3-pptx-spike--selected-id)
+             3 1))))
+    (insert-image
+     (svg-image svg
+                :scale 1.0
+                :base-uri base-uri
+                :map (p3-pptx-spike--canvas-image-map)))
+    (insert (format "\n\nSlide %d  |  selected: %s"
+                    p3-pptx-spike--slide
+                    (p3-pptx-spike--selection-label)))
+    (when p3-pptx-spike--drag-delta
+      (insert (format "  |  drag Δx %+.2f Δy %+.2f in"
+                      (car p3-pptx-spike--drag-delta)
+                      (cdr p3-pptx-spike--drag-delta))))
+    (when (> (p3-pptx-spike--pending-count) 0)
+      (insert (format "  |  %d pending" (p3-pptx-spike--pending-count))))
+    (insert "\nInteraction is memory-only; PPTX persistence and fidelity rendering happen after editing pauses.  s saves; g refreshes; q quits.\n")
+    (goto-char (point-min))))
+
+(defun p3-pptx-spike-select-mouse (event)
+  "Select the PPTX shape under mouse EVENT without rebuilding shape image maps."
+  (interactive "e")
+  (pcase-let* ((`(,x . ,y) (p3-pptx-spike--event-xy (event-start event)))
+               (shape (p3-pptx-spike--shape-at x y)))
+    (when shape
+      (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
+      (p3-pptx-spike--request-preview t))))
+
+(defun p3-pptx-spike-drag-mouse (event)
+  "Track EVENT in memory, coalescing redraws and persisting only after release."
+  (interactive "e")
+  (pcase-let* ((`(,x0 . ,y0) (p3-pptx-spike--event-xy (event-start event)))
+               (shape (p3-pptx-spike--shape-at x0 y0)))
+    (unless shape
+      (user-error "No editable PPTX shape at drag start"))
+    (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
+    (let ((left0 (p3-pptx-spike--get 'left shape))
+          (top0 (p3-pptx-spike--get 'top shape))
+          (dx 0.0)
+          (dy 0.0)
+          (finished nil)
+          (cancelled nil))
+      (p3-pptx-spike--request-preview t)
+      (track-mouse
+        (while (not finished)
+          (let ((next (read-event)))
+            (cond
+             ((mouse-movement-p next)
+              (when-let ((xy (p3-pptx-spike--event-xy-safe (event-start next))))
+                (pcase-let ((`(,next-x . ,next-y) xy))
+                  (pcase-let ((`(,next-dx . ,next-dy)
+                               (p3-pptx-spike--slide-delta x0 y0 next-x next-y)))
+                    (setq dx next-dx
+                          dy next-dy
+                          p3-pptx-spike--drag-delta (cons dx dy))
+                    (p3-pptx-spike--set-shape-position
+                     shape (+ left0 dx) (+ top0 dy))
+                    (p3-pptx-spike--request-preview)))))
+             ((eq (event-basic-type next) 'mouse-1)
+              (when-let ((xy (p3-pptx-spike--event-xy-safe (event-end next))))
+                (pcase-let ((`(,end-x . ,end-y) xy))
+                  (pcase-let ((`(,end-dx . ,end-dy)
+                               (p3-pptx-spike--slide-delta x0 y0 end-x end-y)))
+                    (setq dx end-dx dy end-dy)
+                    (p3-pptx-spike--set-shape-position
+                     shape (+ left0 dx) (+ top0 dy)))))
+              (setq finished t))
+             (t
+              (setq cancelled t
+                    finished t
+                    unread-command-events
+                    (append unread-command-events (list next))))))))
+      (setq p3-pptx-spike--drag-delta nil)
+      (cond
+       (cancelled
+        (p3-pptx-spike--set-shape-position shape left0 top0)
+        (p3-pptx-spike--request-preview t))
+       ((and (= dx 0.0) (= dy 0.0))
+        (p3-pptx-spike--request-preview t))
+       (t
+        (p3-pptx-spike--commit-edit dx dy nil nil t)
+        (p3-pptx-spike--request-preview t))))))
+
+(defun p3-pptx-spike-save-as (output)
+  "Persist queued geometry, then save the edited working PPTX as OUTPUT."
+  (interactive
+   (list (read-file-name "Save edited PPTX as: "
+                         (file-name-directory p3-pptx-spike--source)
+                         nil nil
+                         (concat (file-name-base p3-pptx-spike--source)
+                                 "-edited.pptx"))))
+  (p3-pptx-spike--flush-persistence)
+  (copy-file p3-pptx-spike--working output t)
+  (message "Saved edited PPTX to %s" output))
+
+(defun p3-pptx-spike-refresh ()
+  "Persist queued edits and request fidelity rendering without blocking interaction."
+  (interactive)
+  (if (p3-pptx-spike--persistence-busy-p)
+      (p3-pptx-spike--schedule-persist 0.0)
+    (p3-pptx-spike--schedule-render 0.0))
+  (message "PPTX fidelity refresh queued"))
+
+(defun p3-pptx-spike--cancel-background-work ()
+  "Cancel preview, persistence, and fidelity-render background work."
+  (p3-pptx-spike-fast--original-cancel-background-work)
+  (when (timerp p3-pptx-spike--preview-timer)
+    (cancel-timer p3-pptx-spike--preview-timer)
+    (setq p3-pptx-spike--preview-timer nil))
+  (when (timerp p3-pptx-spike--persist-timer)
+    (cancel-timer p3-pptx-spike--persist-timer)
+    (setq p3-pptx-spike--persist-timer nil))
+  (when (and p3-pptx-spike--persist-process
+             (process-live-p p3-pptx-spike--persist-process))
+    (let ((process-buffer (process-buffer p3-pptx-spike--persist-process)))
+      (set-process-sentinel p3-pptx-spike--persist-process #'ignore)
+      (delete-process p3-pptx-spike--persist-process)
+      (when (buffer-live-p process-buffer)
+        (kill-buffer process-buffer))))
+  (setq p3-pptx-spike--persist-process nil))
+
+(define-key p3-pptx-spike-mode-map [pptx-canvas mouse-1]
+            #'p3-pptx-spike-select-mouse)
+(define-key p3-pptx-spike-mode-map [pptx-canvas down-mouse-1]
+            #'p3-pptx-spike-drag-mouse)
+
+(provide 'p3-pptx-spike-fast)
+
+;;; p3-pptx-spike-fast.el ends here

--- a/spikes/pptx-editor/p3-pptx-spike.el
+++ b/spikes/pptx-editor/p3-pptx-spike.el
@@ -1,0 +1,306 @@
+;;; p3-pptx-spike.el --- Throwaway PPTX visual-layout feasibility spike -*- lexical-binding: t; -*-
+
+;; This is intentionally a spike, not a supported package.  It edits a working
+;; copy of a PPTX by patching only one slide XML member, then renders that real
+;; PPTX through LibreOffice for display in Emacs.
+
+(require 'json)
+(require 'svg)
+(require 'subr-x)
+
+(defgroup p3-pptx-spike nil
+  "Feasibility spike for visually positioning PPTX shapes from Emacs."
+  :group 'applications)
+
+(defconst p3-pptx-spike--module-directory
+  (file-name-directory (or load-file-name buffer-file-name default-directory)))
+
+(defcustom p3-pptx-spike-python "python3"
+  "Python executable used by the spike."
+  :type 'string
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-soffice "libreoffice"
+  "LibreOffice/soffice executable used to render PPTX files."
+  :type 'string
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-pdftoppm "pdftoppm"
+  "pdftoppm executable used to rasterize one rendered slide."
+  :type 'string
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-bridge
+  (expand-file-name "pptx_bridge.py" p3-pptx-spike--module-directory)
+  "Path to the Python OOXML bridge used by this spike."
+  :type 'file
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-canvas-width 1100
+  "Width in pixels of the slide canvas displayed in Emacs."
+  :type 'integer
+  :group 'p3-pptx-spike)
+
+(defcustom p3-pptx-spike-nudge 0.05
+  "Keyboard nudge distance in inches."
+  :type 'number
+  :group 'p3-pptx-spike)
+
+(defvar-local p3-pptx-spike--source nil)
+(defvar-local p3-pptx-spike--working nil)
+(defvar-local p3-pptx-spike--temp-directory nil)
+(defvar-local p3-pptx-spike--slide 1)
+(defvar-local p3-pptx-spike--model nil)
+(defvar-local p3-pptx-spike--selected-id nil)
+(defvar-local p3-pptx-spike--render-file nil)
+
+(defun p3-pptx-spike--program (program label)
+  "Return executable PROGRAM or signal a user error mentioning LABEL."
+  (or (executable-find program)
+      (user-error "%s executable not found: %s" label program)))
+
+(defun p3-pptx-spike--run (&rest args)
+  "Run the bridge with ARGS and return stdout as a string."
+  (unless (file-readable-p p3-pptx-spike-bridge)
+    (user-error "PPTX bridge is not readable: %s" p3-pptx-spike-bridge))
+  (let ((python (p3-pptx-spike--program p3-pptx-spike-python "Python")))
+    (with-temp-buffer
+      (let ((status (apply #'process-file python nil (current-buffer) nil
+                           p3-pptx-spike-bridge args)))
+        (unless (and (integerp status) (zerop status))
+          (user-error "PPTX bridge failed: %s" (string-trim (buffer-string))))
+        (buffer-string)))))
+
+(defun p3-pptx-spike--inspect ()
+  "Refresh the in-memory geometry model for the working deck."
+  (setq p3-pptx-spike--model
+        (json-parse-string
+         (p3-pptx-spike--run
+          "inspect" p3-pptx-spike--working
+          "--slide" (number-to-string p3-pptx-spike--slide))
+         :object-type 'alist :array-type 'list
+         :null-object nil :false-object nil)))
+
+(defun p3-pptx-spike--render ()
+  "Render the current real PPTX slide to PNG and refresh geometry."
+  (p3-pptx-spike--program p3-pptx-spike-soffice "LibreOffice")
+  (p3-pptx-spike--program p3-pptx-spike-pdftoppm "pdftoppm")
+  (p3-pptx-spike--run
+   "render" p3-pptx-spike--working p3-pptx-spike--render-file
+   "--slide" (number-to-string p3-pptx-spike--slide)
+   "--soffice" p3-pptx-spike-soffice
+   "--pdftoppm" p3-pptx-spike-pdftoppm)
+  (p3-pptx-spike--inspect)
+  (p3-pptx-spike--redisplay))
+
+(defun p3-pptx-spike--get (key object)
+  "Return KEY from JSON alist OBJECT."
+  (alist-get key object))
+
+(defun p3-pptx-spike--canvas-size ()
+  "Return displayed canvas size as (WIDTH . HEIGHT)."
+  (let* ((slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
+         (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model))
+         (width p3-pptx-spike-canvas-width))
+    (cons width (round (* width (/ slide-height slide-width))))))
+
+(defun p3-pptx-spike--shape-rect (shape)
+  "Return SHAPE rectangle in displayed canvas pixels."
+  (pcase-let* ((`(,canvas-width . ,canvas-height) (p3-pptx-spike--canvas-size))
+               (slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
+               (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model))
+               (sx (/ canvas-width slide-width))
+               (sy (/ canvas-height slide-height))
+               (x (round (* sx (p3-pptx-spike--get 'left shape))))
+               (y (round (* sy (p3-pptx-spike--get 'top shape))))
+               (w (round (* sx (p3-pptx-spike--get 'width shape))))
+               (h (round (* sy (p3-pptx-spike--get 'height shape)))))
+    (list x y w h)))
+
+(defun p3-pptx-spike--shape-at (x y)
+  "Return top-most editable shape at canvas coordinates X Y."
+  (seq-find
+   (lambda (shape)
+     (pcase-let ((`(,sx ,sy ,sw ,sh) (p3-pptx-spike--shape-rect shape)))
+       (and (<= sx x (+ sx sw)) (<= sy y (+ sy sh)))))
+   (reverse (p3-pptx-spike--get 'shapes p3-pptx-spike--model))))
+
+(defun p3-pptx-spike--image-map ()
+  "Build one Emacs image-map hotspot per editable shape."
+  (mapcar
+   (lambda (shape)
+     (pcase-let* ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape))
+                  (name (p3-pptx-spike--get 'name shape)))
+       (list (cons 'rect (cons (cons x y) (cons (+ x w) (+ y h))))
+             'pptx-shape
+             (list 'help-echo (if (string-empty-p name) "PPTX shape" name)
+                   'pointer 'hand))))
+   (p3-pptx-spike--get 'shapes p3-pptx-spike--model)))
+
+(defun p3-pptx-spike--selection-label ()
+  "Return a short label for the current selection."
+  (if-let ((shape (seq-find
+                   (lambda (item)
+                     (= (p3-pptx-spike--get 'id item) p3-pptx-spike--selected-id))
+                   (p3-pptx-spike--get 'shapes p3-pptx-spike--model))))
+      (format "%s (#%s)"
+              (or (p3-pptx-spike--get 'name shape) "shape")
+              p3-pptx-spike--selected-id)
+    "none"))
+
+(defun p3-pptx-spike--redisplay ()
+  "Redraw the rendered slide plus editable bounding boxes."
+  (let* ((inhibit-read-only t)
+         (size (p3-pptx-spike--canvas-size))
+         (width (car size))
+         (height (cdr size))
+         (svg (svg-create width height))
+         (normal (face-foreground 'shadow nil t))
+         (selected (face-foreground 'font-lock-keyword-face nil t)))
+    (erase-buffer)
+    (svg-embed svg p3-pptx-spike--render-file "image/png" nil
+               :x 0 :y 0 :width width :height height)
+    (dolist (shape (p3-pptx-spike--get 'shapes p3-pptx-spike--model))
+      (pcase-let ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape)))
+        (svg-rectangle
+         svg x y w h
+         :fill-color "none"
+         :stroke-color (if (equal (p3-pptx-spike--get 'id shape)
+                                  p3-pptx-spike--selected-id)
+                           selected normal)
+         :stroke-width (if (equal (p3-pptx-spike--get 'id shape)
+                                  p3-pptx-spike--selected-id)
+                           3 1))))
+    (insert-image
+     (svg-image svg :scale 1.0 :map (p3-pptx-spike--image-map)))
+    (insert (format "\n\nSlide %d  |  selected: %s\n"
+                    p3-pptx-spike--slide (p3-pptx-spike--selection-label)))
+    (insert "Drag a shape to move it. Arrow keys nudge the selected shape.  s saves a copy; g rerenders; q quits.\n")
+    (goto-char (point-min))))
+
+(defun p3-pptx-spike--event-xy (position)
+  "Return image-relative pixel coordinates for mouse POSITION."
+  (or (posn-object-x-y position)
+      (user-error "Mouse event is not over the slide image")))
+
+(defun p3-pptx-spike-select-mouse (event)
+  "Select the PPTX shape under mouse EVENT."
+  (interactive "e")
+  (pcase-let* ((`(,x . ,y) (p3-pptx-spike--event-xy (event-start event)))
+               (shape (p3-pptx-spike--shape-at x y)))
+    (when shape
+      (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
+      (p3-pptx-spike--redisplay))))
+
+(defun p3-pptx-spike-drag-mouse (event)
+  "Move the PPTX shape dragged by mouse EVENT, then rerender the real deck."
+  (interactive "e")
+  (pcase-let* ((start (p3-pptx-spike--event-xy (event-start event)))
+               (end (p3-pptx-spike--event-xy (event-end event)))
+               (`(,x0 . ,y0) start)
+               (`(,x1 . ,y1) end)
+               (shape (p3-pptx-spike--shape-at x0 y0))
+               (canvas (p3-pptx-spike--canvas-size))
+               (slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
+               (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model)))
+    (unless shape
+      (user-error "No editable PPTX shape at drag start"))
+    (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
+    (p3-pptx-spike--edit
+     (* (- x1 x0) (/ slide-width (car canvas)))
+     (* (- y1 y0) (/ slide-height (cdr canvas))))))
+
+(defun p3-pptx-spike--edit (dx dy &optional dw dh)
+  "Patch selected shape by DX/DY and optional DW/DH inches, then rerender."
+  (unless p3-pptx-spike--selected-id
+    (user-error "No PPTX shape is selected"))
+  (p3-pptx-spike--run
+   "edit" p3-pptx-spike--working
+   "--slide" (number-to-string p3-pptx-spike--slide)
+   "--shape-id" (number-to-string p3-pptx-spike--selected-id)
+   "--dx" (number-to-string dx)
+   "--dy" (number-to-string dy)
+   "--dw" (number-to-string (or dw 0.0))
+   "--dh" (number-to-string (or dh 0.0)))
+  (p3-pptx-spike--render))
+
+(defun p3-pptx-spike-nudge-left () (interactive) (p3-pptx-spike--edit (- p3-pptx-spike-nudge) 0))
+(defun p3-pptx-spike-nudge-right () (interactive) (p3-pptx-spike--edit p3-pptx-spike-nudge 0))
+(defun p3-pptx-spike-nudge-up () (interactive) (p3-pptx-spike--edit 0 (- p3-pptx-spike-nudge)))
+(defun p3-pptx-spike-nudge-down () (interactive) (p3-pptx-spike--edit 0 p3-pptx-spike-nudge))
+
+(defun p3-pptx-spike-save-as (output)
+  "Save the edited working PPTX as OUTPUT without modifying the source file."
+  (interactive
+   (list (read-file-name "Save edited PPTX as: "
+                         (file-name-directory p3-pptx-spike--source)
+                         nil nil
+                         (concat (file-name-base p3-pptx-spike--source)
+                                 "-edited.pptx"))))
+  (copy-file p3-pptx-spike--working output t)
+  (message "Saved edited PPTX to %s" output))
+
+(defun p3-pptx-spike-refresh ()
+  "Rerender the current working deck."
+  (interactive)
+  (p3-pptx-spike--render))
+
+(defun p3-pptx-spike-quit ()
+  "Kill the spike buffer and its disposable working directory."
+  (interactive)
+  (let ((directory p3-pptx-spike--temp-directory))
+    (kill-buffer (current-buffer))
+    (when (and directory (file-directory-p directory))
+      (delete-directory directory t))))
+
+(defvar p3-pptx-spike-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "<left>") #'p3-pptx-spike-nudge-left)
+    (define-key map (kbd "<right>") #'p3-pptx-spike-nudge-right)
+    (define-key map (kbd "<up>") #'p3-pptx-spike-nudge-up)
+    (define-key map (kbd "<down>") #'p3-pptx-spike-nudge-down)
+    (define-key map (kbd "g") #'p3-pptx-spike-refresh)
+    (define-key map (kbd "s") #'p3-pptx-spike-save-as)
+    (define-key map (kbd "q") #'p3-pptx-spike-quit)
+    (define-key map [pptx-shape mouse-1] #'p3-pptx-spike-select-mouse)
+    (define-key map [pptx-shape drag-mouse-1] #'p3-pptx-spike-drag-mouse)
+    map)
+  "Keymap for `p3-pptx-spike-mode'.")
+
+(define-derived-mode p3-pptx-spike-mode special-mode "PPTX-Spike"
+  "Throwaway visual positioning mode for real PPTX shapes."
+  (setq-local truncate-lines t))
+
+;;;###autoload
+(defun p3/pptx-spike-open (pptx slide)
+  "Open PPTX at SLIDE in the visual-layout feasibility spike.
+The source is never modified; edits are made to a temporary working copy."
+  (interactive
+   (list (read-file-name "PPTX file: " nil nil t nil
+                         (lambda (file)
+                           (or (file-directory-p file)
+                               (string-equal (downcase (or (file-name-extension file) ""))
+                                             "pptx"))))
+         (read-number "Slide number: " 1)))
+  (unless (file-readable-p pptx)
+    (user-error "PPTX is not readable: %s" pptx))
+  (let* ((source (expand-file-name pptx))
+         (directory (make-temp-file "p3-pptx-spike-" t))
+         (working (expand-file-name "working.pptx" directory))
+         (render (expand-file-name "slide.png" directory))
+         (buffer (get-buffer-create
+                  (format "*PPTX spike: %s [%d]*" (file-name-nondirectory source) slide))))
+    (copy-file source working t)
+    (pop-to-buffer buffer)
+    (p3-pptx-spike-mode)
+    (setq-local p3-pptx-spike--source source
+                p3-pptx-spike--working working
+                p3-pptx-spike--temp-directory directory
+                p3-pptx-spike--slide slide
+                p3-pptx-spike--render-file render
+                p3-pptx-spike--selected-id nil)
+    (p3-pptx-spike--render)))
+
+(provide 'p3-pptx-spike)
+
+;;; p3-pptx-spike.el ends here

--- a/spikes/pptx-editor/p3-pptx-spike.el
+++ b/spikes/pptx-editor/p3-pptx-spike.el
@@ -1,8 +1,8 @@
 ;;; p3-pptx-spike.el --- Throwaway PPTX visual-layout feasibility spike -*- lexical-binding: t; -*-
 
 ;; This is intentionally a spike, not a supported package.  It edits a working
-;; copy of a PPTX by patching only one slide XML member, then renders that real
-;; PPTX through LibreOffice for display in Emacs.
+;; copy of a PPTX by patching only one slide XML member.  LibreOffice provides
+;; fidelity renders, while Emacs provides immediate local movement feedback.
 
 (require 'json)
 (require 'svg)
@@ -46,13 +46,23 @@
   :type 'number
   :group 'p3-pptx-spike)
 
+(defcustom p3-pptx-spike-render-delay 0.45
+  "Seconds of editing idle time before starting a fidelity render."
+  :type 'number
+  :group 'p3-pptx-spike)
+
 (defvar-local p3-pptx-spike--source nil)
 (defvar-local p3-pptx-spike--working nil)
 (defvar-local p3-pptx-spike--temp-directory nil)
 (defvar-local p3-pptx-spike--slide 1)
 (defvar-local p3-pptx-spike--model nil)
+(defvar-local p3-pptx-spike--render-model nil)
 (defvar-local p3-pptx-spike--selected-id nil)
 (defvar-local p3-pptx-spike--render-file nil)
+(defvar-local p3-pptx-spike--render-timer nil)
+(defvar-local p3-pptx-spike--render-process nil)
+(defvar-local p3-pptx-spike--edit-generation 0)
+(defvar-local p3-pptx-spike--drag-delta nil)
 
 (defun p3-pptx-spike--program (program label)
   "Return executable PROGRAM or signal a user error mentioning LABEL."
@@ -82,7 +92,7 @@
          :null-object nil :false-object nil)))
 
 (defun p3-pptx-spike--render ()
-  "Render the current real PPTX slide to PNG and refresh geometry."
+  "Synchronously render the current PPTX slide for initial display only."
   (p3-pptx-spike--program p3-pptx-spike-soffice "LibreOffice")
   (p3-pptx-spike--program p3-pptx-spike-pdftoppm "pdftoppm")
   (p3-pptx-spike--run
@@ -91,11 +101,18 @@
    "--soffice" p3-pptx-spike-soffice
    "--pdftoppm" p3-pptx-spike-pdftoppm)
   (p3-pptx-spike--inspect)
+  (setq p3-pptx-spike--render-model (copy-tree p3-pptx-spike--model))
   (p3-pptx-spike--redisplay))
 
 (defun p3-pptx-spike--get (key object)
   "Return KEY from JSON alist OBJECT."
   (alist-get key object))
+
+(defun p3-pptx-spike--shape-by-id (id &optional model)
+  "Return shape ID from MODEL, defaulting to the current geometry model."
+  (seq-find
+   (lambda (shape) (= (p3-pptx-spike--get 'id shape) id))
+   (p3-pptx-spike--get 'shapes (or model p3-pptx-spike--model))))
 
 (defun p3-pptx-spike--canvas-size ()
   "Return displayed canvas size as (WIDTH . HEIGHT)."
@@ -104,11 +121,11 @@
          (width p3-pptx-spike-canvas-width))
     (cons width (round (* width (/ slide-height slide-width))))))
 
-(defun p3-pptx-spike--shape-rect (shape)
-  "Return SHAPE rectangle in displayed canvas pixels."
+(defun p3-pptx-spike--shape-rect-in-model (shape model)
+  "Return SHAPE rectangle in canvas pixels using MODEL dimensions."
   (pcase-let* ((`(,canvas-width . ,canvas-height) (p3-pptx-spike--canvas-size))
-               (slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
-               (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model))
+               (slide-width (p3-pptx-spike--get 'slide_width model))
+               (slide-height (p3-pptx-spike--get 'slide_height model))
                (sx (/ canvas-width slide-width))
                (sy (/ canvas-height slide-height))
                (x (round (* sx (p3-pptx-spike--get 'left shape))))
@@ -116,6 +133,10 @@
                (w (round (* sx (p3-pptx-spike--get 'width shape))))
                (h (round (* sy (p3-pptx-spike--get 'height shape)))))
     (list x y w h)))
+
+(defun p3-pptx-spike--shape-rect (shape)
+  "Return SHAPE rectangle in displayed canvas pixels."
+  (p3-pptx-spike--shape-rect-in-model shape p3-pptx-spike--model))
 
 (defun p3-pptx-spike--shape-at (x y)
   "Return top-most editable shape at canvas coordinates X Y."
@@ -139,17 +160,46 @@
 
 (defun p3-pptx-spike--selection-label ()
   "Return a short label for the current selection."
-  (if-let ((shape (seq-find
-                   (lambda (item)
-                     (= (p3-pptx-spike--get 'id item) p3-pptx-spike--selected-id))
-                   (p3-pptx-spike--get 'shapes p3-pptx-spike--model))))
-      (format "%s (#%s)"
+  (if-let ((shape (and p3-pptx-spike--selected-id
+                       (p3-pptx-spike--shape-by-id p3-pptx-spike--selected-id))))
+      (format "%s (#%s)  x %.2f  y %.2f"
               (or (p3-pptx-spike--get 'name shape) "shape")
-              p3-pptx-spike--selected-id)
+              p3-pptx-spike--selected-id
+              (p3-pptx-spike--get 'left shape)
+              (p3-pptx-spike--get 'top shape))
     "none"))
 
+(defun p3-pptx-spike--draw-preview-ghost (svg shape width height normal)
+  "Draw a live raster movement preview for SHAPE onto SVG.
+WIDTH and HEIGHT are canvas dimensions; NORMAL is the old-position outline."
+  (when-let* ((render-model p3-pptx-spike--render-model)
+              (render-shape
+               (p3-pptx-spike--shape-by-id
+                (p3-pptx-spike--get 'id shape) render-model)))
+    (pcase-let* ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape))
+                 (`(,old-x ,old-y ,old-w ,old-h)
+                  (p3-pptx-spike--shape-rect-in-model render-shape render-model))
+                 (dx (- x old-x))
+                 (dy (- y old-y)))
+      (unless (and (= dx 0) (= dy 0) (= w old-w) (= h old-h))
+        (let* ((clip-id (format "pptx-preview-%s" (p3-pptx-spike--get 'id shape)))
+               (clip (svg-clip-path svg :id clip-id)))
+          (svg-rectangle clip x y w h)
+          ;; Shift the whole authoritative raster, then clip it to the moved
+          ;; object's rectangle.  This creates an immediate drag ghost without
+          ;; pretending to re-render PowerPoint text/charts in Emacs.
+          (svg-embed svg p3-pptx-spike--render-file "image/png" nil
+                     :x dx :y dy :width width :height height
+                     :clip-path (format "url(#%s)" clip-id)
+                     :opacity 0.78)
+          (svg-rectangle svg old-x old-y old-w old-h
+                         :fill-color "none"
+                         :stroke-color normal
+                         :stroke-width 1
+                         :stroke-dasharray "6 4"))))))
+
 (defun p3-pptx-spike--redisplay ()
-  "Redraw the rendered slide plus editable bounding boxes."
+  "Redraw the authoritative slide raster plus live geometry feedback."
   (let* ((inhibit-read-only t)
          (size (p3-pptx-spike--canvas-size))
          (width (car size))
@@ -160,6 +210,8 @@
     (erase-buffer)
     (svg-embed svg p3-pptx-spike--render-file "image/png" nil
                :x 0 :y 0 :width width :height height)
+    (dolist (shape (p3-pptx-spike--get 'shapes p3-pptx-spike--model))
+      (p3-pptx-spike--draw-preview-ghost svg shape width height normal))
     (dolist (shape (p3-pptx-spike--get 'shapes p3-pptx-spike--model))
       (pcase-let ((`(,x ,y ,w ,h) (p3-pptx-spike--shape-rect shape)))
         (svg-rectangle
@@ -173,15 +225,38 @@
                            3 1))))
     (insert-image
      (svg-image svg :scale 1.0 :map (p3-pptx-spike--image-map)))
-    (insert (format "\n\nSlide %d  |  selected: %s\n"
+    (insert (format "\n\nSlide %d  |  selected: %s"
                     p3-pptx-spike--slide (p3-pptx-spike--selection-label)))
-    (insert "Drag a shape to move it. Arrow keys nudge the selected shape.  s saves a copy; g rerenders; q quits.\n")
+    (when p3-pptx-spike--drag-delta
+      (insert (format "  |  drag Δx %+.2f Δy %+.2f in"
+                      (car p3-pptx-spike--drag-delta)
+                      (cdr p3-pptx-spike--drag-delta))))
+    (insert "\nDrag and arrow keys preview immediately. Fidelity rendering updates after editing pauses; g requests it now; s saves; q quits.\n")
     (goto-char (point-min))))
 
 (defun p3-pptx-spike--event-xy (position)
   "Return image-relative pixel coordinates for mouse POSITION."
   (or (posn-object-x-y position)
       (user-error "Mouse event is not over the slide image")))
+
+(defun p3-pptx-spike--event-xy-safe (position)
+  "Return image-relative coordinates for POSITION, or nil off the image."
+  (condition-case nil
+      (p3-pptx-spike--event-xy position)
+    (user-error nil)))
+
+(defun p3-pptx-spike--slide-delta (x0 y0 x1 y1)
+  "Convert canvas displacement X0/Y0 to X1/Y1 into slide inches."
+  (let* ((canvas (p3-pptx-spike--canvas-size))
+         (slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
+         (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model)))
+    (cons (* (- x1 x0) (/ slide-width (car canvas)))
+          (* (- y1 y0) (/ slide-height (cdr canvas))))))
+
+(defun p3-pptx-spike--set-shape-position (shape left top)
+  "Set SHAPE LEFT and TOP in the live model."
+  (setf (alist-get 'left shape) left
+        (alist-get 'top shape) top))
 
 (defun p3-pptx-spike-select-mouse (event)
   "Select the PPTX shape under mouse EVENT."
@@ -192,42 +267,206 @@
       (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
       (p3-pptx-spike--redisplay))))
 
+(defun p3-pptx-spike--commit-edit (dx dy &optional dw dh model-already-updated)
+  "Commit selected shape DX/DY and optional DW/DH inches to OOXML.
+When MODEL-ALREADY-UPDATED is non-nil, only persist and schedule fidelity
+rendering; otherwise update the live geometry model after persistence."
+  (unless p3-pptx-spike--selected-id
+    (user-error "No PPTX shape is selected"))
+  (let ((shape (p3-pptx-spike--shape-by-id p3-pptx-spike--selected-id)))
+    (unless shape
+      (user-error "Selected PPTX shape no longer exists"))
+    (p3-pptx-spike--run
+     "edit" p3-pptx-spike--working
+     "--slide" (number-to-string p3-pptx-spike--slide)
+     "--shape-id" (number-to-string p3-pptx-spike--selected-id)
+     "--dx" (number-to-string dx)
+     "--dy" (number-to-string dy)
+     "--dw" (number-to-string (or dw 0.0))
+     "--dh" (number-to-string (or dh 0.0)))
+    (unless model-already-updated
+      (setf (alist-get 'left shape) (+ (p3-pptx-spike--get 'left shape) dx)
+            (alist-get 'top shape) (+ (p3-pptx-spike--get 'top shape) dy)
+            (alist-get 'width shape) (+ (p3-pptx-spike--get 'width shape) (or dw 0.0))
+            (alist-get 'height shape) (+ (p3-pptx-spike--get 'height shape) (or dh 0.0))))
+    (setq p3-pptx-spike--edit-generation (1+ p3-pptx-spike--edit-generation))
+    (p3-pptx-spike--redisplay)
+    (p3-pptx-spike--schedule-render)))
+
+(defun p3-pptx-spike--edit (dx dy &optional dw dh)
+  "Immediately preview and persist selected shape DX/DY and optional DW/DH."
+  (p3-pptx-spike--commit-edit dx dy dw dh nil))
+
 (defun p3-pptx-spike-drag-mouse (event)
-  "Move the PPTX shape dragged by mouse EVENT, then rerender the real deck."
+  "Track mouse EVENT continuously, preview movement, and commit on release."
   (interactive "e")
-  (pcase-let* ((start (p3-pptx-spike--event-xy (event-start event)))
-               (end (p3-pptx-spike--event-xy (event-end event)))
-               (`(,x0 . ,y0) start)
-               (`(,x1 . ,y1) end)
-               (shape (p3-pptx-spike--shape-at x0 y0))
-               (canvas (p3-pptx-spike--canvas-size))
-               (slide-width (p3-pptx-spike--get 'slide_width p3-pptx-spike--model))
-               (slide-height (p3-pptx-spike--get 'slide_height p3-pptx-spike--model)))
+  (pcase-let* ((`(,x0 . ,y0) (p3-pptx-spike--event-xy (event-start event)))
+               (shape (p3-pptx-spike--shape-at x0 y0)))
     (unless shape
       (user-error "No editable PPTX shape at drag start"))
     (setq p3-pptx-spike--selected-id (p3-pptx-spike--get 'id shape))
-    (p3-pptx-spike--edit
-     (* (- x1 x0) (/ slide-width (car canvas)))
-     (* (- y1 y0) (/ slide-height (cdr canvas))))))
+    (let ((left0 (p3-pptx-spike--get 'left shape))
+          (top0 (p3-pptx-spike--get 'top shape))
+          (dx 0.0)
+          (dy 0.0)
+          (finished nil)
+          (cancelled nil))
+      (p3-pptx-spike--redisplay)
+      (track-mouse
+        (while (not finished)
+          (let ((next (read-event)))
+            (cond
+             ((mouse-movement-p next)
+              (when-let ((xy (p3-pptx-spike--event-xy-safe (event-start next))))
+                (pcase-let ((`(,next-x . ,next-y) xy))
+                  (pcase-let ((`(,next-dx . ,next-dy)
+                               (p3-pptx-spike--slide-delta x0 y0 next-x next-y)))
+                    (setq dx next-dx
+                          dy next-dy
+                          p3-pptx-spike--drag-delta (cons dx dy))
+                    (p3-pptx-spike--set-shape-position shape (+ left0 dx) (+ top0 dy))
+                    (p3-pptx-spike--redisplay)))))
+             ((eq (event-basic-type next) 'mouse-1)
+              (when-let ((xy (p3-pptx-spike--event-xy-safe (event-end next))))
+                (pcase-let ((`(,end-x . ,end-y) xy))
+                  (pcase-let ((`(,end-dx . ,end-dy)
+                               (p3-pptx-spike--slide-delta x0 y0 end-x end-y)))
+                    (setq dx end-dx dy end-dy)
+                    (p3-pptx-spike--set-shape-position shape (+ left0 dx) (+ top0 dy)))))
+              (setq finished t))
+             (t
+              (setq cancelled t
+                    finished t
+                    unread-command-events
+                    (append unread-command-events (list next))))))))
+      (setq p3-pptx-spike--drag-delta nil)
+      (cond
+       (cancelled
+        (p3-pptx-spike--set-shape-position shape left0 top0)
+        (p3-pptx-spike--redisplay))
+       ((and (= dx 0.0) (= dy 0.0))
+        (p3-pptx-spike--redisplay))
+       (t
+        (condition-case err
+            (p3-pptx-spike--commit-edit dx dy nil nil t)
+          (error
+           (p3-pptx-spike--set-shape-position shape left0 top0)
+           (p3-pptx-spike--redisplay)
+           (signal (car err) (cdr err)))))))))
 
-(defun p3-pptx-spike--edit (dx dy &optional dw dh)
-  "Patch selected shape by DX/DY and optional DW/DH inches, then rerender."
-  (unless p3-pptx-spike--selected-id
-    (user-error "No PPTX shape is selected"))
-  (p3-pptx-spike--run
-   "edit" p3-pptx-spike--working
-   "--slide" (number-to-string p3-pptx-spike--slide)
-   "--shape-id" (number-to-string p3-pptx-spike--selected-id)
-   "--dx" (number-to-string dx)
-   "--dy" (number-to-string dy)
-   "--dw" (number-to-string (or dw 0.0))
-   "--dh" (number-to-string (or dh 0.0)))
-  (p3-pptx-spike--render))
+(defun p3-pptx-spike--render-command (input output)
+  "Return asynchronous bridge command rendering INPUT to OUTPUT."
+  (unless (file-readable-p p3-pptx-spike-bridge)
+    (user-error "PPTX bridge is not readable: %s" p3-pptx-spike-bridge))
+  (list (p3-pptx-spike--program p3-pptx-spike-python "Python")
+        p3-pptx-spike-bridge
+        "render" input output
+        "--slide" (number-to-string p3-pptx-spike--slide)
+        "--soffice" (p3-pptx-spike--program p3-pptx-spike-soffice "LibreOffice")
+        "--pdftoppm" (p3-pptx-spike--program p3-pptx-spike-pdftoppm "pdftoppm")))
 
-(defun p3-pptx-spike-nudge-left () (interactive) (p3-pptx-spike--edit (- p3-pptx-spike-nudge) 0))
-(defun p3-pptx-spike-nudge-right () (interactive) (p3-pptx-spike--edit p3-pptx-spike-nudge 0))
-(defun p3-pptx-spike-nudge-up () (interactive) (p3-pptx-spike--edit 0 (- p3-pptx-spike-nudge)))
-(defun p3-pptx-spike-nudge-down () (interactive) (p3-pptx-spike--edit 0 p3-pptx-spike-nudge))
+(defun p3-pptx-spike--render-timer-fire (buffer)
+  "Start a fidelity render for BUFFER when its debounce timer fires."
+  (when (buffer-live-p buffer)
+    (with-current-buffer buffer
+      (setq p3-pptx-spike--render-timer nil)
+      (p3-pptx-spike--start-render))))
+
+(defun p3-pptx-spike--schedule-render (&optional delay)
+  "Debounce an asynchronous fidelity render by DELAY seconds."
+  (when (timerp p3-pptx-spike--render-timer)
+    (cancel-timer p3-pptx-spike--render-timer))
+  (setq p3-pptx-spike--render-timer
+        (run-with-timer (or delay p3-pptx-spike-render-delay) nil
+                        #'p3-pptx-spike--render-timer-fire
+                        (current-buffer))))
+
+(defun p3-pptx-spike--render-sentinel (process _event)
+  "Install a completed fidelity render from PROCESS when it is still current."
+  (when (memq (process-status process) '(exit signal))
+    (let ((editor (process-get process 'editor-buffer))
+          (generation (process-get process 'generation))
+          (output (process-get process 'output))
+          (snapshot (process-get process 'snapshot))
+          (model (process-get process 'model))
+          (process-buffer (process-buffer process))
+          (status (process-exit-status process)))
+      (when (buffer-live-p editor)
+        (with-current-buffer editor
+          (when (eq process p3-pptx-spike--render-process)
+            (setq p3-pptx-spike--render-process nil))
+          (cond
+           ((and (= status 0) (= generation p3-pptx-spike--edit-generation))
+            (setq p3-pptx-spike--render-file output
+                  p3-pptx-spike--render-model model)
+            (p3-pptx-spike--redisplay))
+           ((not (= status 0))
+            (let ((diagnostics
+                   (when (buffer-live-p process-buffer)
+                     (with-current-buffer process-buffer
+                       (string-trim (buffer-string))))))
+              (message "PPTX fidelity render failed: %s"
+                       (if (string-empty-p (or diagnostics ""))
+                           (format "status %s" status)
+                         diagnostics)))))
+          (when (> p3-pptx-spike--edit-generation generation)
+            (p3-pptx-spike--schedule-render 0.0))))
+      (when (and snapshot (file-exists-p snapshot))
+        (delete-file snapshot))
+      (unless (and (= status 0)
+                   (buffer-live-p editor)
+                   (with-current-buffer editor
+                     (= generation p3-pptx-spike--edit-generation)))
+        (when (and output (file-exists-p output))
+          (delete-file output)))
+      (when (buffer-live-p process-buffer)
+        (kill-buffer process-buffer)))))
+
+(defun p3-pptx-spike--start-render ()
+  "Start one nonblocking fidelity render of the current working deck."
+  (if (and p3-pptx-spike--render-process
+           (process-live-p p3-pptx-spike--render-process))
+      nil
+    (let* ((generation p3-pptx-spike--edit-generation)
+           (snapshot
+            (make-temp-file
+             (expand-file-name (format "render-%d-" generation)
+                               p3-pptx-spike--temp-directory)
+             nil ".pptx"))
+           (output (concat (file-name-sans-extension snapshot) ".png"))
+           (model (copy-tree p3-pptx-spike--model))
+           (process-buffer (generate-new-buffer " *p3-pptx-render*"))
+           (process
+            (make-process
+             :name (format "p3-pptx-render-%d" generation)
+             :buffer process-buffer
+             :command (p3-pptx-spike--render-command snapshot output)
+             :connection-type 'pipe
+             :noquery t
+             :sentinel #'p3-pptx-spike--render-sentinel)))
+      (copy-file p3-pptx-spike--working snapshot t)
+      (process-put process 'editor-buffer (current-buffer))
+      (process-put process 'generation generation)
+      (process-put process 'output output)
+      (process-put process 'snapshot snapshot)
+      (process-put process 'model model)
+      (setq p3-pptx-spike--render-process process))))
+
+(defun p3-pptx-spike-nudge-left ()
+  (interactive)
+  (p3-pptx-spike--edit (- p3-pptx-spike-nudge) 0))
+
+(defun p3-pptx-spike-nudge-right ()
+  (interactive)
+  (p3-pptx-spike--edit p3-pptx-spike-nudge 0))
+
+(defun p3-pptx-spike-nudge-up ()
+  (interactive)
+  (p3-pptx-spike--edit 0 (- p3-pptx-spike-nudge)))
+
+(defun p3-pptx-spike-nudge-down ()
+  (interactive)
+  (p3-pptx-spike--edit 0 p3-pptx-spike-nudge))
 
 (defun p3-pptx-spike-save-as (output)
   "Save the edited working PPTX as OUTPUT without modifying the source file."
@@ -241,14 +480,30 @@
   (message "Saved edited PPTX to %s" output))
 
 (defun p3-pptx-spike-refresh ()
-  "Rerender the current working deck."
+  "Request an immediate nonblocking fidelity render of the working deck."
   (interactive)
-  (p3-pptx-spike--render))
+  (p3-pptx-spike--schedule-render 0.0)
+  (message "PPTX fidelity render requested"))
+
+(defun p3-pptx-spike--cancel-background-work ()
+  "Cancel timers and rendering owned by the current spike buffer."
+  (when (timerp p3-pptx-spike--render-timer)
+    (cancel-timer p3-pptx-spike--render-timer)
+    (setq p3-pptx-spike--render-timer nil))
+  (when (and p3-pptx-spike--render-process
+             (process-live-p p3-pptx-spike--render-process))
+    (let ((process-buffer (process-buffer p3-pptx-spike--render-process)))
+      (set-process-sentinel p3-pptx-spike--render-process #'ignore)
+      (delete-process p3-pptx-spike--render-process)
+      (when (buffer-live-p process-buffer)
+        (kill-buffer process-buffer))))
+  (setq p3-pptx-spike--render-process nil))
 
 (defun p3-pptx-spike-quit ()
   "Kill the spike buffer and its disposable working directory."
   (interactive)
   (let ((directory p3-pptx-spike--temp-directory))
+    (p3-pptx-spike--cancel-background-work)
     (kill-buffer (current-buffer))
     (when (and directory (file-directory-p directory))
       (delete-directory directory t))))
@@ -263,7 +518,7 @@
     (define-key map (kbd "s") #'p3-pptx-spike-save-as)
     (define-key map (kbd "q") #'p3-pptx-spike-quit)
     (define-key map [pptx-shape mouse-1] #'p3-pptx-spike-select-mouse)
-    (define-key map [pptx-shape drag-mouse-1] #'p3-pptx-spike-drag-mouse)
+    (define-key map [pptx-shape down-mouse-1] #'p3-pptx-spike-drag-mouse)
     map)
   "Keymap for `p3-pptx-spike-mode'.")
 
@@ -298,6 +553,11 @@ The source is never modified; edits are made to a temporary working copy."
                 p3-pptx-spike--temp-directory directory
                 p3-pptx-spike--slide slide
                 p3-pptx-spike--render-file render
+                p3-pptx-spike--render-model nil
+                p3-pptx-spike--render-timer nil
+                p3-pptx-spike--render-process nil
+                p3-pptx-spike--edit-generation 0
+                p3-pptx-spike--drag-delta nil
                 p3-pptx-spike--selected-id nil)
     (p3-pptx-spike--render)))
 

--- a/spikes/pptx-editor/p3-pptx-spike.el
+++ b/spikes/pptx-editor/p3-pptx-spike.el
@@ -185,9 +185,6 @@ WIDTH and HEIGHT are canvas dimensions; NORMAL is the old-position outline."
         (let* ((clip-id (format "pptx-preview-%s" (p3-pptx-spike--get 'id shape)))
                (clip (svg-clip-path svg :id clip-id)))
           (svg-rectangle clip x y w h)
-          ;; Shift the whole authoritative raster, then clip it to the moved
-          ;; object's rectangle.  This creates an immediate drag ghost without
-          ;; pretending to re-render PowerPoint text/charts in Emacs.
           (svg-embed svg p3-pptx-spike--render-file "image/png" nil
                      :x dx :y dy :width width :height height
                      :clip-path (format "url(#%s)" clip-id)
@@ -422,17 +419,23 @@ rendering; otherwise update the live geometry model after persistence."
       (when (buffer-live-p process-buffer)
         (kill-buffer process-buffer)))))
 
+(defun p3-pptx-spike--make-render-snapshot (generation)
+  "Copy the working deck to a complete render snapshot for GENERATION."
+  (let ((snapshot
+         (make-temp-file
+          (expand-file-name (format "render-%d-" generation)
+                            p3-pptx-spike--temp-directory)
+          nil ".pptx")))
+    (copy-file p3-pptx-spike--working snapshot t)
+    snapshot))
+
 (defun p3-pptx-spike--start-render ()
   "Start one nonblocking fidelity render of the current working deck."
   (if (and p3-pptx-spike--render-process
            (process-live-p p3-pptx-spike--render-process))
       nil
     (let* ((generation p3-pptx-spike--edit-generation)
-           (snapshot
-            (make-temp-file
-             (expand-file-name (format "render-%d-" generation)
-                               p3-pptx-spike--temp-directory)
-             nil ".pptx"))
+           (snapshot (p3-pptx-spike--make-render-snapshot generation))
            (output (concat (file-name-sans-extension snapshot) ".png"))
            (model (copy-tree p3-pptx-spike--model))
            (process-buffer (generate-new-buffer " *p3-pptx-render*"))
@@ -444,7 +447,6 @@ rendering; otherwise update the live geometry model after persistence."
              :connection-type 'pipe
              :noquery t
              :sentinel #'p3-pptx-spike--render-sentinel)))
-      (copy-file p3-pptx-spike--working snapshot t)
       (process-put process 'editor-buffer (current-buffer))
       (process-put process 'generation generation)
       (process-put process 'output output)

--- a/spikes/pptx-editor/pptx_bridge.py
+++ b/spikes/pptx-editor/pptx_bridge.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Minimal PPTX geometry bridge for the Emacs feasibility spike.
+
+Reads slide geometry without rewriting the package and moves/resizes top-level
+shapes by patching only the selected slide XML member.  All other ZIP members
+are copied byte-for-byte.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import zipfile
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+EMU_PER_INCH = 914400
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
+SUPPORTED_TAGS = {"sp", "pic", "graphicFrame", "cxnSp"}
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def inches(value: int) -> float:
+    return value / EMU_PER_INCH
+
+
+def presentation_size(archive: zipfile.ZipFile) -> tuple[int, int]:
+    root = ET.fromstring(archive.read("ppt/presentation.xml"))
+    size = root.find(f"{{{P_NS}}}sldSz")
+    if size is None:
+        raise ValueError("presentation has no slide size")
+    return int(size.attrib["cx"]), int(size.attrib["cy"])
+
+
+def shape_geometry(element: ET.Element) -> tuple[int, int, int, int] | None:
+    xfrm = next((node for node in element.iter() if local_name(node.tag) == "xfrm"), None)
+    if xfrm is None:
+        return None
+    off = next((node for node in xfrm if local_name(node.tag) == "off"), None)
+    ext = next((node for node in xfrm if local_name(node.tag) == "ext"), None)
+    if off is None or ext is None:
+        return None
+    return int(off.attrib["x"]), int(off.attrib["y"]), int(ext.attrib["cx"]), int(ext.attrib["cy"])
+
+
+def inspect_deck(path: str | Path, slide_number: int) -> dict:
+    member = f"ppt/slides/slide{slide_number}.xml"
+    with zipfile.ZipFile(path, "r") as archive:
+        slide_w, slide_h = presentation_size(archive)
+        root = ET.fromstring(archive.read(member))
+    sp_tree = root.find(f".//{{{P_NS}}}spTree")
+    if sp_tree is None:
+        raise ValueError(f"slide {slide_number} has no shape tree")
+    shapes = []
+    for element in list(sp_tree):
+        kind = local_name(element.tag)
+        if kind not in SUPPORTED_TAGS:
+            continue
+        c_nv_pr = next((node for node in element.iter() if local_name(node.tag) == "cNvPr"), None)
+        geom = shape_geometry(element)
+        if c_nv_pr is None or geom is None:
+            continue
+        x, y, w, h = geom
+        texts = [node.text or "" for node in element.iter() if local_name(node.tag) == "t"]
+        shapes.append({
+            "id": int(c_nv_pr.attrib["id"]),
+            "name": c_nv_pr.attrib.get("name", ""),
+            "type": kind,
+            "left": inches(x),
+            "top": inches(y),
+            "width": inches(w),
+            "height": inches(h),
+            "text": " ".join(t.strip() for t in texts if t.strip())[:160],
+        })
+    return {
+        "slide": slide_number,
+        "slide_width": inches(slide_w),
+        "slide_height": inches(slide_h),
+        "shapes": shapes,
+    }
+
+
+def _shape_block(text: str, shape_id: int) -> tuple[int, int, str]:
+    marker = re.search(
+        r'<(?P<pfx>[A-Za-z_][\w.-]*):cNvPr\b[^>]*\bid="%d"[^>]*>' % shape_id,
+        text,
+    )
+    if not marker:
+        raise ValueError(f"shape id {shape_id} not found")
+    pfx = marker.group("pfx")
+    starts: list[tuple[int, str]] = []
+    for tag in SUPPORTED_TAGS:
+        for match in re.finditer(r'<%s:%s\b' % (re.escape(pfx), tag), text[: marker.start()]):
+            starts.append((match.start(), tag))
+    if not starts:
+        raise ValueError(f"shape id {shape_id} is not a supported top-level shape")
+    start, tag = max(starts)
+    closing = f"</{pfx}:{tag}>"
+    end = text.find(closing, marker.end())
+    if end < 0:
+        raise ValueError("shape closing tag not found")
+    end += len(closing)
+    return start, end, text[start:end]
+
+
+def _replace_int_attr(tag: str, attr: str, value: int) -> str:
+    pattern = re.compile(r'(\b%s=")-?\d+(\")' % re.escape(attr))
+    result, count = pattern.subn(lambda m: f"{m.group(1)}{value}{m.group(2)}", tag, count=1)
+    if count != 1:
+        raise ValueError(f"attribute {attr} not found")
+    return result
+
+
+def patch_geometry(data: bytes, shape_id: int, dx: float, dy: float, dw: float = 0.0, dh: float = 0.0) -> bytes:
+    text = data.decode("utf-8")
+    start, end, block = _shape_block(text, shape_id)
+    xfrm = re.search(r'<(?:[A-Za-z_][\w.-]*):xfrm\b.*?</(?:[A-Za-z_][\w.-]*):xfrm>', block)
+    if not xfrm:
+        raise ValueError("shape transform not found")
+    transform = xfrm.group(0)
+    off = re.search(r'<(?:[A-Za-z_][\w.-]*):off\b[^>]*/?>', transform)
+    ext = re.search(r'<(?:[A-Za-z_][\w.-]*):ext\b[^>]*/?>', transform)
+    if not off or not ext:
+        raise ValueError("shape offset/extent not found")
+
+    def attr(tag: str, name: str) -> int:
+        match = re.search(r'\b%s="(-?\d+)"' % re.escape(name), tag)
+        if not match:
+            raise ValueError(f"attribute {name} not found")
+        return int(match.group(1))
+
+    off_tag, ext_tag = off.group(0), ext.group(0)
+    nx = attr(off_tag, "x") + round(dx * EMU_PER_INCH)
+    ny = attr(off_tag, "y") + round(dy * EMU_PER_INCH)
+    nw = attr(ext_tag, "cx") + round(dw * EMU_PER_INCH)
+    nh = attr(ext_tag, "cy") + round(dh * EMU_PER_INCH)
+    if nw <= 0 or nh <= 0:
+        raise ValueError("resize would make shape non-positive")
+    patched_off = _replace_int_attr(_replace_int_attr(off_tag, "x", nx), "y", ny)
+    patched_ext = _replace_int_attr(_replace_int_attr(ext_tag, "cx", nw), "cy", nh)
+    patched_transform = transform[: off.start()] + patched_off + transform[off.end() :]
+    ext2 = re.search(r'<(?:[A-Za-z_][\w.-]*):ext\b[^>]*/?>', patched_transform)
+    assert ext2 is not None
+    patched_transform = patched_transform[: ext2.start()] + patched_ext + patched_transform[ext2.end() :]
+    patched_block = block[: xfrm.start()] + patched_transform + block[xfrm.end() :]
+    return (text[:start] + patched_block + text[end:]).encode("utf-8")
+
+
+def edit_package(src: str | Path, dst: str | Path, slide_number: int, shape_id: int, dx: float, dy: float, dw: float = 0.0, dh: float = 0.0) -> None:
+    src, dst = Path(src), Path(dst)
+    member = f"ppt/slides/slide{slide_number}.xml"
+    with zipfile.ZipFile(src, "r") as zin, zipfile.ZipFile(dst, "w") as zout:
+        found = False
+        for item in zin.infolist():
+            payload = zin.read(item.filename)
+            if item.filename == member:
+                payload = patch_geometry(payload, shape_id, dx, dy, dw, dh)
+                found = True
+            zout.writestr(item, payload)
+        if not found:
+            raise ValueError(f"slide {slide_number} not found")
+
+
+def edit_in_place(path: str | Path, slide_number: int, shape_id: int, dx: float, dy: float, dw: float = 0.0, dh: float = 0.0) -> None:
+    path = Path(path)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.stem + "-", suffix=".pptx", dir=path.parent)
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        edit_package(path, tmp, slide_number, shape_id, dx, dy, dw, dh)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def render_slide(path: str | Path, output: str | Path, slide_number: int, soffice: str, pdftoppm: str) -> None:
+    path, output = Path(path).resolve(), Path(output).resolve()
+    with tempfile.TemporaryDirectory(prefix="p3-pptx-") as td_name:
+        td = Path(td_name)
+        subprocess.run([soffice, "--headless", "--convert-to", "pdf", "--outdir", str(td), str(path)], check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        pdf = td / f"{path.stem}.pdf"
+        prefix = td / "slide"
+        subprocess.run([pdftoppm, "-png", "-f", str(slide_number), "-singlefile", "-r", "120", str(pdf), str(prefix)], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        shutil.copyfile(str(prefix) + ".png", output)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    inspect_p = sub.add_parser("inspect")
+    inspect_p.add_argument("pptx")
+    inspect_p.add_argument("--slide", type=int, default=1)
+    edit_p = sub.add_parser("edit")
+    edit_p.add_argument("pptx")
+    edit_p.add_argument("--slide", type=int, default=1)
+    edit_p.add_argument("--shape-id", type=int, required=True)
+    for name in ("dx", "dy", "dw", "dh"):
+        edit_p.add_argument(f"--{name}", type=float, default=0.0)
+    render_p = sub.add_parser("render")
+    render_p.add_argument("pptx")
+    render_p.add_argument("output")
+    render_p.add_argument("--slide", type=int, default=1)
+    render_p.add_argument("--soffice", default="libreoffice")
+    render_p.add_argument("--pdftoppm", default="pdftoppm")
+    args = parser.parse_args()
+    if args.command == "inspect":
+        print(json.dumps(inspect_deck(args.pptx, args.slide), indent=2))
+    elif args.command == "edit":
+        edit_in_place(args.pptx, args.slide, args.shape_id, args.dx, args.dy, args.dw, args.dh)
+    else:
+        render_slide(args.pptx, args.output, args.slide, args.soffice, args.pdftoppm)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/p3-pptx-spike-test.el
+++ b/test/p3-pptx-spike-test.el
@@ -53,6 +53,22 @@
         (should render-scheduled)
         (should-not render-called)))))
 
+(ert-deftest p3-pptx-spike-render-snapshot-is-complete-before-use ()
+  (let ((directory (make-temp-file "p3-pptx-spike-test-" t)))
+    (unwind-protect
+        (let ((working (expand-file-name "working.pptx" directory)))
+          (with-temp-file working
+            (insert "complete-pptx-snapshot"))
+          (with-temp-buffer
+            (setq-local p3-pptx-spike--working working
+                        p3-pptx-spike--temp-directory directory)
+            (let ((snapshot (p3-pptx-spike--make-render-snapshot 3)))
+              (should (file-exists-p snapshot))
+              (with-temp-buffer
+                (insert-file-contents-literally snapshot)
+                (should (equal (buffer-string) "complete-pptx-snapshot"))))))
+      (delete-directory directory t))))
+
 (provide 'p3-pptx-spike-test)
 
 ;;; p3-pptx-spike-test.el ends here

--- a/test/p3-pptx-spike-test.el
+++ b/test/p3-pptx-spike-test.el
@@ -10,7 +10,7 @@
   "Root of the Emacs configuration under test.")
 
 (load-file
- (expand-file-name "spikes/pptx-editor/p3-pptx-spike.el"
+ (expand-file-name "spikes/pptx-editor/p3-pptx-spike-fast.el"
                    p3-pptx-spike-test--config-directory))
 
 (defun p3-pptx-spike-test--shape ()
@@ -41,7 +41,7 @@
                 ((symbol-function 'p3-pptx-spike--render)
                  (lambda () (setq render-called t)))
                 ((symbol-function 'p3-pptx-spike--schedule-persist)
-                 (lambda () (setq persist-scheduled t)))
+                 (lambda (&optional _delay) (setq persist-scheduled t)))
                 ((symbol-function 'p3-pptx-spike--redisplay)
                  (lambda () (setq redisplayed t))))
         (p3-pptx-spike--edit 0.5 -0.25)

--- a/test/p3-pptx-spike-test.el
+++ b/test/p3-pptx-spike-test.el
@@ -1,0 +1,58 @@
+;;; p3-pptx-spike-test.el --- Tests for PPTX visual-layout spike -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'cl-lib)
+
+(defconst p3-pptx-spike-test--config-directory
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(load-file
+ (expand-file-name "spikes/pptx-editor/p3-pptx-spike.el"
+                   p3-pptx-spike-test--config-directory))
+
+(defun p3-pptx-spike-test--shape ()
+  "Return one editable shape suitable for latency tests."
+  '((id . 7)
+    (name . "Test shape")
+    (type . "pic")
+    (left . 1.0)
+    (top . 2.0)
+    (width . 3.0)
+    (height . 1.0)))
+
+(ert-deftest p3-pptx-spike-edit-previews-immediately-without-sync-render ()
+  (with-temp-buffer
+    (setq-local p3-pptx-spike--working "/tmp/working.pptx"
+                p3-pptx-spike--slide 1
+                p3-pptx-spike--selected-id 7
+                p3-pptx-spike--model
+                `((slide_width . 10.0)
+                  (slide_height . 7.5)
+                  (shapes . (,(p3-pptx-spike-test--shape)))))
+    (let ((bridge-called nil)
+          (render-called nil)
+          (render-scheduled nil)
+          (redisplayed nil))
+      (cl-letf (((symbol-function 'p3-pptx-spike--run)
+                 (lambda (&rest _args) (setq bridge-called t) ""))
+                ((symbol-function 'p3-pptx-spike--render)
+                 (lambda () (setq render-called t)))
+                ((symbol-function 'p3-pptx-spike--schedule-render)
+                 (lambda () (setq render-scheduled t)))
+                ((symbol-function 'p3-pptx-spike--redisplay)
+                 (lambda () (setq redisplayed t))))
+        (p3-pptx-spike--edit 0.5 -0.25)
+        (let ((shape (car (alist-get 'shapes p3-pptx-spike--model))))
+          (should (= (alist-get 'left shape) 1.5))
+          (should (= (alist-get 'top shape) 1.75)))
+        (should bridge-called)
+        (should redisplayed)
+        (should render-scheduled)
+        (should-not render-called)))))
+
+(provide 'p3-pptx-spike-test)
+
+;;; p3-pptx-spike-test.el ends here

--- a/test/p3-pptx-spike-test.el
+++ b/test/p3-pptx-spike-test.el
@@ -23,7 +23,7 @@
     (width . 3.0)
     (height . 1.0)))
 
-(ert-deftest p3-pptx-spike-edit-previews-immediately-without-sync-render ()
+(ert-deftest p3-pptx-spike-edit-is-memory-only-on-hot-path ()
   (with-temp-buffer
     (setq-local p3-pptx-spike--working "/tmp/working.pptx"
                 p3-pptx-spike--slide 1
@@ -34,24 +34,41 @@
                   (shapes . (,(p3-pptx-spike-test--shape)))))
     (let ((bridge-called nil)
           (render-called nil)
-          (render-scheduled nil)
+          (persist-scheduled nil)
           (redisplayed nil))
       (cl-letf (((symbol-function 'p3-pptx-spike--run)
                  (lambda (&rest _args) (setq bridge-called t) ""))
                 ((symbol-function 'p3-pptx-spike--render)
                  (lambda () (setq render-called t)))
-                ((symbol-function 'p3-pptx-spike--schedule-render)
-                 (lambda () (setq render-scheduled t)))
+                ((symbol-function 'p3-pptx-spike--schedule-persist)
+                 (lambda () (setq persist-scheduled t)))
                 ((symbol-function 'p3-pptx-spike--redisplay)
                  (lambda () (setq redisplayed t))))
         (p3-pptx-spike--edit 0.5 -0.25)
         (let ((shape (car (alist-get 'shapes p3-pptx-spike--model))))
           (should (= (alist-get 'left shape) 1.5))
           (should (= (alist-get 'top shape) 1.75)))
-        (should bridge-called)
         (should redisplayed)
-        (should render-scheduled)
+        (should persist-scheduled)
+        (should-not bridge-called)
         (should-not render-called)))))
+
+(ert-deftest p3-pptx-spike-repeated-edits-aggregate-before-persistence ()
+  (with-temp-buffer
+    (setq-local p3-pptx-spike--selected-id 7
+                p3-pptx-spike--model
+                `((slide_width . 10.0)
+                  (slide_height . 7.5)
+                  (shapes . (,(p3-pptx-spike-test--shape)))))
+    (cl-letf (((symbol-function 'p3-pptx-spike--schedule-persist) #'ignore)
+              ((symbol-function 'p3-pptx-spike--redisplay) #'ignore))
+      (p3-pptx-spike--edit 0.05 0.0)
+      (p3-pptx-spike--edit 0.05 0.0)
+      (p3-pptx-spike--edit 0.0 -0.05)
+      (let ((pending (gethash 7 p3-pptx-spike--pending-edits)))
+        (should pending)
+        (should (< (abs (- (plist-get pending :dx) 0.10)) 1e-9))
+        (should (< (abs (- (plist-get pending :dy) -0.05)) 1e-9))))))
 
 (ert-deftest p3-pptx-spike-render-snapshot-is-complete-before-use ()
   (let ((directory (make-temp-file "p3-pptx-spike-test-" t)))


### PR DESCRIPTION
## Purpose

Throwaway feasibility spike for visually moving ordinary objects in an existing PPTX from Emacs without using PowerPoint/Impress as the editing UI.

This is deliberately **not** proposed as a supported feature yet. The PR exists so the Emacs integration can be byte-compiled by the repository's existing Emacs CI and so the spike can be exercised before any promotion to the normal config.

## What the spike does

- opens a disposable working copy of an existing PPTX
- renders the actual working PPTX through LibreOffice and displays the slide in Emacs
- reads top-level object geometry from OOXML
- overlays selectable object bounds
- supports click selection, mouse drag to move, and arrow-key nudging
- saves the edited working copy as a new PPTX

## Important implementation result

The first prototype used `python-pptx` to save the modified presentation. That was rejected because a one-object move rewrote many unrelated package parts, including chart/master/layout XML.

The implementation in this branch instead patches only the selected object's transform in `ppt/slides/slideN.xml` and copies every other ZIP member byte-for-byte. It uses only the Python standard library for PPTX manipulation.

A fresh proof test against a LibreOffice-rewritten deck containing text, an embedded image, a native chart, and other shapes verifies:

1. inspection recognizes the picture and native chart without rewriting the deck;
2. moving the picture changes only the target slide XML member and the expected geometry;
3. a real LibreOffice before/after render changes only the union of the old/new picture regions.

Fresh local result before opening this PR: 3 tests run, 3 passed.

## Scope / non-goals

Supported top-level types in the spike: ordinary shapes/text boxes, pictures, graphic frames (including charts), and connectors.

Not attempted: SmartArt internals, grouped-object internals, animations, embedded Office-object internals, or a general PowerPoint clone.

Do not merge this as-is merely because CI is green. The remaining proof is an interactive run in graphical Emacs against real-world decks.