### PR TITLE
Extract Org configuration into focused boundaries

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -28,6 +28,7 @@ jobs:
             -L lisp \
             --eval '(require (quote use-package-ensure))' \
             --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            --eval '(require (quote p3-org-export))' \
             --eval '(setq byte-compile-error-on-warn t)' \
             -f batch-byte-compile \
             lisp/p3-platform.el \

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -47,7 +47,13 @@ jobs:
             lisp/p3-terminal.el \
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
-            lisp/p3-gptel.el
+            lisp/p3-gptel.el \
+            lisp/p3-org.el \
+            lisp/p3-config-org.el \
+            lisp/p3-org-roam.el \
+            lisp/p3-config-org-roam.el \
+            lisp/p3-org-present.el \
+            lisp/p3-config-org-present.el
 
       - name: Smoke-load Python configuration boundary
         run: |
@@ -59,6 +65,46 @@ jobs:
             -l lisp/p3-config-loader.el \
             -l lisp/p3-config-python.el \
             --eval '(unless (and (featurep (quote p3-config-python)) (featurep (quote p3-python)) (equal flycheck-python-flake8-executable "flake8")) (kill-emacs 1))'
+
+      - name: Smoke-load Org configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            -l lisp/p3-config-loader.el \
+            -l lisp/p3-config-org.el \
+            --eval '(unless (and (featurep (quote p3-config-org)) (featurep (quote p3-org)) (eq org-startup-folded (quote content)) (eq org-confirm-babel-evaluate t) (featurep (quote p3-org-export))) (kill-emacs 1))'
+
+      - name: Smoke-load Org-roam configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            --eval '(defun org-roam-db-autosync-mode (&optional _arg) t)' \
+            --eval '(provide (quote org-roam))' \
+            -l lisp/p3-config-loader.el \
+            -l lisp/p3-config-org-roam.el \
+            --eval '(unless (and (featurep (quote p3-config-org-roam)) (featurep (quote p3-org-roam)) (equal org-roam-directory "~/org/notes/roam/")) (kill-emacs 1))'
+
+      - name: Smoke-load Org presentation configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            --eval '(require (quote org))' \
+            --eval '(defvar org-present-mode-keymap (make-sparse-keymap))' \
+            --eval '(provide (quote hide-mode-line))' \
+            --eval '(provide (quote visual-fill-column))' \
+            --eval '(provide (quote org-present))' \
+            -l lisp/p3-config-loader.el \
+            -l lisp/p3-config-org-present.el \
+            --eval '(unless (and (featurep (quote p3-config-org-present)) (featurep (quote p3-org-present)) (featurep (quote face-remap)) (equal org-present-text-scale 4)) (kill-emacs 1))'
 
       - name: Run ERT test suite
         run: |
@@ -76,6 +122,12 @@ jobs:
             -l test/p3-ess-test.el \
             -l test/p3-gptel-test.el \
             -l test/p3-r-tools-test.el \
+            -l test/p3-org-test.el \
+            -l test/p3-config-org-test.el \
+            -l test/p3-org-roam-test.el \
+            -l test/p3-config-org-roam-test.el \
+            -l test/p3-org-present-test.el \
+            -l test/p3-config-org-present-test.el \
             -l test/p3-org-export-test.el \
             -l test/p3-commands-test.el \
             -l test/p3-git-test.el \

--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -88,7 +88,7 @@ jobs:
             --eval '(provide (quote org-roam))' \
             -l lisp/p3-config-loader.el \
             -l lisp/p3-config-org-roam.el \
-            --eval '(unless (and (featurep (quote p3-config-org-roam)) (featurep (quote p3-org-roam)) (equal org-roam-directory "~/org/notes/roam/")) (kill-emacs 1))'
+            --eval '(unless (and (featurep (quote p3-config-org-roam)) (featurep (quote p3-org-roam)) (fboundp (quote p3/org-roam-get-agenda))) (kill-emacs 1))'
 
       - name: Smoke-load Org presentation configuration boundary
         run: |
@@ -104,7 +104,7 @@ jobs:
             --eval '(provide (quote org-present))' \
             -l lisp/p3-config-loader.el \
             -l lisp/p3-config-org-present.el \
-            --eval '(unless (and (featurep (quote p3-config-org-present)) (featurep (quote p3-org-present)) (featurep (quote face-remap)) (equal org-present-text-scale 4)) (kill-emacs 1))'
+            --eval '(unless (and (featurep (quote p3-config-org-present)) (featurep (quote p3-org-present)) (featurep (quote face-remap)) (fboundp (quote p3/org-present-start))) (kill-emacs 1))'
 
       - name: Run ERT test suite
         run: |

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -16,6 +16,9 @@ on:
       - "lisp/p3-config-workspace.el"
       - "lisp/p3-config-git.el"
       - "lisp/p3-config-python.el"
+      - "lisp/p3-config-org.el"
+      - "lisp/p3-config-org-roam.el"
+      - "lisp/p3-config-org-present.el"
       - "lisp/p3-ess.el"
       - "lisp/p3-r-tools.el"
       - "test/p3-platform-test.el"
@@ -25,6 +28,9 @@ on:
       - "test/p3-config-test.el"
       - "test/p3-config-ess-test.el"
       - "test/p3-config-python-test.el"
+      - "test/p3-config-org-test.el"
+      - "test/p3-config-org-roam-test.el"
+      - "test/p3-config-org-present-test.el"
       - "test/p3-ess-test.el"
       - "test/p3-r-tools-test.el"
       - "test/p3-commands-test.el"
@@ -88,6 +94,9 @@ jobs:
           -l test/p3-config-test.el
           -l test/p3-config-ess-test.el
           -l test/p3-config-python-test.el
+          -l test/p3-config-org-test.el
+          -l test/p3-config-org-roam-test.el
+          -l test/p3-config-org-present-test.el
           -l test/p3-commands-test.el
           -l test/p3-git-test.el
           -f ert-run-tests-batch-and-exit

--- a/config.org
+++ b/config.org
@@ -337,228 +337,22 @@ Interactive commands to connect to default connection.
 
 ** org
 
-Set org default startup display for bullets globally
+Org core behavior lives in =lisp/p3-org.el=. Declarative Org, Babel, TODO,
+Agenda, PDF-opening, and export-activation configuration lives in
+=lisp/p3-config-org.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (setq org-startup-folded 'content)
-#+END_SRC
-
-Update last modified as shown [[https://org-roam.discourse.group/t/update-a-field-last-modified-at-save/321][here]]
-
-#+BEGIN_SRC emacs-lisp
-  (add-hook 'org-mode-hook (lambda ()
-                             (setq-local time-stamp-active t
-                                         time-stamp-start "#\\+last_modified:[ \t]*"
-                                         time-stamp-end "$"
-                                         time-stamp-format "\[%Y-%m-%d %3a %02H:%02M\]")
-                             (add-hook 'before-save-hook 'time-stamp nil 'local)))
-#+END_SRC
-
-#+BEGIN_SRC emacs-lisp
-    (use-package org
-      :defer t
-      :bind (:map org-mode-map
-                  ("C-c s" lambda() (interactive)
-                   (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
-      :hook ((org-mode . flyspell-mode)
-             (org-mode . visual-line-mode)
-             (org-mode . org-indent-mode))
-      :init
-      ;; Load some languages for org-babel
-      (org-babel-do-load-languages
-       'org-babel-load-languages
-       '((emacs-lisp .t)
-         (R . t)
-         (C . t)
-         (python . t)
-         (latex . t)
-         (shell . t)))
-      :config
-      ;; Treat every code block as executable and confirm before running it.
-      (setq org-confirm-babel-evaluate t
-            ;; Native font coloring
-            org-src-fontify-natively t
-            org-src-tab-acts-natively t
-            org-hide-emphasis-markers t
-            ;; Change ellipsis to dropdown thing
-            org-ellipsis " ↴"))
-#+END_SRC
-
-Turn org-mode bullets into utf-8 characters
-
-#+BEGIN_SRC emacs-lisp
-  ;; (use-package org-bullets
-  ;;       :defer t
-  ;;       :init (add-hook 'org-mode-hook 'org-bullets-mode))
-#+END_SRC
-
-Sort TODOs
-
-#+BEGIN_SRC emacs-lisp
-  (defun p3/org-sort-todos ()
-    "Sort sibling entries by TODO state without changing outline hierarchy.
-Run this on a parent heading to sort its children; DONE entries follow active
-TODO states according to `org-todo-keywords'."
-    (interactive)
-    (org-sort-entries nil ?o))
-
-  (define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
-#+END_SRC
-
-Load the Pandoc-backed Org export workflow from =lisp/p3-org-export.el=.
-This keeps the literate config responsible for enabling the workflow while the
-implementation remains independently testable.
-
-#+BEGIN_SRC emacs-lisp
-  (use-package p3-org-export
-    :ensure nil
-    :demand t
-    :config
-    (p3-org-export-setup))
-#+END_SRC
-
-Make sure org-mode calls evince (gnome pdf viewer) to [[https://emacs.stackexchange.com/questions/28037/org-mode-file-hyperlinks-always-use-doc-view-cant-force-it-to-use-external-pdf][open up pdf files]]
-
-#+BEGIN_SRC emacs-lisp
-  (when (eq system-type 'gnu/linux)
-    (add-to-list 'org-file-apps '("pdf" . "evince %s")))
-#+END_SRC
-
-Set region to checkboxes
-
-#+BEGIN_SRC emacs-lisp
-  (defun org-set-line-checkbox (arg)
-    (interactive "p")
-    (let ((n (or arg 1)))
-      (when (region-active-p)
-        (setq n (count-lines (region-beginning)
-                             (region-end)))
-        (goto-char (region-beginning)))
-      (dotimes (i n)
-        (beginning-of-line)
-        (insert "- [ ] ")
-        (forward-line))
-      (beginning-of-line)))
-#+END_SRC
-
-Include additional states in TODO cycle, as shown [[https://christiantietze.de/posts/2021/02/emacs-org-todo-doing-done-checkbox-cycling/][here]]
-
-#+BEGIN_SRC emacs-lisp
-    (setq org-todo-keywords
-        (quote ((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)")))
-        org-todo-keyword-faces
-        '(("WAIT" .  "DarkOrange" )))
-#+END_SRC
-
-** org-agenda
-
-org-agenda defaults, as shown [[https://orgmode.org/worg/org-tutorials/org-custom-agenda-commands.html][here]]
-
-#+BEGIN_SRC emacs-lisp
-  (use-package org-agenda
-    :ensure nil
-    ;; :bind ("C-c a" . org-agenda)
-    :config
-    (setq org-agenda-sorting-strategy '(priority-down))) ;;effort-down
+  (p3/config-load-module 'p3-config-org)
 #+END_SRC
 
 ** org-roam
 
-[[https://systemcrafters.net/build-a-second-brain-in-emacs/5-org-roam-hacks/#fast-note-insertion-for-a-smoother-writing-flow][From SC]], edited by p3 to include optional tags
+Org-roam package configuration lives in =lisp/p3-config-org-roam.el= and
+reusable Roam search, capture, filtering, and agenda helpers live in
+=lisp/p3-org-roam.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (defun org-roam-generate-tagged-header ()
-    (let ((tag (read-string "Enter tag: ")))
-      (if (string-empty-p tag)
-          (concat "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
-        (concat "#+title: ${title}\n#+category:${title}\n#+filetags: " tag "\n#+created: %U\n#+last_modified: %U\n#"))))
-
-  (defun org-roam-node-insert-immediate-with-tag (arg &rest args)
-        (interactive "p")
-        (let ((args (cons arg args))
-              (org-roam-capture-templates (list (append (car
-                                                         '(("t" "tagged" plain "%?"
-                :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" org-roam-generate-tagged-header)
-                :unnarrowed t)))
-                                                        '(:immediate-finish t)))))
-          (apply #'org-roam-node-insert args)))
-#+END_SRC
-
-[[https://www.reddit.com/r/orgmode/comments/vvx54j/comment/ifn434u/?utm_source=share&utm_medium=web2x&context=3][Search roam for...]] anything
-
-#+BEGIN_SRC emacs-lisp
-  (defun org-roam-rg-search ()
-    "Search org-roam directory using consult-ripgrep. With live-preview."
-    (interactive)
-    (consult-ripgrep org-roam-directory))
-#+END_SRC
-
-[[https://systemcrafters.net/build-a-second-brain-in-emacs/5-org-roam-hacks/#build-your-org-agenda-from-org-roam-notes][org-roam with org-agenda]]
-
-#+BEGIN_SRC emacs-lisp
-  (defun p3/org-roam-filter-by-tag (tag-name)
-    (lambda (node)
-      (member tag-name (org-roam-node-tags node))))
-
-  (defun p3/org-roam-list-notes ()
-    (mapcar #'org-roam-node-file
-             (org-roam-node-list)))
-
-  (defun p3/org-roam-list-notes-by-tag (tag-name)
-    (mapcar #'org-roam-node-file
-            (seq-filter
-             (p3/org-roam-filter-by-tag tag-name)
-             (org-roam-node-list))))
-
-  (defun p3/org-roam-get-agenda ()
-    (interactive)
-    (let ((tag (read-string "Enter tag: ")))
-      (if (string-empty-p tag)
-          (setq org-agenda-files (p3/org-roam-list-notes))
-        (setq org-agenda-files (p3/org-roam-list-notes-by-tag tag))))
-    (org-agenda))
-#+END_SRC
-
-Config from [[https://config.daviwil.com/emacs][System crafters]] with changes based on the basic config from the [[https://github.com/org-roam/org-roam][Github page]]
-See [[https://earvingad.github.io/posts/org_roam_windows/][the following]] for a installation walkthrough for windows
-
-#+BEGIN_SRC emacs-lisp
-  (use-package org-roam
-    :hook
-    (after-init . org-roam-mode)
-    :custom
-    (org-roam-database-connector 'sqlite-builtin)
-    (org-roam-directory "~/org/notes/roam/")
-    (org-roam-completion-everywhere t)
-    (org-roam-completion-system 'default)
-    (org-roam-capture-templates
-     '(("d" "default" plain "%?"
-        :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org" "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
-        :unnarrowed t)
-       ("n" "literature note" plain "* Heading\n %?"
-        :target (file+head "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
-                           "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
-        :unnarrowed t)))
-    (org-roam-dailies-directory "journal/")
-    (org-roam-dailies-capture-templates
-      '(("d" "default" entry "* %<%I:%M %p>: %?"
-         :target (file+head "%<%Y-%m-%d>.org" "#+title: %<%Y-%m-%d %a>\n#+created: %U\n#+last_modified: %U\n"))))
-
-    :bind (("C-c n l" . org-roam-buffer-toggle)
-           ("C-c n f" . org-roam-node-find)
-           ("C-c n g" . org-roam-graph)
-           ("C-c n i" . org-roam-node-insert)
-           ("C-c n c" . org-roam-capture)
-           ("C-c n n" . org-roam-node-insert-immediate-with-tag)
-           ("C-c n s" . org-roam-rg-search)
-         ;; Dailies
-           ("C-c n d" . org-roam-dailies-goto-today)
-           ("C-c n t" . org-roam-dailies-capture-today)
-           ("C-c n C-t" . org-roam-tag-add)
-           ("C-c n a" . p3/org-roam-get-agenda))
-    :config
-    (setq org-roam-node-display-template (concat "${title:*} " (propertize "${tags:10}" 'face 'org-tag)))
-    (org-roam-db-autosync-mode))
+  (p3/config-load-module 'p3-config-org-roam)
 #+END_SRC
 
 ** Poly-R
@@ -587,111 +381,12 @@ Require poly-R
 
 ** Presentation
 
-Do presentations with org-present
+Org presentation package wiring lives in =lisp/p3-config-org-present.el=;
+state capture/restoration and presentation commands live in
+=lisp/p3-org-present.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (use-package hide-mode-line
-    :after (org-present))
-
-  (use-package visual-fill-column)
-
-  (require 'face-remap)
-
-  (defvar-local p3/org-present--state nil
-    "Saved buffer state while `org-present' is active.")
-
-  (defun p3/org-present-start ()
-    "Start a presentation in the current Org buffer."
-    (interactive)
-    (unless (derived-mode-p 'org-mode)
-      (user-error "Presentation mode requires an Org buffer"))
-    (org-present))
-
-  (defun p3/org-present-toggle-fullscreen ()
-    "Toggle fullscreen for the current presentation frame."
-    (interactive)
-    (set-frame-parameter
-     nil 'fullscreen
-     (unless (frame-parameter nil 'fullscreen) 'fullboth)))
-
-  (defun p3/org-present-hook ()
-    "Prepare the current Org buffer for presentation mode."
-    (setq-local p3/org-present--state
-                (list :header-line header-line-format
-                      :line-numbers (bound-and-true-p display-line-numbers-mode)
-                      :inline-images (and (boundp 'org-inline-image-overlays)
-                                          org-inline-image-overlays)
-                      :visual-fill (bound-and-true-p visual-fill-column-mode)
-                      :visual-fill-width visual-fill-column-width
-                      :visual-fill-center visual-fill-column-center-text
-                      :hide-mode-line (bound-and-true-p hide-mode-line-mode)
-                      :face-remap-cookies nil))
-    (setq-local header-line-format " ")
-    (display-line-numbers-mode -1)
-    (org-present-big)
-    (unless (and (boundp 'org-inline-image-overlays)
-                 org-inline-image-overlays)
-      (org-display-inline-images))
-    (setq-local visual-fill-column-width 90
-                visual-fill-column-center-text t)
-    (visual-fill-column-mode 1)
-    (hide-mode-line-mode +1)
-    (setf (plist-get p3/org-present--state :face-remap-cookies)
-          (list (face-remap-add-relative 'org-level-1 :height 1.5)
-                (face-remap-add-relative 'org-level-2 :height 1.2)
-                (face-remap-add-relative 'org-level-3 :height 1.1))))
-
-  (defun p3/org-present-quit-hook ()
-    "Restore the buffer state saved by `p3/org-present-hook'."
-    (let ((state p3/org-present--state))
-      (org-present-small)
-      (when state
-        (setq-local header-line-format (plist-get state :header-line))
-        (if (plist-get state :line-numbers)
-            (display-line-numbers-mode +1)
-          (display-line-numbers-mode -1))
-        (unless (plist-get state :inline-images)
-          (org-remove-inline-images))
-        (setq-local visual-fill-column-width
-                    (plist-get state :visual-fill-width)
-                    visual-fill-column-center-text
-                    (plist-get state :visual-fill-center))
-        (if (plist-get state :visual-fill)
-            (visual-fill-column-mode +1)
-          (visual-fill-column-mode -1))
-        (if (plist-get state :hide-mode-line)
-            (hide-mode-line-mode +1)
-          (hide-mode-line-mode -1))
-        (dolist (cookie (plist-get state :face-remap-cookies))
-          (face-remap-remove-relative cookie)))
-      (setq-local p3/org-present--state nil)))
-
-  (defun p3/org-present-prev ()
-    "Move to the previous presentation slide."
-    (interactive)
-    (org-present-prev))
-
-  (defun p3/org-present-next ()
-    "Move to the next presentation slide."
-    (interactive)
-    (org-present-next))
-
-  (use-package org-present
-    :bind ((:map org-mode-map
-                 ("C-c P" . p3/org-present-start))
-           (:map org-present-mode-keymap
-                 ("C-c C-j" . p3/org-present-next)
-                 ("C-c C-k" . p3/org-present-prev)
-                 ("SPC" . p3/org-present-next)
-                 ("<backspace>" . p3/org-present-prev)
-                 ("n" . p3/org-present-next)
-                 ("p" . p3/org-present-prev)
-                 ("f" . p3/org-present-toggle-fullscreen)
-                 ("q" . org-present-quit)) )
-    :hook ((org-present-mode . p3/org-present-hook)
-           (org-present-mode-quit . p3/org-present-quit-hook))
-    :config
-    (setq org-present-text-scale 4))
+  (p3/config-load-module 'p3-config-org-present)
 #+END_SRC
 
 ** Projectile
@@ -777,7 +472,6 @@ preserve its original startup timing. Project-aware vterm behavior remains in
 #+END_SRC
 
 ** Spelling
-
 #+BEGIN_SRC emacs-lisp
   (use-package ispell
     :defer nil

--- a/docs/superpowers/plans/2026-09-05-org-config-boundaries.md
+++ b/docs/superpowers/plans/2026-09-05-org-config-boundaries.md
@@ -4,7 +4,7 @@
 
 **Goal:** Extract Org core, Org-roam, and Org presentation configuration from `config.org` into three focused configuration modules and three reusable behavior libraries without changing user-facing behavior or startup ordering.
 
-**Architecture:** `config.org` remains the explicit top-level map and loads `p3-config-org`, `p3-config-org-roam`, and `p3-config-org-present` in their current broad positions. Each configuration module owns declarative package wiring and exact-source loads its new behavior library; `p3-org-export.el` remains unchanged and retains its existing `use-package` activation/reload semantics.
+**Architecture:** `config.org` remains the explicit top-level map and loads `p3-config-org`, `p3-config-org-roam`, and `p3-config-org-present` in their current broad positions. Each new config module owns declarative wiring and exact-source loads only its new behavior library. `p3-org-export.el` remains unchanged and keeps its current `use-package` activation/reload semantics.
 
 **Tech Stack:** Emacs Lisp, Org, Org Agenda, Org Babel, Org-roam, org-present, `use-package`, ERT, GitHub Actions.
 
@@ -18,32 +18,33 @@
 - Preserve every existing Org, Roam, and presentation keybinding, hook, template, path, and setting.
 - Preserve Babel languages exactly: Emacs Lisp, R, C, Python, LaTeX, and shell.
 - Preserve `org-confirm-babel-evaluate t`.
-- Preserve the anonymous timestamp-on-save hook as an anonymous hook; do not normalize or deduplicate it.
-- Preserve legacy function names, including `org-set-line-checkbox`, `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, and `org-roam-rg-search`.
+- Preserve the anonymous timestamp-on-save hook as anonymous; do not name, deduplicate, or otherwise normalize it.
+- Preserve legacy command names, including `org-set-line-checkbox`, `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, and `org-roam-rg-search`.
 - Preserve the current trailing `#` in the nonblank tagged-header output.
-- `p3-org-export.el` must not change and must not gain exact-source reload semantics.
+- `lisp/p3-org-export.el` and `test/p3-org-export-test.el` must remain byte-for-byte unchanged.
+- `p3-org-export.el` must not gain exact-source reload semantics.
 - `p3-org-present.el` directly requires built-in `face-remap`.
-- Optional Org-roam/presentation packages must not be installed merely for byte compilation or smoke loading.
-- No broad `display-buffer-alist` policy or other window-management changes.
-- Keep CI economical: no iterative diagnostic workflows; use targeted tests and one final PR CI cycle after local/static verification.
+- Optional Org-roam/presentation packages must not be installed merely for compilation or smoke loading.
+- No broad `display-buffer-alist` policy or other window-management change.
+- Keep CI economical: no diagnostic workflows or iterative Actions loops; perform one final PR CI cycle once the implementation head is coherent.
 
 ---
 
 ## File Map
 
-### New behavior libraries
+**Create behavior libraries**
 
-- `lisp/p3-org.el` — reusable core Org commands only.
-- `lisp/p3-org-roam.el` — reusable Org-roam helper/search/agenda behavior only.
+- `lisp/p3-org.el` — reusable core Org commands.
+- `lisp/p3-org-roam.el` — reusable Org-roam helper/search/agenda behavior.
 - `lisp/p3-org-present.el` — stateful presentation behavior and direct `face-remap` dependency.
 
-### New configuration modules
+**Create configuration modules**
 
-- `lisp/p3-config-org.el` — Org core, Babel, TODO, Agenda, PDF handling, and existing `p3-org-export` activation.
-- `lisp/p3-config-org-roam.el` — Org-roam package settings, templates, bindings, and autosync.
-- `lisp/p3-config-org-present.el` — hide-mode-line, visual-fill-column, org-present package wiring, bindings, hooks, and text scale.
+- `lisp/p3-config-org.el` — Org core, Babel, TODO, Agenda, PDF handling, and unchanged `p3-org-export` activation.
+- `lisp/p3-config-org-roam.el` — Org-roam settings, capture templates, bindings, and autosync.
+- `lisp/p3-config-org-present.el` — hide-mode-line, visual-fill-column, org-present bindings/hooks/config.
 
-### New focused tests
+**Create focused tests**
 
 - `test/p3-org-test.el`
 - `test/p3-config-org-test.el`
@@ -52,21 +53,21 @@
 - `test/p3-org-present-test.el`
 - `test/p3-config-org-present-test.el`
 
-### Existing files to modify
+**Modify**
 
-- `config.org` — replace only the current Org, Org-roam, and Presentation implementation blocks with concise module-loader stanzas; leave intervening/out-of-scope sections in place.
-- `test/p3-config-test.el` — update module ownership/count/order assertions and moved-code exclusions.
-- `.github/workflows/emacs-tests.yml` — compile six new Lisp files, load six focused test files, and add three runtime smoke checks.
-- `.github/workflows/windows-platform-tests.yml` — add source-level architecture/config-boundary coverage and matching path triggers only; do not install optional packages.
+- `config.org`
+- `test/p3-config-test.el`
+- `.github/workflows/emacs-tests.yml`
+- `.github/workflows/windows-platform-tests.yml`
 
-### Existing files that must remain unchanged
+**Must not modify**
 
 - `lisp/p3-org-export.el`
 - `test/p3-org-export-test.el`
 
 ---
 
-### Task 1: Extract Org core behavior and declarative configuration
+### Task 1: Extract Org core behavior and configuration
 
 **Files:**
 - Create: `lisp/p3-org.el`
@@ -75,50 +76,77 @@
 - Create: `test/p3-config-org-test.el`
 
 **Interfaces:**
-- Consumes: `p3/config-load-module` from `p3-config-loader.el`; built-in Org functions at runtime; existing `p3-org-export` feature through unchanged `use-package` activation.
-- Produces: `p3/org-sort-todos`, `org-set-line-checkbox`, feature `p3-org`, feature `p3-config-org`.
+- Consumes: `p3/config-load-module`, built-in Org APIs at runtime, existing `p3-org-export` through unchanged `use-package` activation.
+- Produces: `p3/org-sort-todos`, `org-set-line-checkbox`, features `p3-org` and `p3-config-org`.
 
-- [ ] **Step 1: Write failing core behavior tests before creating `p3-org.el`**
+- [ ] **Step 1: Write failing behavior tests for the two extracted commands**
 
-Create `test/p3-org-test.el` with a repository-root/load-path setup matching the existing test files, then define tests that stub the Org entry points instead of requiring package configuration.
-
-Use this shape for TODO sorting:
+Create `test/p3-org-test.el` with the standard repository-root/load-path setup and:
 
 ```elisp
-(ert-deftest p3-org-sort-todos-preserves-current-org-sort-call ()
+;;; p3-org-test.el --- Tests for p3-org -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'ert)
+
+(defconst p3-org-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name)))))
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-org-test--root))
+(require 'p3-org)
+
+(ert-deftest p3-org-sort-todos-preserves-current-sort-call ()
   (let (seen)
     (cl-letf (((symbol-function 'org-sort-entries)
                (lambda (&rest args) (setq seen args))))
       (p3/org-sort-todos)
-      (should (equal seen '(nil 111))))))
+      (should (equal seen (list nil ?o))))))
+
+(ert-deftest p3-org-set-line-checkbox-prefixes-current-line ()
+  (with-temp-buffer
+    (insert "alpha\nbeta\n")
+    (goto-char (point-min))
+    (org-set-line-checkbox 1)
+    (should (equal (buffer-string) "- [ ] alpha\nbeta\n"))
+    (should (= (point) (line-beginning-position)))))
+
+(ert-deftest p3-org-set-line-checkbox-prefixes-active-region-lines ()
+  (with-temp-buffer
+    (transient-mark-mode 1)
+    (insert "alpha\nbeta\ngamma\n")
+    (goto-char (point-min))
+    (push-mark (line-beginning-position 3) t t)
+    (activate-mark)
+    (org-set-line-checkbox 1)
+    (should (equal (buffer-string)
+                   "- [ ] alpha\n- [ ] beta\ngamma\n"))
+    (should (looking-at "gamma"))))
+
+(provide 'p3-org-test)
+;;; p3-org-test.el ends here
 ```
 
-`111` is the character code for `?o`; if the implementation/test uses `?o` directly, the assertion may use `'(nil ?o)`.
+- [ ] **Step 2: Verify RED before creating the behavior file**
 
-For checkbox behavior, cover both no-region and active-region semantics using temporary buffers. Pin the literal inserted prefix `"- [ ] "`, the number of affected lines, and the final cursor at the beginning of the last processed line as the current function does.
-
-- [ ] **Step 2: Verify the focused behavior tests fail because `p3-org.el` does not exist**
-
-Run, when Emacs is available:
+Run when local Emacs is available:
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-org-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-org-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL/load error for missing `p3-org` or undefined extracted commands.
+Expected: load failure because `p3-org` does not exist. In the connector-only ChatGPT harness, preserve this test-first commit ordering and do not spend a standalone Actions run solely to demonstrate the expected missing-file failure.
 
-In the ChatGPT connector harness, where Emacs is unavailable locally, preserve this RED-before-GREEN commit ordering and defer executable confirmation to the final Actions gate rather than spending a standalone CI run.
-
-- [ ] **Step 3: Create the minimal `p3-org.el` behavior library**
-
-Move the two existing definitions without redesign:
+- [ ] **Step 3: Create `lisp/p3-org.el` exactly as the behavior boundary**
 
 ```elisp
 ;;; p3-org.el --- Core Org workflow helpers -*- lexical-binding: t; -*-
 
-(declare-function org-sort-entries "org" (&optional with-case sorting-type get-key-func compare-func property interactive?))
+(declare-function org-sort-entries
+                  "org"
+                  (&optional with-case sorting-type get-key-func compare-func
+                             property interactive?))
 
 (defun p3/org-sort-todos ()
   "Sort sibling entries by TODO state without changing outline hierarchy.
@@ -141,35 +169,47 @@ TODO states according to `org-todo-keywords'."
     (beginning-of-line)))
 
 (provide 'p3-org)
-
 ;;; p3-org.el ends here
 ```
 
-Do not `(require 'org)` merely to define these functions. Add only compiler declarations actually needed by warnings-as-errors compilation.
+Do not require Org merely to define these commands.
 
-- [ ] **Step 4: Run the core behavior tests and make only behavior-preserving corrections**
-
-Run:
+- [ ] **Step 4: Run the behavior tests**
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-org-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-org-test.el -f ert-run-tests-batch-and-exit
 ```
 
 Expected: PASS.
 
-- [ ] **Step 5: Write source-semantic tests for `p3-config-org.el` before creating it**
+- [ ] **Step 5: Write failing source-semantic tests for `p3-config-org.el`**
 
-Create `test/p3-config-org-test.el` using the parsed-form helpers already established in `test/p3-config-python-test.el`: read top-level forms, find `use-package` forms, and inspect keyword sections.
+Create `test/p3-config-org-test.el` using the parsed-form helper pattern from `test/p3-config-python-test.el`. The tests must assert all of the following exact facts:
 
-Tests must pin at minimum:
+1. `(p3/config-load-module 'p3-org)` exists before the binding of `p3/org-sort-todos`.
+2. `org-startup-folded` is `content`.
+3. The anonymous timestamp hook still sets:
 
 ```elisp
-(p3/config-load-module 'p3-org)
+time-stamp-active t
+time-stamp-start "#\\+last_modified:[ \t]*"
+time-stamp-end "$"
+time-stamp-format "\[%Y-%m-%d %3a %02H:%02M\]"
 ```
 
-before the command binding; the exact Babel language list:
+and locally adds `time-stamp` to `before-save-hook`.
+4. The `use-package org` block preserves:
+
+```elisp
+:bind (:map org-mode-map
+            ("C-c s" lambda () (interactive)
+             (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
+:hook ((org-mode . flyspell-mode)
+       (org-mode . visual-line-mode)
+       (org-mode . org-indent-mode))
+```
+
+5. Babel languages are exactly:
 
 ```elisp
 '((emacs-lisp . t)
@@ -180,25 +220,18 @@ before the command binding; the exact Babel language list:
   (shell . t))
 ```
 
-and these values:
+6. Org settings are exactly:
 
 ```elisp
-(setq org-startup-folded 'content)
 (setq org-confirm-babel-evaluate t
       org-src-fontify-natively t
       org-src-tab-acts-natively t
       org-hide-emphasis-markers t
       org-ellipsis " ↴")
-(setq org-todo-keywords
-      '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
-      org-todo-keyword-faces
-      '(("WAIT" . "DarkOrange")))
-(setq org-agenda-sorting-strategy '(priority-down))
 ```
 
-Pin the existing Org hooks, `C-c s`, `C-c C-x C-o`, Linux Evince PDF association, and the anonymous timestamp hook body.
-
-Also assert that the module retains unchanged exporter activation in substance:
+7. `C-c C-x C-o` binds `p3/org-sort-todos`.
+8. The exporter activation is still:
 
 ```elisp
 (use-package p3-org-export
@@ -208,23 +241,30 @@ Also assert that the module retains unchanged exporter activation in substance:
   (p3-org-export-setup))
 ```
 
-and assert there is **no** `(p3/config-load-module 'p3-org-export)` form.
+and there is no `(p3/config-load-module 'p3-org-export)`.
+9. Linux PDF handling remains `(add-to-list 'org-file-apps '("pdf" . "evince %s"))`.
+10. TODO state remains:
 
-- [ ] **Step 6: Verify the config-boundary tests fail because the new module does not exist**
-
-Run:
-
-```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-org-test.el \
-  -f ert-run-tests-batch-and-exit
+```elisp
+(setq org-todo-keywords
+      '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
+      org-todo-keyword-faces
+      '(("WAIT" . "DarkOrange")))
 ```
 
-Expected: FAIL due to missing `lisp/p3-config-org.el`.
+11. Org Agenda remains `(setq org-agenda-sorting-strategy '(priority-down))`.
 
-- [ ] **Step 7: Create `p3-config-org.el` by moving the current forms without normalization**
+- [ ] **Step 6: Verify the config tests are RED**
 
-Start with:
+```bash
+emacs -Q --batch -L lisp -l test/p3-config-org-test.el -f ert-run-tests-batch-and-exit
+```
+
+Expected: missing `lisp/p3-config-org.el`.
+
+- [ ] **Step 7: Create `lisp/p3-config-org.el` with the complete moved configuration**
+
+Use this implementation, preserving the current anonymous hook and exporter activation:
 
 ```elisp
 ;;; p3-config-org.el --- Org configuration -*- lexical-binding: t; -*-
@@ -232,22 +272,85 @@ Start with:
 (require 'use-package)
 (require 'p3-config-loader)
 
+(defvar org-agenda-sorting-strategy)
+(defvar org-confirm-babel-evaluate)
+(defvar org-ellipsis)
+(defvar org-file-apps)
+(defvar org-hide-emphasis-markers)
+(defvar org-mode-map)
+(defvar org-src-fontify-natively)
+(defvar org-src-tab-acts-natively)
+(defvar org-startup-folded)
+(defvar org-todo-keyword-faces)
+(defvar org-todo-keywords)
+
+(declare-function org-babel-do-load-languages "ob-core" (sym value))
+(declare-function p3-org-export-setup "p3-org-export" ())
+
 (p3/config-load-module 'p3-org)
-```
 
-Then move the current executable Org forms in their current semantic order: `org-startup-folded`, anonymous timestamp hook, `use-package org`, `p3/org-sort-todos` binding, unchanged `use-package p3-org-export`, Linux Evince association, TODO keywords/faces, and `use-package org-agenda` sorting.
+(setq org-startup-folded 'content)
 
-Do not move the earlier Citar/BibTeX/RefTeX block or the LaTeX block into this file.
+(add-hook 'org-mode-hook
+          (lambda ()
+            (setq-local time-stamp-active t
+                        time-stamp-start "#\\+last_modified:[ \t]*"
+                        time-stamp-end "$"
+                        time-stamp-format "\[%Y-%m-%d %3a %02H:%02M\]")
+            (add-hook 'before-save-hook 'time-stamp nil 'local)))
 
-End with:
+(use-package org
+  :defer t
+  :bind (:map org-mode-map
+              ("C-c s" lambda () (interactive)
+               (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
+  :hook ((org-mode . flyspell-mode)
+         (org-mode . visual-line-mode)
+         (org-mode . org-indent-mode))
+  :init
+  (org-babel-do-load-languages
+   'org-babel-load-languages
+   '((emacs-lisp . t)
+     (R . t)
+     (C . t)
+     (python . t)
+     (latex . t)
+     (shell . t)))
+  :config
+  (setq org-confirm-babel-evaluate t
+        org-src-fontify-natively t
+        org-src-tab-acts-natively t
+        org-hide-emphasis-markers t
+        org-ellipsis " ↴"))
 
-```elisp
+(define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
+
+(use-package p3-org-export
+  :ensure nil
+  :demand t
+  :config
+  (p3-org-export-setup))
+
+(when (eq system-type 'gnu/linux)
+  (add-to-list 'org-file-apps '("pdf" . "evince %s")))
+
+(setq org-todo-keywords
+      '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
+      org-todo-keyword-faces
+      '(("WAIT" . "DarkOrange")))
+
+(use-package org-agenda
+  :ensure nil
+  :config
+  (setq org-agenda-sorting-strategy '(priority-down)))
+
 (provide 'p3-config-org)
+;;; p3-config-org.el ends here
 ```
+
+If warnings-as-errors reports a compiler-only declaration mismatch, adjust only declarations/signatures; do not change executable forms.
 
 - [ ] **Step 8: Run both focused Org test files**
-
-Run:
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -258,17 +361,16 @@ emacs -Q --batch -L lisp \
 
 Expected: PASS.
 
-- [ ] **Step 9: Commit the core Org extraction**
+- [ ] **Step 9: Commit Task 1**
 
 ```bash
-git add lisp/p3-org.el lisp/p3-config-org.el \
-        test/p3-org-test.el test/p3-config-org-test.el
+git add lisp/p3-org.el lisp/p3-config-org.el test/p3-org-test.el test/p3-config-org-test.el
 git commit -m "Extract Org core configuration boundary"
 ```
 
 ---
 
-### Task 2: Extract Org-roam behavior and declarative configuration
+### Task 2: Extract Org-roam behavior and configuration
 
 **Files:**
 - Create: `lisp/p3-org-roam.el`
@@ -277,56 +379,40 @@ git commit -m "Extract Org core configuration boundary"
 - Create: `test/p3-config-org-roam-test.el`
 
 **Interfaces:**
-- Consumes: `p3/config-load-module`; Org-roam functions/variables at runtime; `consult-ripgrep`; `org-agenda`; `seq`; `subr-x`.
-- Produces: `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, `org-roam-rg-search`, `p3/org-roam-filter-by-tag`, `p3/org-roam-list-notes`, `p3/org-roam-list-notes-by-tag`, `p3/org-roam-get-agenda`, feature `p3-org-roam`, feature `p3-config-org-roam`.
+- Consumes: `p3/config-load-module`; Org-roam APIs at runtime; `consult-ripgrep`; `org-agenda`; built-in `seq`/`subr-x`.
+- Produces: `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, `org-roam-rg-search`, `p3/org-roam-filter-by-tag`, `p3/org-roam-list-notes`, `p3/org-roam-list-notes-by-tag`, `p3/org-roam-get-agenda`, features `p3-org-roam` and `p3-config-org-roam`.
 
-- [ ] **Step 1: Write failing Org-roam behavior tests with no real database**
+- [ ] **Step 1: Write failing behavior tests that use stubs instead of a database**
 
-Create `test/p3-org-roam-test.el`. Require only ERT/CL helpers and `p3-org-roam`; stub Org-roam functions.
-
-Pin blank tagged-header output exactly:
+Create `test/p3-org-roam-test.el`. Pin these two exact header outputs:
 
 ```elisp
 "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n"
 ```
 
-Pin nonblank output exactly, including the current trailing `#`:
+and, for tag `work`, including the trailing `#`:
 
 ```elisp
 "#+title: ${title}\n#+category:${title}\n#+filetags: work\n#+created: %U\n#+last_modified: %U\n#"
 ```
 
-For list/filter tests, stub:
+Use `cl-letf` stubs for `read-string`, `org-roam-node-list`, `org-roam-node-file`, `org-roam-node-tags`, `org-roam-node-insert`, `consult-ripgrep`, and `org-agenda`. Assert:
 
-```elisp
-org-roam-node-list
-org-roam-node-file
-org-roam-node-tags
-```
+- blank/nonblank tag predicates;
+- all-note and tag-filtered file lists;
+- `p3/org-roam-get-agenda` sets `org-agenda-files` correctly and calls `org-agenda`;
+- `org-roam-rg-search` forwards `org-roam-directory` exactly;
+- immediate insertion passes through its original args and dynamically supplies a one-entry tagged capture template whose plist contains `:immediate-finish t`.
 
-using simple plist/alist nodes and `cl-letf`.
-
-For `p3/org-roam-get-agenda`, stub `read-string`, the listing functions, and `org-agenda`; assert `org-agenda-files` receives all files for blank input and only tagged files for nonblank input.
-
-For `org-roam-rg-search`, bind `org-roam-directory` to a sentinel path and stub `consult-ripgrep`; assert the exact directory argument is forwarded.
-
-For immediate insertion, capture the dynamically bound `org-roam-capture-templates` inside a stubbed `org-roam-node-insert` call and assert `:immediate-finish t` is present.
-
-- [ ] **Step 2: Verify Org-roam behavior tests fail before implementation**
-
-Run:
+- [ ] **Step 2: Verify RED before creating the behavior library**
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-org-roam-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-org-roam-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL/load error for missing `p3-org-roam`.
+Expected: missing `p3-org-roam`.
 
-- [ ] **Step 3: Create `p3-org-roam.el` by moving the current helpers verbatim in behavior**
-
-Use this dependency shape:
+- [ ] **Step 3: Create `lisp/p3-org-roam.el` with the complete moved helpers**
 
 ```elisp
 ;;; p3-org-roam.el --- Org-roam workflow helpers -*- lexical-binding: t; -*-
@@ -344,55 +430,137 @@ Use this dependency shape:
 (declare-function org-roam-node-insert "org-roam-node" (&optional arg &rest args))
 (declare-function org-roam-node-list "org-roam-node" ())
 (declare-function org-roam-node-tags "org-roam-node" (node))
+
+(defun org-roam-generate-tagged-header ()
+  (let ((tag (read-string "Enter tag: ")))
+    (if (string-empty-p tag)
+        (concat "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+      (concat "#+title: ${title}\n#+category:${title}\n#+filetags: " tag
+              "\n#+created: %U\n#+last_modified: %U\n#"))))
+
+(defun org-roam-node-insert-immediate-with-tag (arg &rest args)
+  (interactive "p")
+  (let ((args (cons arg args))
+        (org-roam-capture-templates
+         (list
+          (append
+           (car
+            '(("t" "tagged" plain "%?"
+               :if-new
+               (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                          org-roam-generate-tagged-header)
+               :unnarrowed t)))
+           '(:immediate-finish t)))))
+    (apply #'org-roam-node-insert args)))
+
+(defun org-roam-rg-search ()
+  "Search org-roam directory using consult-ripgrep. With live-preview."
+  (interactive)
+  (consult-ripgrep org-roam-directory))
+
+(defun p3/org-roam-filter-by-tag (tag-name)
+  (lambda (node)
+    (member tag-name (org-roam-node-tags node))))
+
+(defun p3/org-roam-list-notes ()
+  (mapcar #'org-roam-node-file
+          (org-roam-node-list)))
+
+(defun p3/org-roam-list-notes-by-tag (tag-name)
+  (mapcar #'org-roam-node-file
+          (seq-filter
+           (p3/org-roam-filter-by-tag tag-name)
+           (org-roam-node-list))))
+
+(defun p3/org-roam-get-agenda ()
+  (interactive)
+  (let ((tag (read-string "Enter tag: ")))
+    (if (string-empty-p tag)
+        (setq org-agenda-files (p3/org-roam-list-notes))
+      (setq org-agenda-files (p3/org-roam-list-notes-by-tag tag))))
+  (org-agenda))
+
+(provide 'p3-org-roam)
+;;; p3-org-roam.el ends here
 ```
 
-Then move the seven current helper functions unchanged, including the trailing `#` behavior.
+Do not require `org-roam` solely to define these helpers.
 
-Do not require `org-roam` solely to define the helpers.
+- [ ] **Step 4: Run the focused behavior tests**
 
-- [ ] **Step 4: Run Org-roam behavior tests**
+```bash
+emacs -Q --batch -L lisp -l test/p3-org-roam-test.el -f ert-run-tests-batch-and-exit
+```
 
-Run the focused file and expect PASS.
+Expected: PASS.
 
-- [ ] **Step 5: Write failing source-semantic tests for the Org-roam config owner**
+- [ ] **Step 5: Write failing source-semantic tests for the Roam config owner**
 
-Create `test/p3-config-org-roam-test.el` using parsed top-level forms. Assert:
+Create `test/p3-config-org-roam-test.el` using parsed top-level forms. Assert `(p3/config-load-module 'p3-org-roam)` occurs before `(use-package org-roam ...)` and structurally compare these exact values:
 
 ```elisp
-(p3/config-load-module 'p3-org-roam)
+(org-roam-database-connector 'sqlite-builtin)
+(org-roam-directory "~/org/notes/roam/")
+(org-roam-completion-everywhere t)
+(org-roam-completion-system 'default)
+(org-roam-dailies-directory "journal/")
 ```
 
-occurs before `(use-package org-roam ...)`, and pin the current `:hook`, `:custom`, `:bind`, and `:config` values.
-
-The test must compare the current default capture template, literature-note capture template, and dailies template structurally, including this target expression:
+Pin the exact default capture template:
 
 ```elisp
-(file+head
- "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
- "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+'(("d" "default" plain "%?"
+   :if-new (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                      "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+   :unnarrowed t)
 ```
 
-Pin all existing bindings:
+plus the existing literature-note entry:
+
+```elisp
+("n" "literature note" plain "* Heading\n %?"
+ :target
+ (file+head
+  "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
+  "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+ :unnarrowed t)
+```
+
+and dailies template:
+
+```elisp
+'(("d" "default" entry "* %<%I:%M %p>: %?"
+   :target
+   (file+head "%<%Y-%m-%d>.org"
+              "#+title: %<%Y-%m-%d %a>\n#+created: %U\n#+last_modified: %U\n")))
+```
+
+Pin all bindings exactly:
 
 ```text
-C-c n l  org-roam-buffer-toggle
-C-c n f  org-roam-node-find
-C-c n g  org-roam-graph
-C-c n i  org-roam-node-insert
-C-c n c  org-roam-capture
-C-c n n  org-roam-node-insert-immediate-with-tag
-C-c n s  org-roam-rg-search
-C-c n d  org-roam-dailies-goto-today
-C-c n t  org-roam-dailies-capture-today
+C-c n l   org-roam-buffer-toggle
+C-c n f   org-roam-node-find
+C-c n g   org-roam-graph
+C-c n i   org-roam-node-insert
+C-c n c   org-roam-capture
+C-c n n   org-roam-node-insert-immediate-with-tag
+C-c n s   org-roam-rg-search
+C-c n d   org-roam-dailies-goto-today
+C-c n t   org-roam-dailies-capture-today
 C-c n C-t org-roam-tag-add
-C-c n a  p3/org-roam-get-agenda
+C-c n a   p3/org-roam-get-agenda
 ```
 
-Pin `(org-roam-db-autosync-mode)` and the current node display template.
+Also pin:
 
-- [ ] **Step 6: Create `p3-config-org-roam.el`**
+```elisp
+(setq org-roam-node-display-template
+      (concat "${title:*} "
+              (propertize "${tags:10}" 'face 'org-tag)))
+(org-roam-db-autosync-mode)
+```
 
-Use:
+- [ ] **Step 6: Create `lisp/p3-config-org-roam.el` with the complete current declaration**
 
 ```elisp
 ;;; p3-config-org-roam.el --- Org-roam configuration -*- lexical-binding: t; -*-
@@ -400,21 +568,73 @@ Use:
 (require 'use-package)
 (require 'p3-config-loader)
 
+(defvar org-roam-node-display-template)
+
+(declare-function org-roam-db-autosync-mode "org-roam-db" (&optional arg))
+
 (p3/config-load-module 'p3-org-roam)
 
 (use-package org-roam
-  ...current declaration moved without semantic edits...)
+  :hook
+  (after-init . org-roam-mode)
+  :custom
+  (org-roam-database-connector 'sqlite-builtin)
+  (org-roam-directory "~/org/notes/roam/")
+  (org-roam-completion-everywhere t)
+  (org-roam-completion-system 'default)
+  (org-roam-capture-templates
+   '(("d" "default" plain "%?"
+      :if-new
+      (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                 "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+      :unnarrowed t)
+     ("n" "literature note" plain "* Heading\n %?"
+      :target
+      (file+head
+       "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
+       "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+      :unnarrowed t)))
+  (org-roam-dailies-directory "journal/")
+  (org-roam-dailies-capture-templates
+   '(("d" "default" entry "* %<%I:%M %p>: %?"
+      :target
+      (file+head "%<%Y-%m-%d>.org"
+                 "#+title: %<%Y-%m-%d %a>\n#+created: %U\n#+last_modified: %U\n"))))
+  :bind (("C-c n l" . org-roam-buffer-toggle)
+         ("C-c n f" . org-roam-node-find)
+         ("C-c n g" . org-roam-graph)
+         ("C-c n i" . org-roam-node-insert)
+         ("C-c n c" . org-roam-capture)
+         ("C-c n n" . org-roam-node-insert-immediate-with-tag)
+         ("C-c n s" . org-roam-rg-search)
+         ("C-c n d" . org-roam-dailies-goto-today)
+         ("C-c n t" . org-roam-dailies-capture-today)
+         ("C-c n C-t" . org-roam-tag-add)
+         ("C-c n a" . p3/org-roam-get-agenda))
+  :config
+  (setq org-roam-node-display-template
+        (concat "${title:*} "
+                (propertize "${tags:10}" 'face 'org-tag)))
+  (org-roam-db-autosync-mode))
 
 (provide 'p3-config-org-roam)
+;;; p3-config-org-roam.el ends here
 ```
 
-Keep `citar-org-roam` outside this file. Do not alter its existing earlier `:after (citar org-roam)` declaration.
+Keep the existing earlier `use-package citar-org-roam` block in `config.org`; do not move it into this module.
 
 - [ ] **Step 7: Run both focused Roam test files**
 
-Run both and expect PASS without creating a real Roam database or touching `~/org/notes/roam/`.
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-roam-test.el \
+  -l test/p3-config-org-roam-test.el \
+  -f ert-run-tests-batch-and-exit
+```
 
-- [ ] **Step 8: Commit the Roam extraction**
+Expected: PASS without creating a real Roam database.
+
+- [ ] **Step 8: Commit Task 2**
 
 ```bash
 git add lisp/p3-org-roam.el lisp/p3-config-org-roam.el \
@@ -424,7 +644,7 @@ git commit -m "Extract Org-roam configuration boundary"
 
 ---
 
-### Task 3: Extract presentation state behavior and package wiring
+### Task 3: Extract presentation behavior and configuration
 
 **Files:**
 - Create: `lisp/p3-org-present.el`
@@ -433,24 +653,22 @@ git commit -m "Extract Org-roam configuration boundary"
 - Create: `test/p3-config-org-present-test.el`
 
 **Interfaces:**
-- Consumes: built-in `face-remap`; runtime `org-present`, `visual-fill-column`, and `hide-mode-line` functions/variables supplied by packages.
-- Produces: `p3/org-present--state`, `p3/org-present-start`, `p3/org-present-toggle-fullscreen`, `p3/org-present-hook`, `p3/org-present-quit-hook`, `p3/org-present-prev`, `p3/org-present-next`, feature `p3-org-present`, feature `p3-config-org-present`.
+- Consumes: built-in `face-remap`; optional `org-present`, `visual-fill-column`, and `hide-mode-line` APIs at runtime.
+- Produces: `p3/org-present--state`, `p3/org-present-start`, `p3/org-present-toggle-fullscreen`, `p3/org-present-hook`, `p3/org-present-quit-hook`, `p3/org-present-prev`, `p3/org-present-next`, features `p3-org-present` and `p3-config-org-present`.
 
-- [ ] **Step 1: Write failing presentation behavior tests before implementation**
+- [ ] **Step 1: Write failing behavior tests with all optional-package calls stubbed**
 
-Create `test/p3-org-present-test.el` and stub every optional-package function the behavior calls.
+Create `test/p3-org-present-test.el`. Cover:
 
-Tests must cover:
+- `p3/org-present-start` rejects a non-Org buffer with `user-error` and calls `org-present` in an Org-derived-mode test buffer;
+- fullscreen toggles nil -> `fullboth` -> nil by stubbing `frame-parameter`/`set-frame-parameter`;
+- next/prev wrappers delegate once;
+- enter hook stores header-line, line-number state, inline-image state, visual-fill state/settings, hide-mode-line state, and remap cookies, then applies line numbers off, `org-present-big`, inline images if absent, width `90`, centering `t`, visual-fill on, hide-mode-line on, and scale factors `1.5`, `1.2`, `1.1`;
+- quit hook calls `org-present-small`, restores each prior state, removes every stored remap cookie, and clears `p3/org-present--state`.
 
-1. `p3/org-present-start` signals `user-error` outside Org-derived modes and delegates to `org-present` inside a stubbed Org context.
-2. `p3/org-present-toggle-fullscreen` changes frame parameter `fullscreen` from nil to `fullboth` and back.
-3. `p3/org-present-next` and `p3/org-present-prev` delegate exactly once.
-4. `p3/org-present-hook` captures header line, line-number mode state, inline-image state, visual-fill state/settings, hide-mode-line state, and face-remap cookies; then applies width `90`, centered text, hide-mode-line, and face scales `1.5`, `1.2`, `1.1`.
-5. `p3/org-present-quit-hook` calls `org-present-small`, restores each saved state, removes each remap cookie, and sets `p3/org-present--state` back to nil.
+Stub with `cl-letf`:
 
-Use `cl-letf` stubs for:
-
-```elisp
+```text
 org-present
 org-present-big
 org-present-small
@@ -465,13 +683,15 @@ face-remap-add-relative
 face-remap-remove-relative
 ```
 
-- [ ] **Step 2: Verify presentation behavior tests fail before `p3-org-present.el` exists**
+- [ ] **Step 2: Verify RED before creating `p3-org-present.el`**
 
-Run focused ERT and expect FAIL/load error.
+```bash
+emacs -Q --batch -L lisp -l test/p3-org-present-test.el -f ert-run-tests-batch-and-exit
+```
 
-- [ ] **Step 3: Create `p3-org-present.el` with direct `face-remap` ownership**
+Expected: missing `p3-org-present`.
 
-Start with:
+- [ ] **Step 3: Create `lisp/p3-org-present.el` with direct `face-remap` dependency and unchanged behavior**
 
 ```elisp
 ;;; p3-org-present.el --- Org presentation behavior -*- lexical-binding: t; -*-
@@ -491,19 +711,101 @@ Start with:
 (declare-function org-present-small "org-present" ())
 (declare-function org-remove-inline-images "org" ())
 (declare-function visual-fill-column-mode "visual-fill-column" (&optional arg))
+
+(defvar-local p3/org-present--state nil
+  "Saved buffer state while `org-present' is active.")
+
+(defun p3/org-present-start ()
+  "Start a presentation in the current Org buffer."
+  (interactive)
+  (unless (derived-mode-p 'org-mode)
+    (user-error "Presentation mode requires an Org buffer"))
+  (org-present))
+
+(defun p3/org-present-toggle-fullscreen ()
+  "Toggle fullscreen for the current presentation frame."
+  (interactive)
+  (set-frame-parameter
+   nil 'fullscreen
+   (unless (frame-parameter nil 'fullscreen) 'fullboth)))
+
+(defun p3/org-present-hook ()
+  "Prepare the current Org buffer for presentation mode."
+  (setq-local p3/org-present--state
+              (list :header-line header-line-format
+                    :line-numbers (bound-and-true-p display-line-numbers-mode)
+                    :inline-images (and (boundp 'org-inline-image-overlays)
+                                        org-inline-image-overlays)
+                    :visual-fill (bound-and-true-p visual-fill-column-mode)
+                    :visual-fill-width visual-fill-column-width
+                    :visual-fill-center visual-fill-column-center-text
+                    :hide-mode-line (bound-and-true-p hide-mode-line-mode)
+                    :face-remap-cookies nil))
+  (setq-local header-line-format " ")
+  (display-line-numbers-mode -1)
+  (org-present-big)
+  (unless (and (boundp 'org-inline-image-overlays)
+               org-inline-image-overlays)
+    (org-display-inline-images))
+  (setq-local visual-fill-column-width 90
+              visual-fill-column-center-text t)
+  (visual-fill-column-mode 1)
+  (hide-mode-line-mode +1)
+  (setf (plist-get p3/org-present--state :face-remap-cookies)
+        (list (face-remap-add-relative 'org-level-1 :height 1.5)
+              (face-remap-add-relative 'org-level-2 :height 1.2)
+              (face-remap-add-relative 'org-level-3 :height 1.1))))
+
+(defun p3/org-present-quit-hook ()
+  "Restore the buffer state saved by `p3/org-present-hook'."
+  (let ((state p3/org-present--state))
+    (org-present-small)
+    (when state
+      (setq-local header-line-format (plist-get state :header-line))
+      (if (plist-get state :line-numbers)
+          (display-line-numbers-mode +1)
+        (display-line-numbers-mode -1))
+      (unless (plist-get state :inline-images)
+        (org-remove-inline-images))
+      (setq-local visual-fill-column-width
+                  (plist-get state :visual-fill-width)
+                  visual-fill-column-center-text
+                  (plist-get state :visual-fill-center))
+      (if (plist-get state :visual-fill)
+          (visual-fill-column-mode +1)
+        (visual-fill-column-mode -1))
+      (if (plist-get state :hide-mode-line)
+          (hide-mode-line-mode +1)
+        (hide-mode-line-mode -1))
+      (dolist (cookie (plist-get state :face-remap-cookies))
+        (face-remap-remove-relative cookie)))
+    (setq-local p3/org-present--state nil)))
+
+(defun p3/org-present-prev ()
+  "Move to the previous presentation slide."
+  (interactive)
+  (org-present-prev))
+
+(defun p3/org-present-next ()
+  "Move to the next presentation slide."
+  (interactive)
+  (org-present-next))
+
+(provide 'p3-org-present)
+;;; p3-org-present.el ends here
 ```
 
-Then move the current state variable and six functions without semantic changes.
+- [ ] **Step 4: Run focused presentation behavior tests**
 
-Do not add `use-package` or require `p3-config-org-present`.
-
-- [ ] **Step 4: Run focused presentation behavior tests and correct only declaration/test harness issues**
+```bash
+emacs -Q --batch -L lisp -l test/p3-org-present-test.el -f ert-run-tests-batch-and-exit
+```
 
 Expected: PASS.
 
-- [ ] **Step 5: Write failing source-semantic tests for `p3-config-org-present.el`**
+- [ ] **Step 5: Write failing source-semantic tests for the presentation config owner**
 
-Create `test/p3-config-org-present-test.el` and pin this effective top-level order:
+Create `test/p3-config-org-present-test.el`. Parse top-level forms and pin this effective order:
 
 ```text
 (use-package hide-mode-line ...)
@@ -512,9 +814,16 @@ Create `test/p3-config-org-present-test.el` and pin this effective top-level ord
 (use-package org-present ...)
 ```
 
-Assert there is no standalone `(require 'face-remap)` in the config owner; the behavior library owns it.
+Assert `p3-config-org-present.el` has no standalone `(require 'face-remap)` and `p3-org-present.el` does.
 
-Pin `hide-mode-line :after (org-present)`, `org-present-text-scale 4`, both hooks, `C-c P`, and every `org-present-mode-keymap` binding:
+Pin `hide-mode-line :after (org-present)`, hooks:
+
+```elisp
+((org-present-mode . p3/org-present-hook)
+ (org-present-mode-quit . p3/org-present-quit-hook))
+```
+
+`org-present-text-scale 4`, `C-c P`, and these map bindings:
 
 ```text
 C-c C-j     p3/org-present-next
@@ -527,15 +836,17 @@ f           p3/org-present-toggle-fullscreen
 q           org-present-quit
 ```
 
-- [ ] **Step 6: Create `p3-config-org-present.el` with package wiring only**
-
-Use:
+- [ ] **Step 6: Create `lisp/p3-config-org-present.el` with exact package wiring**
 
 ```elisp
 ;;; p3-config-org-present.el --- Org presentation configuration -*- lexical-binding: t; -*-
 
 (require 'use-package)
 (require 'p3-config-loader)
+
+(defvar org-mode-map)
+(defvar org-present-mode-keymap)
+(defvar org-present-text-scale)
 
 (use-package hide-mode-line
   :after (org-present))
@@ -545,18 +856,38 @@ Use:
 (p3/config-load-module 'p3-org-present)
 
 (use-package org-present
-  ...current bindings/hooks/config moved unchanged...)
+  :bind ((:map org-mode-map
+               ("C-c P" . p3/org-present-start))
+         (:map org-present-mode-keymap
+               ("C-c C-j" . p3/org-present-next)
+               ("C-c C-k" . p3/org-present-prev)
+               ("SPC" . p3/org-present-next)
+               ("<backspace>" . p3/org-present-prev)
+               ("n" . p3/org-present-next)
+               ("p" . p3/org-present-prev)
+               ("f" . p3/org-present-toggle-fullscreen)
+               ("q" . org-present-quit)))
+  :hook ((org-present-mode . p3/org-present-hook)
+         (org-present-mode-quit . p3/org-present-quit-hook))
+  :config
+  (setq org-present-text-scale 4))
 
 (provide 'p3-config-org-present)
+;;; p3-config-org-present.el ends here
 ```
-
-Add only compile-time declarations required by warnings-as-errors byte compilation.
 
 - [ ] **Step 7: Run both focused presentation test files**
 
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-present-test.el \
+  -l test/p3-config-org-present-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
 Expected: PASS.
 
-- [ ] **Step 8: Commit the presentation extraction**
+- [ ] **Step 8: Commit Task 3**
 
 ```bash
 git add lisp/p3-org-present.el lisp/p3-config-org-present.el \
@@ -573,12 +904,12 @@ git commit -m "Extract Org presentation configuration boundary"
 - Modify: `test/p3-config-test.el`
 
 **Interfaces:**
-- Consumes: features `p3-config-org`, `p3-config-org-roam`, `p3-config-org-present` from Tasks 1-3.
-- Produces: one explicit loader stanza per new configuration owner, with existing out-of-scope sections retaining their positions.
+- Consumes: `p3-config-org`, `p3-config-org-roam`, `p3-config-org-present`.
+- Produces: one explicit top-level loader stanza per subsystem with current out-of-scope sections retaining their positions.
 
 - [ ] **Step 1: Add failing architecture assertions before editing `config.org`**
 
-Update the config-module test to expect ten explicit configuration modules:
+Update the config-module ownership test to require all ten modules:
 
 ```elisp
 '(p3-config-base
@@ -593,24 +924,18 @@ Update the config-module test to expect ten explicit configuration modules:
   p3-config-git)
 ```
 
-Add a dedicated ordering test that locates these exact needles in `config.org`:
+Add an ordering test locating:
 
-```elisp
-"(p3/config-load-module 'p3-config-org)"
-"(p3/config-load-module 'p3-config-org-roam)"
-"(use-package poly-R"
-"(p3/config-load-module 'p3-config-org-present)"
+```text
+(p3/config-load-module 'p3-config-org)
+(p3/config-load-module 'p3-config-org-roam)
+(use-package poly-R
+(p3/config-load-module 'p3-config-org-present)
 ```
 
-and asserts:
+and assert Org < Roam < Poly-R < Presentation.
 
-```elisp
-(should (< org roam))
-(should (< roam poly-r))
-(should (< poly-r present))
-```
-
-Add ownership assertions that each loader stanza occurs exactly once and that the following moved definitions/forms no longer appear inline:
+Add one-owner assertions that each new loader occurs exactly once and that `config.org` no longer contains:
 
 ```text
 (defun p3/org-sort-todos
@@ -633,61 +958,81 @@ Add ownership assertions that each loader stanza occurs exactly once and that th
 (use-package org-present
 ```
 
-Do **not** forbid legitimate `(python . t)`, `(R . t)`, citation, LaTeX, or `citar-org-roam` references.
+Do not forbid Babel `(python . t)` or `(R . t)` references. Assert `config.org` still contains `(use-package citar-org-roam`, the BibTeX/RefTeX setup, the LaTeX `org-latex-pdf-process`, and `(use-package poly-R`.
 
-Assert `config.org` still contains the existing Citar/BibTeX/RefTeX section markers/forms, LaTeX forms, Poly-R declaration, and `(use-package citar-org-roam ...)`.
-
-- [ ] **Step 2: Verify the new architecture assertions fail against the still-inline config**
-
-Run:
+- [ ] **Step 2: Verify RED against the still-inline config**
 
 ```bash
-emacs -Q --batch -L lisp \
-  -l test/p3-config-test.el \
-  -f ert-run-tests-batch-and-exit
+emacs -Q --batch -L lisp -l test/p3-config-test.el -f ert-run-tests-batch-and-exit
 ```
 
-Expected: FAIL because the three loader stanzas are absent and inline implementation remains.
+Expected: FAIL because the three loader stanzas do not yet exist.
 
-- [ ] **Step 3: Replace only the three approved implementation regions in `config.org`**
+- [ ] **Step 3: Replace only the approved Org section with concise orchestration**
 
-Replace the current Org implementation block with concise prose and:
+The `** org` section becomes:
 
-```elisp
-(p3/config-load-module 'p3-config-org)
+```org
+** org
+
+Org core behavior lives in =lisp/p3-org.el=. Declarative Org, Babel, TODO,
+Agenda, PDF-opening, and export-activation configuration lives in
+=lisp/p3-config-org.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-org)
+#+END_SRC
 ```
 
-Replace the current Org-roam implementation block with concise prose and:
+The separate `** org-agenda` implementation is absorbed into `p3-config-org.el`; do not leave a second inline Agenda owner.
 
-```elisp
-(p3/config-load-module 'p3-config-org-roam)
+- [ ] **Step 4: Replace only the approved Org-roam section**
+
+Use:
+
+```org
+** org-roam
+
+Org-roam package configuration lives in =lisp/p3-config-org-roam.el= and
+reusable Roam search, capture, filtering, and agenda helpers live in
+=lisp/p3-org-roam.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-org-roam)
+#+END_SRC
 ```
 
-Leave the `** Poly-R` section exactly between Roam and Presentation.
+Leave `** Poly-R` immediately after this section.
 
-Replace the current Presentation implementation block with concise prose and:
+- [ ] **Step 5: Replace only the approved Presentation section**
 
-```elisp
-(p3/config-load-module 'p3-config-org-present)
+Use:
+
+```org
+** Presentation
+
+Org presentation package wiring lives in =lisp/p3-config-org-present.el=;
+state capture/restoration and presentation commands live in
+=lisp/p3-org-present.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-org-present)
+#+END_SRC
 ```
 
-Do not move or rewrite the earlier citation/BibTeX/RefTeX or LaTeX sections.
+Do not move Projectile/Python or any section around it.
 
-Because connector updates replace whole files, reconstruct `config.org` from exact current branch contents, then reject any diff containing unrelated whitespace/content changes before committing.
+- [ ] **Step 6: Update the existing export integration architecture test**
 
-- [ ] **Step 4: Update the older export-ownership architecture assertion without changing exporter semantics**
+Change `p3-config-org-owns-org-export-integration` so it asserts:
 
-The existing test currently expects `(use-package p3-org-export` directly in `config.org`. Change it to assert:
+- `config.org` contains `(p3/config-load-module 'p3-config-org)`;
+- `lisp/p3-config-org.el` contains `(use-package p3-org-export`;
+- neither file contains the implementation definition `(defun p3/org-export-to-office`.
 
-```elisp
-(p3/config-load-module 'p3-config-org)
-```
+This verifies ownership moved without changing exporter implementation/reload semantics.
 
-in `config.org`, `(use-package p3-org-export` in `lisp/p3-config-org.el`, and absence of `p3/org-export-to-office` implementation from both top-level config and config module.
-
-- [ ] **Step 5: Run architecture and all six focused Org boundary tests**
-
-Run:
+- [ ] **Step 7: Run architecture plus all six focused tests**
 
 ```bash
 emacs -Q --batch -L lisp \
@@ -703,17 +1048,17 @@ emacs -Q --batch -L lisp \
 
 Expected: PASS.
 
-- [ ] **Step 6: Confirm `p3-org-export.el` and its test are byte-for-byte unchanged**
-
-Run:
+- [ ] **Step 8: Verify untouched exporter files and inspect the whole `config.org` diff**
 
 ```bash
 git diff --exit-code master -- lisp/p3-org-export.el test/p3-org-export-test.el
+git diff --check master...HEAD
+git diff master...HEAD -- config.org
 ```
 
-Expected: no output, exit 0.
+Expected: exporter command exits 0 with no output; `config.org` diff is limited to the Org/Agenda, Org-roam, and Presentation regions. If connector whole-file replacement introduced unrelated blank-line or content changes, restore them before proceeding.
 
-- [ ] **Step 7: Commit top-level orchestration**
+- [ ] **Step 9: Commit Task 4**
 
 ```bash
 git add config.org test/p3-config-test.el
@@ -729,12 +1074,12 @@ git commit -m "Route Org subsystems through focused modules"
 - Modify: `.github/workflows/windows-platform-tests.yml`
 
 **Interfaces:**
-- Consumes: all six new Lisp files and six new focused test files.
+- Consumes: six new Lisp files and six new focused tests.
 - Produces: warnings-as-errors compilation, three runtime-load smoke checks, Ubuntu full-suite coverage, and Windows source-level boundary coverage without optional-package installation.
 
-- [ ] **Step 1: Add all six new Lisp files to Ubuntu warnings-as-errors byte compilation**
+- [ ] **Step 1: Add all six new Lisp files to Ubuntu byte compilation**
 
-Add:
+Add these exact paths to the existing `batch-byte-compile` list:
 
 ```text
 lisp/p3-org.el
@@ -745,62 +1090,88 @@ lisp/p3-org-present.el
 lisp/p3-config-org-present.el
 ```
 
-to the existing `batch-byte-compile` list after package installation has already been suppressed with:
+Keep the existing package-install suppression:
 
 ```elisp
 (require 'use-package-ensure)
 (setq use-package-ensure-function (lambda (&rest _) t))
 ```
 
-Do not install Org-roam, org-present, hide-mode-line, or visual-fill-column for this compile step. Resolve warnings with declaration-only `defvar`/`declare-function` forms in the owning source files.
+Do not install Org-roam, org-present, hide-mode-line, or visual-fill-column. Compiler failures caused only by unknown external variables/functions are resolved with declaration-only source forms, not package installation.
 
-- [ ] **Step 2: Add an Org-core runtime smoke check**
+- [ ] **Step 2: Add an exact Org-core runtime smoke step**
 
-Add a workflow step that loads `p3-config-loader.el` and `p3-config-org.el` with package installation suppressed, then exits nonzero unless:
+Add this workflow command:
 
-```elisp
-(featurep 'p3-config-org)
-(featurep 'p3-org)
-(equal org-startup-folded 'content)
-(eq org-confirm-babel-evaluate t)
+```bash
+emacs -Q --batch \
+  -L lisp \
+  --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+  --eval '(require (quote use-package-ensure))' \
+  --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+  -l lisp/p3-config-loader.el \
+  -l lisp/p3-config-org.el \
+  --eval '(unless (and (featurep (quote p3-config-org))
+                       (featurep (quote p3-org))
+                       (eq org-startup-folded (quote content))
+                       (eq org-confirm-babel-evaluate t)
+                       (featurep (quote p3-org-export)))
+             (kill-emacs 1))'
 ```
 
-are all true.
+This deliberately exercises the unchanged `use-package p3-org-export :demand t` path instead of exact-source loading the exporter.
 
-Do not exact-source load `p3-org-export`; let the unchanged `use-package p3-org-export :demand t` form exercise its real activation path.
+- [ ] **Step 3: Add an exact stubbed Org-roam runtime smoke step**
 
-- [ ] **Step 3: Add an Org-roam config smoke test using stubs, not package installation**
+Use this command so no database or third-party package is installed:
 
-Before loading `p3-config-org-roam.el`, provide the minimum package surface needed for the `use-package org-roam` declaration to evaluate without side effects. Use temporary symbols/maps/functions and `(provide 'org-roam)` / any required subfeatures rather than creating a database.
-
-The assertion must at least verify:
-
-```elisp
-(featurep 'p3-config-org-roam)
-(featurep 'p3-org-roam)
-(equal org-roam-directory "~/org/notes/roam/")
+```bash
+emacs -Q --batch \
+  -L lisp \
+  --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+  --eval '(require (quote use-package-ensure))' \
+  --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+  --eval '(defun org-roam-db-autosync-mode (&optional _arg) t)' \
+  --eval '(provide (quote org-roam))' \
+  -l lisp/p3-config-loader.el \
+  -l lisp/p3-config-org-roam.el \
+  --eval '(unless (and (featurep (quote p3-config-org-roam))
+                       (featurep (quote p3-org-roam))
+                       (equal org-roam-directory "~/org/notes/roam/"))
+             (kill-emacs 1))'
 ```
 
-and the smoke harness must stub `org-roam-db-autosync-mode` so no database is opened.
+If `use-package` requires a specific Org-roam subfeature solely because of macro expansion on the runner version, provide that feature in this smoke command; do not install or initialize Org-roam. No smoke code may call a real database function.
 
-- [ ] **Step 4: Add a presentation config smoke test using stubs, not package installation**
+- [ ] **Step 4: Add an exact stubbed presentation runtime smoke step**
 
-Provide stub features/functions/maps for `hide-mode-line`, `visual-fill-column`, and `org-present`, including `org-mode-map` and `org-present-mode-keymap` where necessary for `use-package :bind` evaluation.
+Use:
 
-Load `p3-config-org-present.el` and assert:
-
-```elisp
-(featurep 'p3-config-org-present)
-(featurep 'p3-org-present)
-(featurep 'face-remap)
-(equal org-present-text-scale 4)
+```bash
+emacs -Q --batch \
+  -L lisp \
+  --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+  --eval '(require (quote use-package-ensure))' \
+  --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+  --eval '(require (quote org))' \
+  --eval '(defvar org-present-mode-keymap (make-sparse-keymap))' \
+  --eval '(provide (quote hide-mode-line))' \
+  --eval '(provide (quote visual-fill-column))' \
+  --eval '(provide (quote org-present))' \
+  -l lisp/p3-config-loader.el \
+  -l lisp/p3-config-org-present.el \
+  --eval '(unless (and (featurep (quote p3-config-org-present))
+                       (featurep (quote p3-org-present))
+                       (featurep (quote face-remap))
+                       (equal org-present-text-scale 4))
+             (kill-emacs 1))'
 ```
 
-Do not enter presentation mode or manipulate a real frame/buffer beyond what batch Emacs itself creates.
+The smoke test must not invoke `p3/org-present-start` or either presentation hook.
 
-- [ ] **Step 5: Add all six focused tests to the Ubuntu full ERT invocation**
+- [ ] **Step 5: Load all six new focused tests in the Ubuntu ERT command**
 
-Load:
+Add:
 
 ```text
 test/p3-org-test.el
@@ -811,11 +1182,11 @@ test/p3-org-present-test.el
 test/p3-config-org-present-test.el
 ```
 
-Keep the existing `test/p3-org-export-test.el` line unchanged.
+Keep `-l test/p3-org-export-test.el` unchanged.
 
-- [ ] **Step 6: Extend Windows path triggers and source-level test invocation only**
+- [ ] **Step 6: Extend Windows only for source-level boundary coverage**
 
-Add the three new config modules and three config-boundary test files to Windows workflow path triggers:
+Add path triggers for:
 
 ```text
 lisp/p3-config-org.el
@@ -826,61 +1197,56 @@ test/p3-config-org-roam-test.el
 test/p3-config-org-present-test.el
 ```
 
-Add the three config-boundary tests to the existing Windows config-architecture ERT command.
+Load those three config-boundary tests in the existing Windows config-architecture ERT command. Do not add Org-roam/presentation runtime smoke tests on Windows and do not add behavior-library triggers that would spend Windows Actions minutes without corresponding behavior coverage.
 
-Do not add runtime Org-roam/presentation smoke checks on Windows and do not add behavior-library path triggers that would cause Windows jobs without corresponding Windows behavior coverage.
+- [ ] **Step 7: Perform pre-PR static rejection checks**
 
-- [ ] **Step 7: Run static pre-PR verification before pushing the implementation head**
-
-Confirm:
+Run or reproduce through connector diffs:
 
 ```bash
 git diff --check master...HEAD
 git diff --exit-code master -- lisp/p3-org-export.el test/p3-org-export-test.el
+git diff master...HEAD -- config.org
+git diff master...HEAD -- .github/workflows/emacs-tests.yml
+git diff master...HEAD -- .github/workflows/windows-platform-tests.yml
 ```
 
-Inspect the aggregate `config.org` diff and reject any changes outside the Org, Org-roam, and Presentation regions.
+Reject any unrelated change, package-install command for Org-roam/presentation dependencies, broad display policy, citation/LaTeX/Poly-R/Projectile change, or normalization of the trailing `#`/anonymous timestamp hook.
 
-Search the branch diff for `TBD`, `TODO` placeholders introduced by this work, accidental package-install commands, broad `display-buffer-alist` changes, or changes under citation/LaTeX/Poly-R/Projectile.
+- [ ] **Step 8: Commit CI wiring**
 
-- [ ] **Step 8: Open/update the PR only after the implementation head is final enough for one CI cycle**
+```bash
+git add .github/workflows/emacs-tests.yml .github/workflows/windows-platform-tests.yml
+git commit -m "Cover Org configuration boundaries in CI"
+```
 
-The PR summary must state that this is behavior-preserving decomposition and explicitly note:
+- [ ] **Step 9: Open the PR only after the implementation branch is coherent enough for one CI cycle**
 
-- exporter implementation/reload behavior unchanged;
-- trailing Roam header `#` intentionally preserved;
-- direct `face-remap` dependency moved with presentation behavior;
-- optional packages are stubbed rather than installed in smoke checks;
-- Citar/BibTeX/RefTeX, LaTeX, and Poly-R are out of scope.
+PR summary must explicitly state:
 
-- [ ] **Step 9: Verify the final Ubuntu and Windows runs from the exact PR head**
+- structural/behavior-preserving extraction only;
+- exporter implementation and reload behavior unchanged;
+- trailing tagged-header `#` intentionally preserved;
+- `face-remap` now travels with the extracted behavior that calls it, at the same effective point in startup;
+- optional package surfaces are stubbed rather than installed in smoke checks;
+- Citar/BibTeX/RefTeX, LaTeX, and Poly-R are outside scope.
 
-Ubuntu must show:
+- [ ] **Step 10: Verify final CI from the exact PR head**
 
-- warnings-as-errors byte compilation success;
-- Org core runtime smoke success;
-- Org-roam stubbed runtime smoke success;
-- presentation stubbed runtime smoke success;
-- full ERT suite success with zero unexpected failures.
+Ubuntu must show success for:
 
-Windows must show:
+1. warnings-as-errors byte compilation;
+2. Org-core runtime smoke;
+3. stubbed Org-roam runtime smoke;
+4. stubbed presentation runtime smoke;
+5. full ERT suite with zero unexpected failures.
 
-- existing platform/project gate success;
-- config architecture gate success including the three new source-level config-boundary tests.
+Windows must show success for the existing platform/project gate and config architecture gate including the three new source-level boundary suites.
 
-If a run fails, inspect the exact job log and fix the root cause; do not add diagnostic workflows.
+For any failure, inspect the exact failing job/assertion and fix its root cause. Do not create diagnostic workflows or repeatedly push speculative changes.
 
-- [ ] **Step 10: Perform final adversarial review before any merge recommendation**
+- [ ] **Step 11: Perform final adversarial review before merge recommendation**
 
-Review the aggregate PR against the spec for:
-
-- any changed Org/Roam/presentation behavior;
-- accidental exporter reload changes;
-- missing direct dependencies in behavior libraries;
-- package installation in compile/smoke steps;
-- config ordering drift;
-- capture/template/keybinding drift;
-- presentation state restoration coverage;
-- unrelated modifications.
+Review the aggregate PR specifically for behavior drift, exporter reload drift, direct dependency mistakes, optional-package installation, `config.org` ordering changes, capture/template/keybinding changes, incomplete presentation restoration testing, or unrelated edits.
 
 Do not merge without explicit user approval.

--- a/docs/superpowers/plans/2026-09-05-org-config-boundaries.md
+++ b/docs/superpowers/plans/2026-09-05-org-config-boundaries.md
@@ -1,0 +1,886 @@
+# Org Configuration Boundaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract Org core, Org-roam, and Org presentation configuration from `config.org` into three focused configuration modules and three reusable behavior libraries without changing user-facing behavior or startup ordering.
+
+**Architecture:** `config.org` remains the explicit top-level map and loads `p3-config-org`, `p3-config-org-roam`, and `p3-config-org-present` in their current broad positions. Each configuration module owns declarative package wiring and exact-source loads its new behavior library; `p3-org-export.el` remains unchanged and retains its existing `use-package` activation/reload semantics.
+
+**Tech Stack:** Emacs Lisp, Org, Org Agenda, Org Babel, Org-roam, org-present, `use-package`, ERT, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md`
+
+## Global Constraints
+
+- Preserve behavior exactly; this is a structural refactor only.
+- Do not reorganize Citar, `citar-org-roam`, BibTeX, RefTeX, LaTeX, Poly-R, Projectile, completion, or window management.
+- Preserve Org -> Org-roam -> Poly-R -> Presentation broad ordering in `config.org`.
+- Preserve every existing Org, Roam, and presentation keybinding, hook, template, path, and setting.
+- Preserve Babel languages exactly: Emacs Lisp, R, C, Python, LaTeX, and shell.
+- Preserve `org-confirm-babel-evaluate t`.
+- Preserve the anonymous timestamp-on-save hook as an anonymous hook; do not normalize or deduplicate it.
+- Preserve legacy function names, including `org-set-line-checkbox`, `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, and `org-roam-rg-search`.
+- Preserve the current trailing `#` in the nonblank tagged-header output.
+- `p3-org-export.el` must not change and must not gain exact-source reload semantics.
+- `p3-org-present.el` directly requires built-in `face-remap`.
+- Optional Org-roam/presentation packages must not be installed merely for byte compilation or smoke loading.
+- No broad `display-buffer-alist` policy or other window-management changes.
+- Keep CI economical: no iterative diagnostic workflows; use targeted tests and one final PR CI cycle after local/static verification.
+
+---
+
+## File Map
+
+### New behavior libraries
+
+- `lisp/p3-org.el` — reusable core Org commands only.
+- `lisp/p3-org-roam.el` — reusable Org-roam helper/search/agenda behavior only.
+- `lisp/p3-org-present.el` — stateful presentation behavior and direct `face-remap` dependency.
+
+### New configuration modules
+
+- `lisp/p3-config-org.el` — Org core, Babel, TODO, Agenda, PDF handling, and existing `p3-org-export` activation.
+- `lisp/p3-config-org-roam.el` — Org-roam package settings, templates, bindings, and autosync.
+- `lisp/p3-config-org-present.el` — hide-mode-line, visual-fill-column, org-present package wiring, bindings, hooks, and text scale.
+
+### New focused tests
+
+- `test/p3-org-test.el`
+- `test/p3-config-org-test.el`
+- `test/p3-org-roam-test.el`
+- `test/p3-config-org-roam-test.el`
+- `test/p3-org-present-test.el`
+- `test/p3-config-org-present-test.el`
+
+### Existing files to modify
+
+- `config.org` — replace only the current Org, Org-roam, and Presentation implementation blocks with concise module-loader stanzas; leave intervening/out-of-scope sections in place.
+- `test/p3-config-test.el` — update module ownership/count/order assertions and moved-code exclusions.
+- `.github/workflows/emacs-tests.yml` — compile six new Lisp files, load six focused test files, and add three runtime smoke checks.
+- `.github/workflows/windows-platform-tests.yml` — add source-level architecture/config-boundary coverage and matching path triggers only; do not install optional packages.
+
+### Existing files that must remain unchanged
+
+- `lisp/p3-org-export.el`
+- `test/p3-org-export-test.el`
+
+---
+
+### Task 1: Extract Org core behavior and declarative configuration
+
+**Files:**
+- Create: `lisp/p3-org.el`
+- Create: `lisp/p3-config-org.el`
+- Create: `test/p3-org-test.el`
+- Create: `test/p3-config-org-test.el`
+
+**Interfaces:**
+- Consumes: `p3/config-load-module` from `p3-config-loader.el`; built-in Org functions at runtime; existing `p3-org-export` feature through unchanged `use-package` activation.
+- Produces: `p3/org-sort-todos`, `org-set-line-checkbox`, feature `p3-org`, feature `p3-config-org`.
+
+- [ ] **Step 1: Write failing core behavior tests before creating `p3-org.el`**
+
+Create `test/p3-org-test.el` with a repository-root/load-path setup matching the existing test files, then define tests that stub the Org entry points instead of requiring package configuration.
+
+Use this shape for TODO sorting:
+
+```elisp
+(ert-deftest p3-org-sort-todos-preserves-current-org-sort-call ()
+  (let (seen)
+    (cl-letf (((symbol-function 'org-sort-entries)
+               (lambda (&rest args) (setq seen args))))
+      (p3/org-sort-todos)
+      (should (equal seen '(nil 111))))))
+```
+
+`111` is the character code for `?o`; if the implementation/test uses `?o` directly, the assertion may use `'(nil ?o)`.
+
+For checkbox behavior, cover both no-region and active-region semantics using temporary buffers. Pin the literal inserted prefix `"- [ ] "`, the number of affected lines, and the final cursor at the beginning of the last processed line as the current function does.
+
+- [ ] **Step 2: Verify the focused behavior tests fail because `p3-org.el` does not exist**
+
+Run, when Emacs is available:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL/load error for missing `p3-org` or undefined extracted commands.
+
+In the ChatGPT connector harness, where Emacs is unavailable locally, preserve this RED-before-GREEN commit ordering and defer executable confirmation to the final Actions gate rather than spending a standalone CI run.
+
+- [ ] **Step 3: Create the minimal `p3-org.el` behavior library**
+
+Move the two existing definitions without redesign:
+
+```elisp
+;;; p3-org.el --- Core Org workflow helpers -*- lexical-binding: t; -*-
+
+(declare-function org-sort-entries "org" (&optional with-case sorting-type get-key-func compare-func property interactive?))
+
+(defun p3/org-sort-todos ()
+  "Sort sibling entries by TODO state without changing outline hierarchy.
+Run this on a parent heading to sort its children; DONE entries follow active
+TODO states according to `org-todo-keywords'."
+  (interactive)
+  (org-sort-entries nil ?o))
+
+(defun org-set-line-checkbox (arg)
+  (interactive "p")
+  (let ((n (or arg 1)))
+    (when (region-active-p)
+      (setq n (count-lines (region-beginning)
+                           (region-end)))
+      (goto-char (region-beginning)))
+    (dotimes (_i n)
+      (beginning-of-line)
+      (insert "- [ ] ")
+      (forward-line))
+    (beginning-of-line)))
+
+(provide 'p3-org)
+
+;;; p3-org.el ends here
+```
+
+Do not `(require 'org)` merely to define these functions. Add only compiler declarations actually needed by warnings-as-errors compilation.
+
+- [ ] **Step 4: Run the core behavior tests and make only behavior-preserving corrections**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write source-semantic tests for `p3-config-org.el` before creating it**
+
+Create `test/p3-config-org-test.el` using the parsed-form helpers already established in `test/p3-config-python-test.el`: read top-level forms, find `use-package` forms, and inspect keyword sections.
+
+Tests must pin at minimum:
+
+```elisp
+(p3/config-load-module 'p3-org)
+```
+
+before the command binding; the exact Babel language list:
+
+```elisp
+'((emacs-lisp . t)
+  (R . t)
+  (C . t)
+  (python . t)
+  (latex . t)
+  (shell . t))
+```
+
+and these values:
+
+```elisp
+(setq org-startup-folded 'content)
+(setq org-confirm-babel-evaluate t
+      org-src-fontify-natively t
+      org-src-tab-acts-natively t
+      org-hide-emphasis-markers t
+      org-ellipsis " ↴")
+(setq org-todo-keywords
+      '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
+      org-todo-keyword-faces
+      '(("WAIT" . "DarkOrange")))
+(setq org-agenda-sorting-strategy '(priority-down))
+```
+
+Pin the existing Org hooks, `C-c s`, `C-c C-x C-o`, Linux Evince PDF association, and the anonymous timestamp hook body.
+
+Also assert that the module retains unchanged exporter activation in substance:
+
+```elisp
+(use-package p3-org-export
+  :ensure nil
+  :demand t
+  :config
+  (p3-org-export-setup))
+```
+
+and assert there is **no** `(p3/config-load-module 'p3-org-export)` form.
+
+- [ ] **Step 6: Verify the config-boundary tests fail because the new module does not exist**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-org-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL due to missing `lisp/p3-config-org.el`.
+
+- [ ] **Step 7: Create `p3-config-org.el` by moving the current forms without normalization**
+
+Start with:
+
+```elisp
+;;; p3-config-org.el --- Org configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(p3/config-load-module 'p3-org)
+```
+
+Then move the current executable Org forms in their current semantic order: `org-startup-folded`, anonymous timestamp hook, `use-package org`, `p3/org-sort-todos` binding, unchanged `use-package p3-org-export`, Linux Evince association, TODO keywords/faces, and `use-package org-agenda` sorting.
+
+Do not move the earlier Citar/BibTeX/RefTeX block or the LaTeX block into this file.
+
+End with:
+
+```elisp
+(provide 'p3-config-org)
+```
+
+- [ ] **Step 8: Run both focused Org test files**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-test.el \
+  -l test/p3-config-org-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit the core Org extraction**
+
+```bash
+git add lisp/p3-org.el lisp/p3-config-org.el \
+        test/p3-org-test.el test/p3-config-org-test.el
+git commit -m "Extract Org core configuration boundary"
+```
+
+---
+
+### Task 2: Extract Org-roam behavior and declarative configuration
+
+**Files:**
+- Create: `lisp/p3-org-roam.el`
+- Create: `lisp/p3-config-org-roam.el`
+- Create: `test/p3-org-roam-test.el`
+- Create: `test/p3-config-org-roam-test.el`
+
+**Interfaces:**
+- Consumes: `p3/config-load-module`; Org-roam functions/variables at runtime; `consult-ripgrep`; `org-agenda`; `seq`; `subr-x`.
+- Produces: `org-roam-generate-tagged-header`, `org-roam-node-insert-immediate-with-tag`, `org-roam-rg-search`, `p3/org-roam-filter-by-tag`, `p3/org-roam-list-notes`, `p3/org-roam-list-notes-by-tag`, `p3/org-roam-get-agenda`, feature `p3-org-roam`, feature `p3-config-org-roam`.
+
+- [ ] **Step 1: Write failing Org-roam behavior tests with no real database**
+
+Create `test/p3-org-roam-test.el`. Require only ERT/CL helpers and `p3-org-roam`; stub Org-roam functions.
+
+Pin blank tagged-header output exactly:
+
+```elisp
+"#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n"
+```
+
+Pin nonblank output exactly, including the current trailing `#`:
+
+```elisp
+"#+title: ${title}\n#+category:${title}\n#+filetags: work\n#+created: %U\n#+last_modified: %U\n#"
+```
+
+For list/filter tests, stub:
+
+```elisp
+org-roam-node-list
+org-roam-node-file
+org-roam-node-tags
+```
+
+using simple plist/alist nodes and `cl-letf`.
+
+For `p3/org-roam-get-agenda`, stub `read-string`, the listing functions, and `org-agenda`; assert `org-agenda-files` receives all files for blank input and only tagged files for nonblank input.
+
+For `org-roam-rg-search`, bind `org-roam-directory` to a sentinel path and stub `consult-ripgrep`; assert the exact directory argument is forwarded.
+
+For immediate insertion, capture the dynamically bound `org-roam-capture-templates` inside a stubbed `org-roam-node-insert` call and assert `:immediate-finish t` is present.
+
+- [ ] **Step 2: Verify Org-roam behavior tests fail before implementation**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-org-roam-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL/load error for missing `p3-org-roam`.
+
+- [ ] **Step 3: Create `p3-org-roam.el` by moving the current helpers verbatim in behavior**
+
+Use this dependency shape:
+
+```elisp
+;;; p3-org-roam.el --- Org-roam workflow helpers -*- lexical-binding: t; -*-
+
+(require 'seq)
+(require 'subr-x)
+
+(defvar org-agenda-files)
+(defvar org-roam-capture-templates)
+(defvar org-roam-directory)
+
+(declare-function consult-ripgrep "consult" (dir &optional initial))
+(declare-function org-agenda "org-agenda" (&optional arg keys restriction))
+(declare-function org-roam-node-file "org-roam-node" (node))
+(declare-function org-roam-node-insert "org-roam-node" (&optional arg &rest args))
+(declare-function org-roam-node-list "org-roam-node" ())
+(declare-function org-roam-node-tags "org-roam-node" (node))
+```
+
+Then move the seven current helper functions unchanged, including the trailing `#` behavior.
+
+Do not require `org-roam` solely to define the helpers.
+
+- [ ] **Step 4: Run Org-roam behavior tests**
+
+Run the focused file and expect PASS.
+
+- [ ] **Step 5: Write failing source-semantic tests for the Org-roam config owner**
+
+Create `test/p3-config-org-roam-test.el` using parsed top-level forms. Assert:
+
+```elisp
+(p3/config-load-module 'p3-org-roam)
+```
+
+occurs before `(use-package org-roam ...)`, and pin the current `:hook`, `:custom`, `:bind`, and `:config` values.
+
+The test must compare the current default capture template, literature-note capture template, and dailies template structurally, including this target expression:
+
+```elisp
+(file+head
+ "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
+ "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+```
+
+Pin all existing bindings:
+
+```text
+C-c n l  org-roam-buffer-toggle
+C-c n f  org-roam-node-find
+C-c n g  org-roam-graph
+C-c n i  org-roam-node-insert
+C-c n c  org-roam-capture
+C-c n n  org-roam-node-insert-immediate-with-tag
+C-c n s  org-roam-rg-search
+C-c n d  org-roam-dailies-goto-today
+C-c n t  org-roam-dailies-capture-today
+C-c n C-t org-roam-tag-add
+C-c n a  p3/org-roam-get-agenda
+```
+
+Pin `(org-roam-db-autosync-mode)` and the current node display template.
+
+- [ ] **Step 6: Create `p3-config-org-roam.el`**
+
+Use:
+
+```elisp
+;;; p3-config-org-roam.el --- Org-roam configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(p3/config-load-module 'p3-org-roam)
+
+(use-package org-roam
+  ...current declaration moved without semantic edits...)
+
+(provide 'p3-config-org-roam)
+```
+
+Keep `citar-org-roam` outside this file. Do not alter its existing earlier `:after (citar org-roam)` declaration.
+
+- [ ] **Step 7: Run both focused Roam test files**
+
+Run both and expect PASS without creating a real Roam database or touching `~/org/notes/roam/`.
+
+- [ ] **Step 8: Commit the Roam extraction**
+
+```bash
+git add lisp/p3-org-roam.el lisp/p3-config-org-roam.el \
+        test/p3-org-roam-test.el test/p3-config-org-roam-test.el
+git commit -m "Extract Org-roam configuration boundary"
+```
+
+---
+
+### Task 3: Extract presentation state behavior and package wiring
+
+**Files:**
+- Create: `lisp/p3-org-present.el`
+- Create: `lisp/p3-config-org-present.el`
+- Create: `test/p3-org-present-test.el`
+- Create: `test/p3-config-org-present-test.el`
+
+**Interfaces:**
+- Consumes: built-in `face-remap`; runtime `org-present`, `visual-fill-column`, and `hide-mode-line` functions/variables supplied by packages.
+- Produces: `p3/org-present--state`, `p3/org-present-start`, `p3/org-present-toggle-fullscreen`, `p3/org-present-hook`, `p3/org-present-quit-hook`, `p3/org-present-prev`, `p3/org-present-next`, feature `p3-org-present`, feature `p3-config-org-present`.
+
+- [ ] **Step 1: Write failing presentation behavior tests before implementation**
+
+Create `test/p3-org-present-test.el` and stub every optional-package function the behavior calls.
+
+Tests must cover:
+
+1. `p3/org-present-start` signals `user-error` outside Org-derived modes and delegates to `org-present` inside a stubbed Org context.
+2. `p3/org-present-toggle-fullscreen` changes frame parameter `fullscreen` from nil to `fullboth` and back.
+3. `p3/org-present-next` and `p3/org-present-prev` delegate exactly once.
+4. `p3/org-present-hook` captures header line, line-number mode state, inline-image state, visual-fill state/settings, hide-mode-line state, and face-remap cookies; then applies width `90`, centered text, hide-mode-line, and face scales `1.5`, `1.2`, `1.1`.
+5. `p3/org-present-quit-hook` calls `org-present-small`, restores each saved state, removes each remap cookie, and sets `p3/org-present--state` back to nil.
+
+Use `cl-letf` stubs for:
+
+```elisp
+org-present
+org-present-big
+org-present-small
+org-present-next
+org-present-prev
+org-display-inline-images
+org-remove-inline-images
+visual-fill-column-mode
+hide-mode-line-mode
+display-line-numbers-mode
+face-remap-add-relative
+face-remap-remove-relative
+```
+
+- [ ] **Step 2: Verify presentation behavior tests fail before `p3-org-present.el` exists**
+
+Run focused ERT and expect FAIL/load error.
+
+- [ ] **Step 3: Create `p3-org-present.el` with direct `face-remap` ownership**
+
+Start with:
+
+```elisp
+;;; p3-org-present.el --- Org presentation behavior -*- lexical-binding: t; -*-
+
+(require 'face-remap)
+
+(defvar org-inline-image-overlays)
+(defvar visual-fill-column-center-text)
+(defvar visual-fill-column-width)
+
+(declare-function hide-mode-line-mode "hide-mode-line" (&optional arg))
+(declare-function org-display-inline-images "org" (&rest args))
+(declare-function org-present "org-present" ())
+(declare-function org-present-big "org-present" ())
+(declare-function org-present-next "org-present" ())
+(declare-function org-present-prev "org-present" ())
+(declare-function org-present-small "org-present" ())
+(declare-function org-remove-inline-images "org" ())
+(declare-function visual-fill-column-mode "visual-fill-column" (&optional arg))
+```
+
+Then move the current state variable and six functions without semantic changes.
+
+Do not add `use-package` or require `p3-config-org-present`.
+
+- [ ] **Step 4: Run focused presentation behavior tests and correct only declaration/test harness issues**
+
+Expected: PASS.
+
+- [ ] **Step 5: Write failing source-semantic tests for `p3-config-org-present.el`**
+
+Create `test/p3-config-org-present-test.el` and pin this effective top-level order:
+
+```text
+(use-package hide-mode-line ...)
+(use-package visual-fill-column ...)
+(p3/config-load-module 'p3-org-present)
+(use-package org-present ...)
+```
+
+Assert there is no standalone `(require 'face-remap)` in the config owner; the behavior library owns it.
+
+Pin `hide-mode-line :after (org-present)`, `org-present-text-scale 4`, both hooks, `C-c P`, and every `org-present-mode-keymap` binding:
+
+```text
+C-c C-j     p3/org-present-next
+C-c C-k     p3/org-present-prev
+SPC         p3/org-present-next
+<backspace> p3/org-present-prev
+n           p3/org-present-next
+p           p3/org-present-prev
+f           p3/org-present-toggle-fullscreen
+q           org-present-quit
+```
+
+- [ ] **Step 6: Create `p3-config-org-present.el` with package wiring only**
+
+Use:
+
+```elisp
+;;; p3-config-org-present.el --- Org presentation configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(use-package hide-mode-line
+  :after (org-present))
+
+(use-package visual-fill-column)
+
+(p3/config-load-module 'p3-org-present)
+
+(use-package org-present
+  ...current bindings/hooks/config moved unchanged...)
+
+(provide 'p3-config-org-present)
+```
+
+Add only compile-time declarations required by warnings-as-errors byte compilation.
+
+- [ ] **Step 7: Run both focused presentation test files**
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the presentation extraction**
+
+```bash
+git add lisp/p3-org-present.el lisp/p3-config-org-present.el \
+        test/p3-org-present-test.el test/p3-config-org-present-test.el
+git commit -m "Extract Org presentation configuration boundary"
+```
+
+---
+
+### Task 4: Route `config.org` through the three owners and harden architecture tests
+
+**Files:**
+- Modify: `config.org`
+- Modify: `test/p3-config-test.el`
+
+**Interfaces:**
+- Consumes: features `p3-config-org`, `p3-config-org-roam`, `p3-config-org-present` from Tasks 1-3.
+- Produces: one explicit loader stanza per new configuration owner, with existing out-of-scope sections retaining their positions.
+
+- [ ] **Step 1: Add failing architecture assertions before editing `config.org`**
+
+Update the config-module test to expect ten explicit configuration modules:
+
+```elisp
+'(p3-config-base
+  p3-config-editing
+  p3-config-completion
+  p3-config-ess
+  p3-config-org
+  p3-config-org-roam
+  p3-config-org-present
+  p3-config-python
+  p3-config-workspace
+  p3-config-git)
+```
+
+Add a dedicated ordering test that locates these exact needles in `config.org`:
+
+```elisp
+"(p3/config-load-module 'p3-config-org)"
+"(p3/config-load-module 'p3-config-org-roam)"
+"(use-package poly-R"
+"(p3/config-load-module 'p3-config-org-present)"
+```
+
+and asserts:
+
+```elisp
+(should (< org roam))
+(should (< roam poly-r))
+(should (< poly-r present))
+```
+
+Add ownership assertions that each loader stanza occurs exactly once and that the following moved definitions/forms no longer appear inline:
+
+```text
+(defun p3/org-sort-todos
+(defun org-set-line-checkbox
+(defun org-roam-generate-tagged-header
+(defun org-roam-node-insert-immediate-with-tag
+(defun org-roam-rg-search
+(defun p3/org-roam-filter-by-tag
+(defun p3/org-roam-list-notes
+(defun p3/org-roam-list-notes-by-tag
+(defun p3/org-roam-get-agenda
+(defvar-local p3/org-present--state
+(defun p3/org-present-start
+(defun p3/org-present-toggle-fullscreen
+(defun p3/org-present-hook
+(defun p3/org-present-quit-hook
+(defun p3/org-present-prev
+(defun p3/org-present-next
+(use-package org-roam
+(use-package org-present
+```
+
+Do **not** forbid legitimate `(python . t)`, `(R . t)`, citation, LaTeX, or `citar-org-roam` references.
+
+Assert `config.org` still contains the existing Citar/BibTeX/RefTeX section markers/forms, LaTeX forms, Poly-R declaration, and `(use-package citar-org-roam ...)`.
+
+- [ ] **Step 2: Verify the new architecture assertions fail against the still-inline config**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: FAIL because the three loader stanzas are absent and inline implementation remains.
+
+- [ ] **Step 3: Replace only the three approved implementation regions in `config.org`**
+
+Replace the current Org implementation block with concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org)
+```
+
+Replace the current Org-roam implementation block with concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org-roam)
+```
+
+Leave the `** Poly-R` section exactly between Roam and Presentation.
+
+Replace the current Presentation implementation block with concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org-present)
+```
+
+Do not move or rewrite the earlier citation/BibTeX/RefTeX or LaTeX sections.
+
+Because connector updates replace whole files, reconstruct `config.org` from exact current branch contents, then reject any diff containing unrelated whitespace/content changes before committing.
+
+- [ ] **Step 4: Update the older export-ownership architecture assertion without changing exporter semantics**
+
+The existing test currently expects `(use-package p3-org-export` directly in `config.org`. Change it to assert:
+
+```elisp
+(p3/config-load-module 'p3-config-org)
+```
+
+in `config.org`, `(use-package p3-org-export` in `lisp/p3-config-org.el`, and absence of `p3/org-export-to-office` implementation from both top-level config and config module.
+
+- [ ] **Step 5: Run architecture and all six focused Org boundary tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-test.el \
+  -l test/p3-org-test.el \
+  -l test/p3-config-org-test.el \
+  -l test/p3-org-roam-test.el \
+  -l test/p3-config-org-roam-test.el \
+  -l test/p3-org-present-test.el \
+  -l test/p3-config-org-present-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Confirm `p3-org-export.el` and its test are byte-for-byte unchanged**
+
+Run:
+
+```bash
+git diff --exit-code master -- lisp/p3-org-export.el test/p3-org-export-test.el
+```
+
+Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit top-level orchestration**
+
+```bash
+git add config.org test/p3-config-test.el
+git commit -m "Route Org subsystems through focused modules"
+```
+
+---
+
+### Task 5: Add compile/runtime CI coverage and run the final regression gate
+
+**Files:**
+- Modify: `.github/workflows/emacs-tests.yml`
+- Modify: `.github/workflows/windows-platform-tests.yml`
+
+**Interfaces:**
+- Consumes: all six new Lisp files and six new focused test files.
+- Produces: warnings-as-errors compilation, three runtime-load smoke checks, Ubuntu full-suite coverage, and Windows source-level boundary coverage without optional-package installation.
+
+- [ ] **Step 1: Add all six new Lisp files to Ubuntu warnings-as-errors byte compilation**
+
+Add:
+
+```text
+lisp/p3-org.el
+lisp/p3-config-org.el
+lisp/p3-org-roam.el
+lisp/p3-config-org-roam.el
+lisp/p3-org-present.el
+lisp/p3-config-org-present.el
+```
+
+to the existing `batch-byte-compile` list after package installation has already been suppressed with:
+
+```elisp
+(require 'use-package-ensure)
+(setq use-package-ensure-function (lambda (&rest _) t))
+```
+
+Do not install Org-roam, org-present, hide-mode-line, or visual-fill-column for this compile step. Resolve warnings with declaration-only `defvar`/`declare-function` forms in the owning source files.
+
+- [ ] **Step 2: Add an Org-core runtime smoke check**
+
+Add a workflow step that loads `p3-config-loader.el` and `p3-config-org.el` with package installation suppressed, then exits nonzero unless:
+
+```elisp
+(featurep 'p3-config-org)
+(featurep 'p3-org)
+(equal org-startup-folded 'content)
+(eq org-confirm-babel-evaluate t)
+```
+
+are all true.
+
+Do not exact-source load `p3-org-export`; let the unchanged `use-package p3-org-export :demand t` form exercise its real activation path.
+
+- [ ] **Step 3: Add an Org-roam config smoke test using stubs, not package installation**
+
+Before loading `p3-config-org-roam.el`, provide the minimum package surface needed for the `use-package org-roam` declaration to evaluate without side effects. Use temporary symbols/maps/functions and `(provide 'org-roam)` / any required subfeatures rather than creating a database.
+
+The assertion must at least verify:
+
+```elisp
+(featurep 'p3-config-org-roam)
+(featurep 'p3-org-roam)
+(equal org-roam-directory "~/org/notes/roam/")
+```
+
+and the smoke harness must stub `org-roam-db-autosync-mode` so no database is opened.
+
+- [ ] **Step 4: Add a presentation config smoke test using stubs, not package installation**
+
+Provide stub features/functions/maps for `hide-mode-line`, `visual-fill-column`, and `org-present`, including `org-mode-map` and `org-present-mode-keymap` where necessary for `use-package :bind` evaluation.
+
+Load `p3-config-org-present.el` and assert:
+
+```elisp
+(featurep 'p3-config-org-present)
+(featurep 'p3-org-present)
+(featurep 'face-remap)
+(equal org-present-text-scale 4)
+```
+
+Do not enter presentation mode or manipulate a real frame/buffer beyond what batch Emacs itself creates.
+
+- [ ] **Step 5: Add all six focused tests to the Ubuntu full ERT invocation**
+
+Load:
+
+```text
+test/p3-org-test.el
+test/p3-config-org-test.el
+test/p3-org-roam-test.el
+test/p3-config-org-roam-test.el
+test/p3-org-present-test.el
+test/p3-config-org-present-test.el
+```
+
+Keep the existing `test/p3-org-export-test.el` line unchanged.
+
+- [ ] **Step 6: Extend Windows path triggers and source-level test invocation only**
+
+Add the three new config modules and three config-boundary test files to Windows workflow path triggers:
+
+```text
+lisp/p3-config-org.el
+lisp/p3-config-org-roam.el
+lisp/p3-config-org-present.el
+test/p3-config-org-test.el
+test/p3-config-org-roam-test.el
+test/p3-config-org-present-test.el
+```
+
+Add the three config-boundary tests to the existing Windows config-architecture ERT command.
+
+Do not add runtime Org-roam/presentation smoke checks on Windows and do not add behavior-library path triggers that would cause Windows jobs without corresponding Windows behavior coverage.
+
+- [ ] **Step 7: Run static pre-PR verification before pushing the implementation head**
+
+Confirm:
+
+```bash
+git diff --check master...HEAD
+git diff --exit-code master -- lisp/p3-org-export.el test/p3-org-export-test.el
+```
+
+Inspect the aggregate `config.org` diff and reject any changes outside the Org, Org-roam, and Presentation regions.
+
+Search the branch diff for `TBD`, `TODO` placeholders introduced by this work, accidental package-install commands, broad `display-buffer-alist` changes, or changes under citation/LaTeX/Poly-R/Projectile.
+
+- [ ] **Step 8: Open/update the PR only after the implementation head is final enough for one CI cycle**
+
+The PR summary must state that this is behavior-preserving decomposition and explicitly note:
+
+- exporter implementation/reload behavior unchanged;
+- trailing Roam header `#` intentionally preserved;
+- direct `face-remap` dependency moved with presentation behavior;
+- optional packages are stubbed rather than installed in smoke checks;
+- Citar/BibTeX/RefTeX, LaTeX, and Poly-R are out of scope.
+
+- [ ] **Step 9: Verify the final Ubuntu and Windows runs from the exact PR head**
+
+Ubuntu must show:
+
+- warnings-as-errors byte compilation success;
+- Org core runtime smoke success;
+- Org-roam stubbed runtime smoke success;
+- presentation stubbed runtime smoke success;
+- full ERT suite success with zero unexpected failures.
+
+Windows must show:
+
+- existing platform/project gate success;
+- config architecture gate success including the three new source-level config-boundary tests.
+
+If a run fails, inspect the exact job log and fix the root cause; do not add diagnostic workflows.
+
+- [ ] **Step 10: Perform final adversarial review before any merge recommendation**
+
+Review the aggregate PR against the spec for:
+
+- any changed Org/Roam/presentation behavior;
+- accidental exporter reload changes;
+- missing direct dependencies in behavior libraries;
+- package installation in compile/smoke steps;
+- config ordering drift;
+- capture/template/keybinding drift;
+- presentation state restoration coverage;
+- unrelated modifications.
+
+Do not merge without explicit user approval.

--- a/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
+++ b/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
@@ -72,6 +72,8 @@ The commented-out `org-bullets` block has no runtime effect and does not need to
 
 `p3-org.el` must not require Org merely to define its commands. It should use declarations where needed so exact-source loading the behavior library does not force Org earlier than the current configuration does.
 
+The existing anonymous timestamp-on-save hook is preserved as an anonymous hook form in this PR. Do not opportunistically name, deduplicate, or otherwise change its reload behavior while moving it.
+
 ### Existing exporter timing
 
 `p3-org-export.el` already requires Org. Therefore `p3-config-org.el` must not exact-source load it at module entry.
@@ -149,7 +151,15 @@ The agenda helper retains its existing semantics: prompt for a tag, set `org-age
 - the current enter/quit hooks;
 - `org-present-text-scale 4`.
 
-The module exact-source loads `p3-org-present.el` after the prerequisite declaration/load point needed to preserve the current `face-remap` relationship and before binding the behavior commands.
+The module preserves the current executable sequence exactly in substance:
+
+1. declare `hide-mode-line` with `:after (org-present)`;
+2. declare/load `visual-fill-column` as it is loaded today;
+3. require built-in `face-remap`;
+4. exact-source load `p3-org-present.el` so the presentation commands/state functions exist;
+5. evaluate the `use-package org-present` declaration that binds those commands and installs the existing hooks.
+
+This sequence avoids moving `face-remap`, `visual-fill-column`, or presentation behavior across a package-loading boundary merely because the code is being extracted.
 
 No new display-buffer or window-placement policy is introduced.
 
@@ -226,7 +236,8 @@ Specifically:
 - no agenda workflow is redesigned;
 - no Roam path/template/database behavior is redesigned;
 - no presentation UX is redesigned;
-- no broad window-management rule is introduced.
+- no broad window-management rule is introduced;
+- no anonymous hooks, legacy function names, or other odd-but-working forms are opportunistically normalized merely because they move files.
 
 ## Exact-Source Reload Semantics
 
@@ -258,6 +269,7 @@ Add source-semantic tests for `p3-config-org.el` that verify:
 - Babel confirmation remains `t`;
 - Org visual/source settings and ellipsis are unchanged;
 - `C-c s` and `C-c C-x C-o` remain bound to the same behavior;
+- the anonymous timestamp hook remains behaviorally unchanged;
 - `p3-org-export.el` is loaded/activated after the Org declaration rather than at module entry;
 - Linux PDF handling remains unchanged;
 - TODO keywords/faces remain unchanged;
@@ -306,11 +318,10 @@ The state-restoration test is important because moving these functions is the hi
 Source-semantic tests should pin:
 
 - package relationships for `hide-mode-line`, `visual-fill-column`, and `org-present`;
-- prerequisite `face-remap` availability/order;
+- the exact sequence `hide-mode-line -> visual-fill-column -> face-remap -> p3-org-present -> org-present`;
 - all current presentation bindings;
 - both presentation hooks;
-- `org-present-text-scale 4`;
-- exact-source loading of `p3-org-present.el` at the intended point.
+- `org-present-text-scale 4`.
 
 ### Architecture tests
 
@@ -371,6 +382,7 @@ The refactor is complete when:
 9. Poly-R remains between Roam and Presentation;
 10. citation/BibTeX/RefTeX and LaTeX configuration remain outside this refactor;
 11. existing keybindings/settings/templates are semantically unchanged;
-12. new modules/libraries byte-compile cleanly without optional-package installation churn;
-13. focused and full regression suites pass on the intended CI platforms;
-14. no unrelated subsystem or behavior change is included.
+12. no odd-but-working hooks or legacy command names are normalized as part of the move;
+13. new modules/libraries byte-compile cleanly without optional-package installation churn;
+14. focused and full regression suites pass on the intended CI platforms;
+15. no unrelated subsystem or behavior change is included.

--- a/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
+++ b/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
@@ -16,7 +16,7 @@ The remaining Org area in `config.org` combines several distinct responsibilitie
 - Org-roam helper behavior for tagged note insertion, ripgrep search, tag filtering, note enumeration, and agenda construction;
 - Org presentation package wiring plus substantial stateful presentation behavior.
 
-`lisp/p3-org-export.el` is already a focused reusable behavior library and has its own tests. It should remain intact.
+`lisp/p3-org-export.el` is already a focused reusable behavior library and has its own tests. It should remain intact and retain its current loading/reload semantics.
 
 Citation/BibTeX/RefTeX configuration and LaTeX configuration are adjacent to Org functionality but have distinct dependencies and ownership. They are deliberately excluded from this PR.
 
@@ -29,7 +29,7 @@ config.org
   |
   +--> p3-config-org
   |      +--> p3-org
-  |      +--> p3-org-export   ; existing library, unchanged
+  |      +--> p3-org-export   ; existing library, activated as today
   |
   +--> p3-config-org-roam
   |      +--> p3-org-roam
@@ -74,18 +74,28 @@ The commented-out `org-bullets` block has no runtime effect and does not need to
 
 The existing anonymous timestamp-on-save hook is preserved as an anonymous hook form in this PR. Do not opportunistically name, deduplicate, or otherwise change its reload behavior while moving it.
 
-### Existing exporter timing
+### Existing exporter timing and reload behavior
 
-`p3-org-export.el` already requires Org. Therefore `p3-config-org.el` must not exact-source load it at module entry.
+`p3-org-export.el` already requires Org and is currently activated through:
+
+```elisp
+(use-package p3-org-export
+  :ensure nil
+  :demand t
+  :config
+  (p3-org-export-setup))
+```
+
+That activation form moves into `p3-config-org.el` unchanged in substance. The configuration module must **not** exact-source load `p3-org-export.el` through `p3/config-load-module`.
 
 The current order is preserved semantically:
 
 1. establish the Org core settings/hooks and evaluate the existing `use-package org` declaration, including Babel setup;
 2. define/bind the extracted core Org commands;
-3. at the point corresponding to the current `use-package p3-org-export` block, exact-source load `p3-org-export.el` and call `p3-org-export-setup`;
-4. continue with the remaining Org settings such as PDF opening, TODO configuration, and agenda configuration in their current relative order where that order can be observed.
+3. evaluate the existing `use-package p3-org-export` activation at the point where it exists today;
+4. continue with PDF opening, TODO configuration, and agenda configuration in their current relative order where that order can be observed.
 
-This keeps the exporter reloadable through `C-c r` without moving its `require 'org` side effect earlier in startup.
+This preserves both startup timing and current reload behavior. `C-c r` will re-evaluate the moved `use-package p3-org-export` declaration just as it re-evaluates that declaration today, but it will not gain new exact-source reload semantics for the exporter implementation.
 
 `p3-org-export.el` itself is unchanged in this PR.
 
@@ -138,13 +148,14 @@ The library may require generic built-ins such as `seq` and `subr-x`, but it mus
 
 The agenda helper retains its existing semantics: prompt for a tag, set `org-agenda-files` to all Roam notes or only tagged notes, then invoke `org-agenda`.
 
+The current nonblank branch of `org-roam-generate-tagged-header` produces a header string whose final line ends with a stray `#`. That output is odd but observable behavior. This structural PR preserves it exactly and tests for it explicitly rather than silently correcting it.
+
 ## `p3-config-org-present.el`
 
 `lisp/p3-config-org-present.el` becomes the declarative presentation owner. It preserves:
 
 - `use-package hide-mode-line` with the current `:after (org-present)` relationship;
 - `use-package visual-fill-column`;
-- the current `face-remap` availability before presentation behavior is exercised;
 - the existing `use-package org-present` declaration;
 - `C-c P` from `org-mode-map`;
 - all current presentation-mode navigation/fullscreen/quit bindings;
@@ -155,11 +166,10 @@ The module preserves the current executable sequence exactly in substance:
 
 1. declare `hide-mode-line` with `:after (org-present)`;
 2. declare/load `visual-fill-column` as it is loaded today;
-3. require built-in `face-remap`;
-4. exact-source load `p3-org-present.el` so the presentation commands/state functions exist;
-5. evaluate the `use-package org-present` declaration that binds those commands and installs the existing hooks.
+3. exact-source load `p3-org-present.el`, which itself requires built-in `face-remap` before defining the presentation behavior;
+4. evaluate the `use-package org-present` declaration that binds those commands and installs the existing hooks.
 
-This sequence avoids moving `face-remap`, `visual-fill-column`, or presentation behavior across a package-loading boundary merely because the code is being extracted.
+This keeps `face-remap` at the same effective point in the sequence while giving the behavior library direct ownership of the built-in dependency it actually calls.
 
 No new display-buffer or window-placement policy is introduced.
 
@@ -174,6 +184,8 @@ No new display-buffer or window-placement policy is introduced.
 - `p3/org-present-quit-hook`;
 - `p3/org-present-prev`;
 - `p3/org-present-next`.
+
+The library directly requires built-in `face-remap`, because its enter/quit behavior calls `face-remap-add-relative` and `face-remap-remove-relative`. It must not rely on its configuration owner having loaded that dependency incidentally.
 
 The exact presentation behavior is frozen:
 
@@ -229,23 +241,24 @@ Specifically:
 - the earlier Citar/BibTeX/RefTeX configuration stays where it is;
 - `citar-org-roam` remains outside the new Roam module and retains its `:after` relationship;
 - LaTeX configuration stays where it is;
-- the existing Pandoc exporter implementation stays unchanged;
+- the existing Pandoc exporter implementation and its current loading/reload semantics stay unchanged;
 - no keybindings are renamed or moved to new keys;
 - no Org Babel language is added or removed;
 - Babel confirmation remains enabled;
 - no agenda workflow is redesigned;
 - no Roam path/template/database behavior is redesigned;
+- the stray trailing `#` in nonblank tagged Roam headers is preserved;
 - no presentation UX is redesigned;
 - no broad window-management rule is introduced;
 - no anonymous hooks, legacy function names, or other odd-but-working forms are opportunistically normalized merely because they move files.
 
 ## Exact-Source Reload Semantics
 
-The new configuration modules are loaded through `p3/config-load-module`, so `C-c r` re-evaluates their current tracked source.
+The three new configuration modules are loaded through `p3/config-load-module`, so `C-c r` re-evaluates their current tracked source.
 
-Each new configuration owner also exact-source loads its behavior library so edits to `p3-org.el`, `p3-org-roam.el`, and `p3-org-present.el` are picked up by configuration reload, matching the pattern already used for migrated ESS/Python behavior boundaries.
+Each new configuration owner exact-source loads its newly extracted behavior library so edits to `p3-org.el`, `p3-org-roam.el`, and `p3-org-present.el` are picked up by configuration reload, matching the pattern already used for migrated ESS/Python behavior boundaries.
 
-`p3-org-export.el` is exact-source loaded at its preserved activation point within `p3-config-org.el`, so exporter edits also remain visible to reload without moving Org loading earlier.
+The existing exporter is the deliberate exception. `p3-config-org.el` retains the current `use-package p3-org-export :demand t` activation instead of exact-source loading `p3-org-export.el`, so this PR does not change exporter implementation reload semantics.
 
 No module registry, scanning, autoload framework, or recursive generic reload mechanism is added.
 
@@ -270,7 +283,7 @@ Add source-semantic tests for `p3-config-org.el` that verify:
 - Org visual/source settings and ellipsis are unchanged;
 - `C-c s` and `C-c C-x C-o` remain bound to the same behavior;
 - the anonymous timestamp hook remains behaviorally unchanged;
-- `p3-org-export.el` is loaded/activated after the Org declaration rather than at module entry;
+- the existing `use-package p3-org-export` activation remains after the Org declaration and is not replaced with exact-source loading;
 - Linux PDF handling remains unchanged;
 - TODO keywords/faces remain unchanged;
 - Org Agenda sorting remains `priority-down`.
@@ -279,7 +292,8 @@ Add source-semantic tests for `p3-config-org.el` that verify:
 
 Add focused tests for `p3-org-roam.el` using stubs rather than a real Org-roam database. Cover at minimum:
 
-- tagged-header output for blank and nonblank tags;
+- tagged-header output for a blank tag;
+- the exact nonblank tagged-header string, including its current trailing `#`;
 - tag predicate behavior;
 - note enumeration from stubbed nodes;
 - tagged note filtering;
@@ -305,6 +319,7 @@ Tests should not create a real Roam database or depend on the user's notes direc
 
 Add focused tests for `p3-org-present.el` with external presentation/display functions stubbed. Cover at minimum:
 
+- direct ownership of the built-in `face-remap` dependency;
 - non-Org start rejection;
 - fullscreen toggle behavior;
 - enter hook captures relevant prior buffer state and applies presentation state;
@@ -318,7 +333,7 @@ The state-restoration test is important because moving these functions is the hi
 Source-semantic tests should pin:
 
 - package relationships for `hide-mode-line`, `visual-fill-column`, and `org-present`;
-- the exact sequence `hide-mode-line -> visual-fill-column -> face-remap -> p3-org-present -> org-present`;
+- the exact effective sequence `hide-mode-line -> visual-fill-column -> p3-org-present[face-remap] -> org-present`;
 - all current presentation bindings;
 - both presentation hooks;
 - `org-present-text-scale 4`.
@@ -335,18 +350,31 @@ Update `test/p3-config-test.el` to verify:
 - Org Babel's Python/R/etc. references are not mistaken for configuration-ownership leaks;
 - `p3-org-export.el` remains a behavior library rather than being folded into a new module.
 
+### Runtime-load smoke tests
+
+The CI design must verify evaluation, not only parsing and byte compilation.
+
+Ubuntu should smoke-load each new configuration owner in batch Emacs with package installation suppressed:
+
+- `p3-config-org.el` must evaluate successfully and provide `p3-config-org` and `p3-org` while preserving the expected core Org configuration state;
+- `p3-config-org-roam.el` must evaluate successfully with the optional Org-roam package surface stubbed/provided by the test harness rather than installed, and must provide both `p3-config-org-roam` and `p3-org-roam`;
+- `p3-config-org-present.el` must evaluate successfully with `hide-mode-line`, `visual-fill-column`, and `org-present` package surfaces stubbed/provided by the harness rather than installed, and must provide both `p3-config-org-present` and `p3-org-present`.
+
+The smoke harness must avoid opening a real Roam database, touching the user's notes directory, starting presentation mode, or installing optional third-party packages. Its purpose is to catch load-order, missing-variable, missing-function, and package-wiring failures in the actual modules.
+
 ### CI
 
 Ubuntu should:
 
 - byte-compile all six new Lisp files with warnings treated as errors and package installation suppressed;
+- run all three runtime-load smoke checks;
 - run the new focused behavior/configuration-boundary tests;
 - run the existing `p3-org-export` tests unchanged;
 - run the full ERT suite as the final regression gate.
 
 Windows should cover source-level architecture/configuration-boundary tests when the changed files participate in portable configuration structure. It should not install Org-roam or presentation packages or create a second broad runtime suite solely for this refactor.
 
-Optional third-party packages must not be installed merely to byte-compile the new modules. Compiler-only `defvar` and `declare-function` forms are acceptable when needed and must not change runtime behavior.
+Optional third-party packages must not be installed merely to byte-compile or smoke-load the new modules. Compiler-only `defvar` and `declare-function` forms and smoke-test-only package stubs are acceptable when needed and must not change runtime behavior.
 
 ## Out of Scope
 
@@ -357,8 +385,9 @@ This PR does not:
 - rename existing Org commands;
 - change Org Agenda semantics;
 - redesign Org-roam capture templates, database settings, note paths, or keybindings;
+- fix the current trailing `#` emitted by nonblank tagged Roam headers;
 - redesign the presentation experience;
-- change the Pandoc export implementation or supported formats;
+- change the Pandoc export implementation, supported formats, or reload semantics;
 - reorganize Citar, `citar-org-roam`, BibTeX, RefTeX, or citation configuration;
 - reorganize LaTeX configuration;
 - change Poly-R;
@@ -374,15 +403,16 @@ The refactor is complete when:
 1. `p3-config-org.el` is the sole declarative owner for Org core/Agenda/export activation configuration in this scope;
 2. `p3-org.el` owns the extracted reusable Org commands with unchanged behavior;
 3. `p3-config-org-roam.el` is the sole declarative Org-roam owner;
-4. `p3-org-roam.el` owns the extracted Roam helper behavior with unchanged semantics;
+4. `p3-org-roam.el` owns the extracted Roam helper behavior with unchanged semantics, including the current trailing `#` in nonblank tagged headers;
 5. `p3-config-org-present.el` is the sole declarative Org presentation owner;
-6. `p3-org-present.el` owns the stateful presentation behavior with correct restoration semantics;
-7. `p3-org-export.el` remains unchanged and is activated at its preserved point after Org core setup;
+6. `p3-org-present.el` owns the stateful presentation behavior, directly owns its `face-remap` dependency, and preserves restoration semantics;
+7. `p3-org-export.el` remains unchanged and retains its current `use-package`-based activation/reload behavior;
 8. `config.org` contains the three concise loader stanzas in the same broad positions as the old sections;
 9. Poly-R remains between Roam and Presentation;
 10. citation/BibTeX/RefTeX and LaTeX configuration remain outside this refactor;
 11. existing keybindings/settings/templates are semantically unchanged;
 12. no odd-but-working hooks or legacy command names are normalized as part of the move;
 13. new modules/libraries byte-compile cleanly without optional-package installation churn;
-14. focused and full regression suites pass on the intended CI platforms;
-15. no unrelated subsystem or behavior change is included.
+14. each new configuration owner passes a runtime-load smoke check without optional-package installation or external side effects;
+15. focused and full regression suites pass on the intended CI platforms;
+16. no unrelated subsystem or behavior change is included.

--- a/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
+++ b/docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md
@@ -1,0 +1,376 @@
+# Org Configuration Boundaries Design
+
+## Goal
+
+Decompose the remaining Org-related configuration in `config.org` into focused declarative configuration modules and reusable behavior libraries while preserving current behavior and startup ordering.
+
+This is a structural refactor only. It does not redesign Org, Org-roam, Org Agenda, Org Babel, presentations, citations, export formats, or note-taking workflow.
+
+## Current State
+
+The remaining Org area in `config.org` combines several distinct responsibilities:
+
+- Org core settings, mode hooks, Babel language enablement, TODO states, agenda sorting, PDF opening, and activation of the existing Pandoc exporter;
+- reusable Org commands such as TODO sorting and region-to-checkbox conversion;
+- Org-roam package configuration, capture templates, bindings, display settings, and autosync;
+- Org-roam helper behavior for tagged note insertion, ripgrep search, tag filtering, note enumeration, and agenda construction;
+- Org presentation package wiring plus substantial stateful presentation behavior.
+
+`lisp/p3-org-export.el` is already a focused reusable behavior library and has its own tests. It should remain intact.
+
+Citation/BibTeX/RefTeX configuration and LaTeX configuration are adjacent to Org functionality but have distinct dependencies and ownership. They are deliberately excluded from this PR.
+
+## Chosen Architecture
+
+The refactor introduces three declarative configuration owners and three behavior libraries:
+
+```text
+config.org
+  |
+  +--> p3-config-org
+  |      +--> p3-org
+  |      +--> p3-org-export   ; existing library, unchanged
+  |
+  +--> p3-config-org-roam
+  |      +--> p3-org-roam
+  |
+  +--> [Poly-R remains here]
+  |
+  +--> p3-config-org-present
+         +--> p3-org-present
+```
+
+The three module-loader stanzas remain in the same broad positions currently occupied by the Org, Org-roam, and Presentation sections. The PR must not collapse them into one adjacent block or otherwise normalize their ordering.
+
+In particular, Poly-R remains between Org-roam and Presentation exactly as it is now.
+
+## `p3-config-org.el`
+
+`lisp/p3-config-org.el` becomes the declarative owner for Org core configuration. It owns the current behavior and values for:
+
+- `org-startup-folded` = `content`;
+- timestamp-on-save setup for `#+last_modified:`;
+- the existing `use-package org` declaration;
+- `C-c s` insertion of an Emacs Lisp source block;
+- Org-mode hooks for `flyspell-mode`, `visual-line-mode`, and `org-indent-mode`;
+- Org Babel language enablement for Emacs Lisp, R, C, Python, LaTeX, and shell;
+- `org-confirm-babel-evaluate t`;
+- native source fontification/tab behavior;
+- hidden emphasis markers;
+- the existing Org ellipsis;
+- the `C-c C-x C-o` binding for `p3/org-sort-todos`;
+- Linux PDF opening through Evince;
+- TODO sequence `TODO -> WAIT -> DONE` and the existing WAIT face;
+- the existing `org-agenda` package declaration and priority-down sorting strategy;
+- activation of the existing Pandoc-backed export workflow from `p3-org-export.el`.
+
+The commented-out `org-bullets` block has no runtime effect and does not need to be preserved as executable configuration. If retained for historical context, it should remain comment-only and should not create another owner.
+
+### Core behavior loading
+
+`p3-config-org.el` exact-source loads `p3-org.el` through `p3/config-load-module` before binding commands from it.
+
+`p3-org.el` must not require Org merely to define its commands. It should use declarations where needed so exact-source loading the behavior library does not force Org earlier than the current configuration does.
+
+### Existing exporter timing
+
+`p3-org-export.el` already requires Org. Therefore `p3-config-org.el` must not exact-source load it at module entry.
+
+The current order is preserved semantically:
+
+1. establish the Org core settings/hooks and evaluate the existing `use-package org` declaration, including Babel setup;
+2. define/bind the extracted core Org commands;
+3. at the point corresponding to the current `use-package p3-org-export` block, exact-source load `p3-org-export.el` and call `p3-org-export-setup`;
+4. continue with the remaining Org settings such as PDF opening, TODO configuration, and agenda configuration in their current relative order where that order can be observed.
+
+This keeps the exporter reloadable through `C-c r` without moving its `require 'org` side effect earlier in startup.
+
+`p3-org-export.el` itself is unchanged in this PR.
+
+## `p3-org.el`
+
+`lisp/p3-org.el` owns reusable Org commands currently defined inline:
+
+- `p3/org-sort-todos`;
+- `org-set-line-checkbox`.
+
+The existing names and semantics are preserved. In particular, this PR does not rename the legacy unprefixed `org-set-line-checkbox` command.
+
+The behavior library contains no `use-package` declarations and no configuration-module dependencies.
+
+## `p3-config-org-roam.el`
+
+`lisp/p3-config-org-roam.el` becomes the declarative owner for Org-roam. It exact-source loads `p3-org-roam.el` before wiring commands from it, then preserves the current `use-package org-roam` declaration exactly in substance:
+
+- `after-init . org-roam-mode` hook;
+- SQLite built-in database connector;
+- `~/org/notes/roam/` directory;
+- completion everywhere and default completion system;
+- the existing default and literature-note capture templates;
+- the current literature-note target expression using `citar-org-roam-subdir`, `citar-citekey`, `citar-date`, and `note-title`;
+- `journal/` dailies directory;
+- the existing dailies capture template;
+- all current `C-c n ...` bindings;
+- the existing node display template;
+- `org-roam-db-autosync-mode` activation.
+
+The earlier `citar-org-roam` declaration remains outside this PR. Its existing `:after (citar org-roam)` relationship must continue to work when Org-roam is loaded from the new configuration module.
+
+No capture template, path, keybinding, or database behavior is redesigned here.
+
+## `p3-org-roam.el`
+
+`lisp/p3-org-roam.el` owns the reusable helper behavior currently inline:
+
+- `org-roam-generate-tagged-header`;
+- `org-roam-node-insert-immediate-with-tag`;
+- `org-roam-rg-search`;
+- `p3/org-roam-filter-by-tag`;
+- `p3/org-roam-list-notes`;
+- `p3/org-roam-list-notes-by-tag`;
+- `p3/org-roam-get-agenda`.
+
+Existing function names are preserved, including the legacy unprefixed Org-roam helper names.
+
+The library may require generic built-ins such as `seq` and `subr-x`, but it must not require `org-roam` solely to define these functions. Org-roam functions and variables should be declared as needed for warnings-as-errors byte compilation. This preserves the current package-loading boundary.
+
+The agenda helper retains its existing semantics: prompt for a tag, set `org-agenda-files` to all Roam notes or only tagged notes, then invoke `org-agenda`.
+
+## `p3-config-org-present.el`
+
+`lisp/p3-config-org-present.el` becomes the declarative presentation owner. It preserves:
+
+- `use-package hide-mode-line` with the current `:after (org-present)` relationship;
+- `use-package visual-fill-column`;
+- the current `face-remap` availability before presentation behavior is exercised;
+- the existing `use-package org-present` declaration;
+- `C-c P` from `org-mode-map`;
+- all current presentation-mode navigation/fullscreen/quit bindings;
+- the current enter/quit hooks;
+- `org-present-text-scale 4`.
+
+The module exact-source loads `p3-org-present.el` after the prerequisite declaration/load point needed to preserve the current `face-remap` relationship and before binding the behavior commands.
+
+No new display-buffer or window-placement policy is introduced.
+
+## `p3-org-present.el`
+
+`lisp/p3-org-present.el` owns the stateful presentation behavior currently inline:
+
+- buffer-local `p3/org-present--state`;
+- `p3/org-present-start`;
+- `p3/org-present-toggle-fullscreen`;
+- `p3/org-present-hook`;
+- `p3/org-present-quit-hook`;
+- `p3/org-present-prev`;
+- `p3/org-present-next`.
+
+The exact presentation behavior is frozen:
+
+- presentation start rejects non-Org buffers;
+- current header-line state is saved and restored;
+- current line-number state is saved and restored;
+- existing inline-image state is preserved;
+- `org-present-big` / `org-present-small` behavior is retained;
+- visual-fill width remains 90 and centered during presentation;
+- prior visual-fill state and settings are restored on quit;
+- prior hide-mode-line state is restored on quit;
+- Org level 1/2/3 face remapping remains 1.5/1.2/1.1;
+- face-remap cookies are removed on quit;
+- presentation state is cleared after restoration;
+- navigation wrappers continue to delegate to `org-present-next` and `org-present-prev`;
+- fullscreen continues to toggle the frame's `fullscreen` parameter to/from `fullboth`.
+
+The behavior library contains no `use-package` declarations and no dependency on `p3-config-org-present.el`.
+
+## `config.org` End State
+
+The existing Org section is reduced to concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org)
+```
+
+The existing Org-roam section is reduced to concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org-roam)
+```
+
+The existing Presentation section is reduced to concise prose and:
+
+```elisp
+(p3/config-load-module 'p3-config-org-present)
+```
+
+These stanzas stay in their current relative locations. `config.org` must still visibly communicate the broad subsystem sequence rather than hiding it inside one umbrella Org module.
+
+## Behavior and Ordering Freeze
+
+This PR preserves all current user-facing behavior and broad startup order.
+
+Specifically:
+
+- Org core remains before Org Agenda and Org-roam;
+- Org Agenda remains configured before the Roam-backed agenda helper is used;
+- Org-roam remains in its current position;
+- Poly-R remains between Org-roam and Presentation;
+- Presentation remains in its current position before Projectile/Python;
+- the earlier Citar/BibTeX/RefTeX configuration stays where it is;
+- `citar-org-roam` remains outside the new Roam module and retains its `:after` relationship;
+- LaTeX configuration stays where it is;
+- the existing Pandoc exporter implementation stays unchanged;
+- no keybindings are renamed or moved to new keys;
+- no Org Babel language is added or removed;
+- Babel confirmation remains enabled;
+- no agenda workflow is redesigned;
+- no Roam path/template/database behavior is redesigned;
+- no presentation UX is redesigned;
+- no broad window-management rule is introduced.
+
+## Exact-Source Reload Semantics
+
+The new configuration modules are loaded through `p3/config-load-module`, so `C-c r` re-evaluates their current tracked source.
+
+Each new configuration owner also exact-source loads its behavior library so edits to `p3-org.el`, `p3-org-roam.el`, and `p3-org-present.el` are picked up by configuration reload, matching the pattern already used for migrated ESS/Python behavior boundaries.
+
+`p3-org-export.el` is exact-source loaded at its preserved activation point within `p3-config-org.el`, so exporter edits also remain visible to reload without moving Org loading earlier.
+
+No module registry, scanning, autoload framework, or recursive generic reload mechanism is added.
+
+## Testing Strategy
+
+### Core Org behavior tests
+
+Add focused tests for `p3-org.el` covering at minimum:
+
+- `p3/org-sort-todos` delegates to `org-sort-entries` with the current arguments;
+- `org-set-line-checkbox` preserves single-line behavior;
+- region behavior prefixes every selected line with `- [ ] ` and retains the current cursor semantics.
+
+### Org configuration-boundary tests
+
+Add source-semantic tests for `p3-config-org.el` that verify:
+
+- exact-source loading of `p3-org.el` occurs before command binding;
+- the existing Org mode hooks are preserved;
+- the exact Babel language set is preserved;
+- Babel confirmation remains `t`;
+- Org visual/source settings and ellipsis are unchanged;
+- `C-c s` and `C-c C-x C-o` remain bound to the same behavior;
+- `p3-org-export.el` is loaded/activated after the Org declaration rather than at module entry;
+- Linux PDF handling remains unchanged;
+- TODO keywords/faces remain unchanged;
+- Org Agenda sorting remains `priority-down`.
+
+### Org-roam behavior tests
+
+Add focused tests for `p3-org-roam.el` using stubs rather than a real Org-roam database. Cover at minimum:
+
+- tagged-header output for blank and nonblank tags;
+- tag predicate behavior;
+- note enumeration from stubbed nodes;
+- tagged note filtering;
+- agenda file selection for blank and nonblank tag input;
+- ripgrep search delegates to `consult-ripgrep` with `org-roam-directory`;
+- immediate insertion temporarily uses the tagged capture template and delegates to `org-roam-node-insert`.
+
+### Org-roam configuration-boundary tests
+
+Source-semantic tests should pin:
+
+- exact-source load of `p3-org-roam.el` before its commands are wired;
+- all current `org-roam` custom values;
+- both capture templates and the dailies template;
+- all current `C-c n` bindings;
+- node display template;
+- autosync activation;
+- absence of the moved helper definitions from `config.org`.
+
+Tests should not create a real Roam database or depend on the user's notes directory.
+
+### Presentation behavior tests
+
+Add focused tests for `p3-org-present.el` with external presentation/display functions stubbed. Cover at minimum:
+
+- non-Org start rejection;
+- fullscreen toggle behavior;
+- enter hook captures relevant prior buffer state and applies presentation state;
+- quit hook restores saved state and clears `p3/org-present--state`;
+- navigation wrappers delegate to `org-present-next` / `org-present-prev`.
+
+The state-restoration test is important because moving these functions is the highest-risk part of the refactor.
+
+### Presentation configuration-boundary tests
+
+Source-semantic tests should pin:
+
+- package relationships for `hide-mode-line`, `visual-fill-column`, and `org-present`;
+- prerequisite `face-remap` availability/order;
+- all current presentation bindings;
+- both presentation hooks;
+- `org-present-text-scale 4`;
+- exact-source loading of `p3-org-present.el` at the intended point.
+
+### Architecture tests
+
+Update `test/p3-config-test.el` to verify:
+
+- configuration-module count increases from seven to ten;
+- the three new module-loader stanzas each occur exactly once;
+- their broad order is Org -> Org-roam -> Poly-R -> Presentation;
+- moved Org/Roam/Presentation function definitions are absent from `config.org`;
+- the existing citation/BibTeX/RefTeX and LaTeX blocks remain in `config.org`;
+- Org Babel's Python/R/etc. references are not mistaken for configuration-ownership leaks;
+- `p3-org-export.el` remains a behavior library rather than being folded into a new module.
+
+### CI
+
+Ubuntu should:
+
+- byte-compile all six new Lisp files with warnings treated as errors and package installation suppressed;
+- run the new focused behavior/configuration-boundary tests;
+- run the existing `p3-org-export` tests unchanged;
+- run the full ERT suite as the final regression gate.
+
+Windows should cover source-level architecture/configuration-boundary tests when the changed files participate in portable configuration structure. It should not install Org-roam or presentation packages or create a second broad runtime suite solely for this refactor.
+
+Optional third-party packages must not be installed merely to byte-compile the new modules. Compiler-only `defvar` and `declare-function` forms are acceptable when needed and must not change runtime behavior.
+
+## Out of Scope
+
+This PR does not:
+
+- redesign Org workflows;
+- change Org Babel languages or execution-confirmation policy;
+- rename existing Org commands;
+- change Org Agenda semantics;
+- redesign Org-roam capture templates, database settings, note paths, or keybindings;
+- redesign the presentation experience;
+- change the Pandoc export implementation or supported formats;
+- reorganize Citar, `citar-org-roam`, BibTeX, RefTeX, or citation configuration;
+- reorganize LaTeX configuration;
+- change Poly-R;
+- change Projectile;
+- change completion technology;
+- add display/window-placement rules;
+- introduce module discovery or a registry.
+
+## Acceptance Criteria
+
+The refactor is complete when:
+
+1. `p3-config-org.el` is the sole declarative owner for Org core/Agenda/export activation configuration in this scope;
+2. `p3-org.el` owns the extracted reusable Org commands with unchanged behavior;
+3. `p3-config-org-roam.el` is the sole declarative Org-roam owner;
+4. `p3-org-roam.el` owns the extracted Roam helper behavior with unchanged semantics;
+5. `p3-config-org-present.el` is the sole declarative Org presentation owner;
+6. `p3-org-present.el` owns the stateful presentation behavior with correct restoration semantics;
+7. `p3-org-export.el` remains unchanged and is activated at its preserved point after Org core setup;
+8. `config.org` contains the three concise loader stanzas in the same broad positions as the old sections;
+9. Poly-R remains between Roam and Presentation;
+10. citation/BibTeX/RefTeX and LaTeX configuration remain outside this refactor;
+11. existing keybindings/settings/templates are semantically unchanged;
+12. new modules/libraries byte-compile cleanly without optional-package installation churn;
+13. focused and full regression suites pass on the intended CI platforms;
+14. no unrelated subsystem or behavior change is included.

--- a/lisp/p3-config-org-present.el
+++ b/lisp/p3-config-org-present.el
@@ -7,6 +7,13 @@
 (defvar org-present-mode-keymap)
 (defvar org-present-text-scale)
 
+(declare-function p3/org-present-hook "p3-org-present" ())
+(declare-function p3/org-present-next "p3-org-present" ())
+(declare-function p3/org-present-prev "p3-org-present" ())
+(declare-function p3/org-present-quit-hook "p3-org-present" ())
+(declare-function p3/org-present-start "p3-org-present" ())
+(declare-function p3/org-present-toggle-fullscreen "p3-org-present" ())
+
 (use-package hide-mode-line
   :after (org-present))
 

--- a/lisp/p3-config-org-present.el
+++ b/lisp/p3-config-org-present.el
@@ -1,0 +1,36 @@
+;;; p3-config-org-present.el --- Org presentation configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(defvar org-mode-map)
+(defvar org-present-mode-keymap)
+(defvar org-present-text-scale)
+
+(use-package hide-mode-line
+  :after (org-present))
+
+(use-package visual-fill-column)
+
+(p3/config-load-module 'p3-org-present)
+
+(use-package org-present
+  :bind ((:map org-mode-map
+               ("C-c P" . p3/org-present-start))
+         (:map org-present-mode-keymap
+               ("C-c C-j" . p3/org-present-next)
+               ("C-c C-k" . p3/org-present-prev)
+               ("SPC" . p3/org-present-next)
+               ("<backspace>" . p3/org-present-prev)
+               ("n" . p3/org-present-next)
+               ("p" . p3/org-present-prev)
+               ("f" . p3/org-present-toggle-fullscreen)
+               ("q" . org-present-quit)))
+  :hook ((org-present-mode . p3/org-present-hook)
+         (org-present-mode-quit . p3/org-present-quit-hook))
+  :config
+  (setq org-present-text-scale 4))
+
+(provide 'p3-config-org-present)
+
+;;; p3-config-org-present.el ends here

--- a/lisp/p3-config-org-roam.el
+++ b/lisp/p3-config-org-roam.el
@@ -13,6 +13,9 @@
 (defvar org-roam-node-display-template)
 
 (declare-function org-roam-db-autosync-mode "org-roam-db" (&optional arg))
+(declare-function org-roam-node-insert-immediate-with-tag "p3-org-roam" (arg &rest args))
+(declare-function org-roam-rg-search "p3-org-roam" ())
+(declare-function p3/org-roam-get-agenda "p3-org-roam" ())
 
 (p3/config-load-module 'p3-org-roam)
 

--- a/lisp/p3-config-org-roam.el
+++ b/lisp/p3-config-org-roam.el
@@ -1,0 +1,57 @@
+;;; p3-config-org-roam.el --- Org-roam configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(defvar org-roam-node-display-template)
+
+(declare-function org-roam-db-autosync-mode "org-roam-db" (&optional arg))
+
+(p3/config-load-module 'p3-org-roam)
+
+(use-package org-roam
+  :hook
+  (after-init . org-roam-mode)
+  :custom
+  (org-roam-database-connector 'sqlite-builtin)
+  (org-roam-directory "~/org/notes/roam/")
+  (org-roam-completion-everywhere t)
+  (org-roam-completion-system 'default)
+  (org-roam-capture-templates
+   '(("d" "default" plain "%?"
+      :if-new
+      (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                 "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+      :unnarrowed t)
+     ("n" "literature note" plain "* Heading\n %?"
+      :target
+      (file+head
+       "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
+       "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+      :unnarrowed t)))
+  (org-roam-dailies-directory "journal/")
+  (org-roam-dailies-capture-templates
+   '(("d" "default" entry "* %<%I:%M %p>: %?"
+      :target
+      (file+head "%<%Y-%m-%d>.org"
+                 "#+title: %<%Y-%m-%d %a>\n#+created: %U\n#+last_modified: %U\n"))))
+  :bind (("C-c n l" . org-roam-buffer-toggle)
+         ("C-c n f" . org-roam-node-find)
+         ("C-c n g" . org-roam-graph)
+         ("C-c n i" . org-roam-node-insert)
+         ("C-c n c" . org-roam-capture)
+         ("C-c n n" . org-roam-node-insert-immediate-with-tag)
+         ("C-c n s" . org-roam-rg-search)
+         ("C-c n d" . org-roam-dailies-goto-today)
+         ("C-c n t" . org-roam-dailies-capture-today)
+         ("C-c n C-t" . org-roam-tag-add)
+         ("C-c n a" . p3/org-roam-get-agenda))
+  :config
+  (setq org-roam-node-display-template
+        (concat "${title:*} "
+                (propertize "${tags:10}" 'face 'org-tag)))
+  (org-roam-db-autosync-mode))
+
+(provide 'p3-config-org-roam)
+
+;;; p3-config-org-roam.el ends here

--- a/lisp/p3-config-org-roam.el
+++ b/lisp/p3-config-org-roam.el
@@ -3,6 +3,13 @@
 (require 'use-package)
 (require 'p3-config-loader)
 
+(defvar org-roam-capture-templates)
+(defvar org-roam-completion-everywhere)
+(defvar org-roam-completion-system)
+(defvar org-roam-dailies-capture-templates)
+(defvar org-roam-dailies-directory)
+(defvar org-roam-database-connector)
+(defvar org-roam-directory)
 (defvar org-roam-node-display-template)
 
 (declare-function org-roam-db-autosync-mode "org-roam-db" (&optional arg))

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -62,9 +62,8 @@
 (use-package p3-org-export
   :ensure nil
   :demand t
-  :functions p3-org-export-setup
   :config
-  (p3-org-export-setup))
+  (funcall 'p3-org-export-setup))
 
 (when (eq system-type 'gnu/linux)
   (add-to-list 'org-file-apps '("pdf" . "evince %s")))

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -45,7 +45,7 @@
   :init
   (org-babel-do-load-languages
    'org-babel-load-languages
-   '((emacs-lisp . t)
+   '((emacs-lisp .t)
      (R . t)
      (C . t)
      (python . t)

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -59,11 +59,13 @@
 
 (define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
 
+(require 'p3-org-export)
+
 (use-package p3-org-export
   :ensure nil
   :demand t
   :config
-  (funcall 'p3-org-export-setup))
+  (p3-org-export-setup))
 
 (when (eq system-type 'gnu/linux)
   (add-to-list 'org-file-apps '("pdf" . "evince %s")))

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -21,6 +21,7 @@
 
 (declare-function org-babel-do-load-languages "ob-core" (sym value))
 (declare-function p3/org-sort-todos "p3-org" ())
+(declare-function p3-org-export-setup "p3-org-export" ())
 
 (p3/config-load-module 'p3-org)
 
@@ -59,8 +60,6 @@
         org-ellipsis " ↴"))
 
 (define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
-
-(require 'p3-org-export)
 
 (use-package p3-org-export
   :ensure nil

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -20,6 +20,7 @@
 (defvar time-stamp-start)
 
 (declare-function org-babel-do-load-languages "ob-core" (sym value))
+(declare-function p3/org-sort-todos "p3-org" ())
 
 (p3/config-load-module 'p3-org)
 

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -14,6 +14,10 @@
 (defvar org-startup-folded)
 (defvar org-todo-keyword-faces)
 (defvar org-todo-keywords)
+(defvar time-stamp-active)
+(defvar time-stamp-end)
+(defvar time-stamp-format)
+(defvar time-stamp-start)
 
 (declare-function org-babel-do-load-languages "ob-core" (sym value))
 (declare-function p3-org-export-setup "p3-org-export" ())

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -20,7 +20,6 @@
 (defvar time-stamp-start)
 
 (declare-function org-babel-do-load-languages "ob-core" (sym value))
-(declare-function p3-org-export-setup "p3-org-export" ())
 
 (p3/config-load-module 'p3-org)
 
@@ -63,6 +62,7 @@
 (use-package p3-org-export
   :ensure nil
   :demand t
+  :functions p3-org-export-setup
   :config
   (p3-org-export-setup))
 

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -1,0 +1,80 @@
+;;; p3-config-org.el --- Org configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(defvar org-agenda-sorting-strategy)
+(defvar org-confirm-babel-evaluate)
+(defvar org-ellipsis)
+(defvar org-file-apps)
+(defvar org-hide-emphasis-markers)
+(defvar org-mode-map)
+(defvar org-src-fontify-natively)
+(defvar org-src-tab-acts-natively)
+(defvar org-startup-folded)
+(defvar org-todo-keyword-faces)
+(defvar org-todo-keywords)
+
+(declare-function org-babel-do-load-languages "ob-core" (sym value))
+(declare-function p3-org-export-setup "p3-org-export" ())
+
+(p3/config-load-module 'p3-org)
+
+(setq org-startup-folded 'content)
+
+(add-hook 'org-mode-hook
+          (lambda ()
+            (setq-local time-stamp-active t
+                        time-stamp-start "#\\+last_modified:[ \t]*"
+                        time-stamp-end "$"
+                        time-stamp-format "\[%Y-%m-%d %3a %02H:%02M\]")
+            (add-hook 'before-save-hook 'time-stamp nil 'local)))
+
+(use-package org
+  :defer t
+  :bind (:map org-mode-map
+              ("C-c s" lambda () (interactive)
+               (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
+  :hook ((org-mode . flyspell-mode)
+         (org-mode . visual-line-mode)
+         (org-mode . org-indent-mode))
+  :init
+  (org-babel-do-load-languages
+   'org-babel-load-languages
+   '((emacs-lisp . t)
+     (R . t)
+     (C . t)
+     (python . t)
+     (latex . t)
+     (shell . t)))
+  :config
+  (setq org-confirm-babel-evaluate t
+        org-src-fontify-natively t
+        org-src-tab-acts-natively t
+        org-hide-emphasis-markers t
+        org-ellipsis " ↴"))
+
+(define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
+
+(use-package p3-org-export
+  :ensure nil
+  :demand t
+  :config
+  (p3-org-export-setup))
+
+(when (eq system-type 'gnu/linux)
+  (add-to-list 'org-file-apps '("pdf" . "evince %s")))
+
+(setq org-todo-keywords
+      '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
+      org-todo-keyword-faces
+      '(("WAIT" . "DarkOrange")))
+
+(use-package org-agenda
+  :ensure nil
+  :config
+  (setq org-agenda-sorting-strategy '(priority-down)))
+
+(provide 'p3-config-org)
+
+;;; p3-config-org.el ends here

--- a/lisp/p3-org-present.el
+++ b/lisp/p3-org-present.el
@@ -1,0 +1,100 @@
+;;; p3-org-present.el --- Org presentation behavior -*- lexical-binding: t; -*-
+
+(require 'face-remap)
+
+(defvar org-inline-image-overlays)
+(defvar visual-fill-column-center-text)
+(defvar visual-fill-column-width)
+
+(declare-function hide-mode-line-mode "hide-mode-line" (&optional arg))
+(declare-function org-display-inline-images "org" (&rest args))
+(declare-function org-present "org-present" ())
+(declare-function org-present-big "org-present" ())
+(declare-function org-present-next "org-present" ())
+(declare-function org-present-prev "org-present" ())
+(declare-function org-present-small "org-present" ())
+(declare-function org-remove-inline-images "org" ())
+(declare-function visual-fill-column-mode "visual-fill-column" (&optional arg))
+
+(defvar-local p3/org-present--state nil
+  "Saved buffer state while `org-present' is active.")
+
+(defun p3/org-present-start ()
+  "Start a presentation in the current Org buffer."
+  (interactive)
+  (unless (derived-mode-p 'org-mode)
+    (user-error "Presentation mode requires an Org buffer"))
+  (org-present))
+
+(defun p3/org-present-toggle-fullscreen ()
+  "Toggle fullscreen for the current presentation frame."
+  (interactive)
+  (set-frame-parameter
+   nil 'fullscreen
+   (unless (frame-parameter nil 'fullscreen) 'fullboth)))
+
+(defun p3/org-present-hook ()
+  "Prepare the current Org buffer for presentation mode."
+  (setq-local p3/org-present--state
+              (list :header-line header-line-format
+                    :line-numbers (bound-and-true-p display-line-numbers-mode)
+                    :inline-images (and (boundp 'org-inline-image-overlays)
+                                        org-inline-image-overlays)
+                    :visual-fill (bound-and-true-p visual-fill-column-mode)
+                    :visual-fill-width visual-fill-column-width
+                    :visual-fill-center visual-fill-column-center-text
+                    :hide-mode-line (bound-and-true-p hide-mode-line-mode)
+                    :face-remap-cookies nil))
+  (setq-local header-line-format " ")
+  (display-line-numbers-mode -1)
+  (org-present-big)
+  (unless (and (boundp 'org-inline-image-overlays)
+               org-inline-image-overlays)
+    (org-display-inline-images))
+  (setq-local visual-fill-column-width 90
+              visual-fill-column-center-text t)
+  (visual-fill-column-mode 1)
+  (hide-mode-line-mode +1)
+  (setf (plist-get p3/org-present--state :face-remap-cookies)
+        (list (face-remap-add-relative 'org-level-1 :height 1.5)
+              (face-remap-add-relative 'org-level-2 :height 1.2)
+              (face-remap-add-relative 'org-level-3 :height 1.1))))
+
+(defun p3/org-present-quit-hook ()
+  "Restore the buffer state saved by `p3/org-present-hook'."
+  (let ((state p3/org-present--state))
+    (org-present-small)
+    (when state
+      (setq-local header-line-format (plist-get state :header-line))
+      (if (plist-get state :line-numbers)
+          (display-line-numbers-mode +1)
+        (display-line-numbers-mode -1))
+      (unless (plist-get state :inline-images)
+        (org-remove-inline-images))
+      (setq-local visual-fill-column-width
+                  (plist-get state :visual-fill-width)
+                  visual-fill-column-center-text
+                  (plist-get state :visual-fill-center))
+      (if (plist-get state :visual-fill)
+          (visual-fill-column-mode +1)
+        (visual-fill-column-mode -1))
+      (if (plist-get state :hide-mode-line)
+          (hide-mode-line-mode +1)
+        (hide-mode-line-mode -1))
+      (dolist (cookie (plist-get state :face-remap-cookies))
+        (face-remap-remove-relative cookie)))
+    (setq-local p3/org-present--state nil)))
+
+(defun p3/org-present-prev ()
+  "Move to the previous presentation slide."
+  (interactive)
+  (org-present-prev))
+
+(defun p3/org-present-next ()
+  "Move to the next presentation slide."
+  (interactive)
+  (org-present-next))
+
+(provide 'p3-org-present)
+
+;;; p3-org-present.el ends here

--- a/lisp/p3-org-present.el
+++ b/lisp/p3-org-present.el
@@ -2,10 +2,14 @@
 
 (require 'face-remap)
 
+(defvar display-line-numbers-mode)
+(defvar hide-mode-line-mode)
 (defvar org-inline-image-overlays)
 (defvar visual-fill-column-center-text)
+(defvar visual-fill-column-mode)
 (defvar visual-fill-column-width)
 
+(declare-function display-line-numbers-mode "display-line-numbers" (&optional arg))
 (declare-function hide-mode-line-mode "hide-mode-line" (&optional arg))
 (declare-function org-display-inline-images "org" (&rest args))
 (declare-function org-present "org-present" ())

--- a/lisp/p3-org-roam.el
+++ b/lisp/p3-org-roam.el
@@ -1,0 +1,68 @@
+;;; p3-org-roam.el --- Org-roam workflow helpers -*- lexical-binding: t; -*-
+
+(require 'seq)
+(require 'subr-x)
+
+(defvar org-agenda-files)
+(defvar org-roam-capture-templates)
+(defvar org-roam-directory)
+
+(declare-function consult-ripgrep "consult" (dir &optional initial))
+(declare-function org-agenda "org-agenda" (&optional arg keys restriction))
+(declare-function org-roam-node-file "org-roam-node" (node))
+(declare-function org-roam-node-insert "org-roam-node" (&optional arg &rest args))
+(declare-function org-roam-node-list "org-roam-node" ())
+(declare-function org-roam-node-tags "org-roam-node" (node))
+
+(defun org-roam-generate-tagged-header ()
+  (let ((tag (read-string "Enter tag: ")))
+    (if (string-empty-p tag)
+        (concat "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+      (concat "#+title: ${title}\n#+category:${title}\n#+filetags: " tag
+              "\n#+created: %U\n#+last_modified: %U\n#"))))
+
+(defun org-roam-node-insert-immediate-with-tag (arg &rest args)
+  (interactive "p")
+  (let ((args (cons arg args))
+        (org-roam-capture-templates
+         (list
+          (append
+           (car
+            '(("t" "tagged" plain "%?"
+               :if-new
+               (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                          org-roam-generate-tagged-header)
+               :unnarrowed t)))
+           '(:immediate-finish t)))))
+    (apply #'org-roam-node-insert args)))
+
+(defun org-roam-rg-search ()
+  "Search org-roam directory using consult-ripgrep. With live-preview."
+  (interactive)
+  (consult-ripgrep org-roam-directory))
+
+(defun p3/org-roam-filter-by-tag (tag-name)
+  (lambda (node)
+    (member tag-name (org-roam-node-tags node))))
+
+(defun p3/org-roam-list-notes ()
+  (mapcar #'org-roam-node-file
+          (org-roam-node-list)))
+
+(defun p3/org-roam-list-notes-by-tag (tag-name)
+  (mapcar #'org-roam-node-file
+          (seq-filter
+           (p3/org-roam-filter-by-tag tag-name)
+           (org-roam-node-list))))
+
+(defun p3/org-roam-get-agenda ()
+  (interactive)
+  (let ((tag (read-string "Enter tag: ")))
+    (if (string-empty-p tag)
+        (setq org-agenda-files (p3/org-roam-list-notes))
+      (setq org-agenda-files (p3/org-roam-list-notes-by-tag tag))))
+  (org-agenda))
+
+(provide 'p3-org-roam)
+
+;;; p3-org-roam.el ends here

--- a/lisp/p3-org-roam.el
+++ b/lisp/p3-org-roam.el
@@ -1,4 +1,4 @@
-;;; p3-org-roam.el --- Org-roam workflow helpers -*- lexical-binding: t; -*-
+;;; p3-org-roam.el --- Org-roam workflow helpers
 
 (require 'seq)
 (require 'subr-x)

--- a/lisp/p3-org.el
+++ b/lisp/p3-org.el
@@ -1,0 +1,30 @@
+;;; p3-org.el --- Core Org workflow helpers -*- lexical-binding: t; -*-
+
+(declare-function org-sort-entries
+                  "org"
+                  (&optional with-case sorting-type get-key-func compare-func
+                             property interactive?))
+
+(defun p3/org-sort-todos ()
+  "Sort sibling entries by TODO state without changing outline hierarchy.
+Run this on a parent heading to sort its children; DONE entries follow active
+TODO states according to `org-todo-keywords'."
+  (interactive)
+  (org-sort-entries nil ?o))
+
+(defun org-set-line-checkbox (arg)
+  (interactive "p")
+  (let ((n (or arg 1)))
+    (when (region-active-p)
+      (setq n (count-lines (region-beginning)
+                           (region-end)))
+      (goto-char (region-beginning)))
+    (dotimes (_i n)
+      (beginning-of-line)
+      (insert "- [ ] ")
+      (forward-line))
+    (beginning-of-line)))
+
+(provide 'p3-org)
+
+;;; p3-org.el ends here

--- a/test/p3-config-org-present-test.el
+++ b/test/p3-config-org-present-test.el
@@ -1,0 +1,126 @@
+;;; p3-config-org-present-test.el --- Org presentation config tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-org-present-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-org-present-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-org-present-test--root))
+
+(defun p3-config-org-present-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-org-present-test--path relative))
+    (buffer-string)))
+
+(defun p3-config-org-present-test--forms ()
+  "Read all top-level forms from the Org presentation config module."
+  (with-temp-buffer
+    (insert-file-contents
+     (p3-config-org-present-test--path "lisp/p3-config-org-present.el"))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(defun p3-config-org-present-test--use-package-form (package)
+  "Return the top-level `use-package' form for PACKAGE."
+  (seq-find
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'use-package)
+          (eq (cadr form) package)))
+   (p3-config-org-present-test--forms)))
+
+(defun p3-config-org-present-test--keyword-values (package keyword)
+  "Return values following KEYWORD for PACKAGE."
+  (let* ((form (p3-config-org-present-test--use-package-form package))
+         (tail (memq keyword (cddr form)))
+         values)
+    (should tail)
+    (setq tail (cdr tail))
+    (while (and tail (not (keywordp (car tail))))
+      (push (car tail) values)
+      (setq tail (cdr tail)))
+    (nreverse values)))
+
+(ert-deftest p3-config-org-present-preserves-package-order-and-dependency-owner ()
+  (let* ((forms (p3-config-org-present-test--forms))
+         (hide (seq-position
+                forms (p3-config-org-present-test--use-package-form
+                       'hide-mode-line)
+                #'equal))
+         (fill (seq-position
+                forms (p3-config-org-present-test--use-package-form
+                       'visual-fill-column)
+                #'equal))
+         (behavior (seq-position
+                    forms '(p3/config-load-module 'p3-org-present) #'equal))
+         (present (seq-position
+                   forms (p3-config-org-present-test--use-package-form
+                          'org-present)
+                   #'equal))
+         (config-source
+          (p3-config-org-present-test--contents
+           "lisp/p3-config-org-present.el"))
+         (behavior-source
+          (p3-config-org-present-test--contents
+           "lisp/p3-org-present.el")))
+    (should (< hide fill))
+    (should (< fill behavior))
+    (should (< behavior present))
+    (should-not (string-match-p
+                 (regexp-quote "(require 'face-remap)")
+                 config-source))
+    (should (string-match-p
+             (regexp-quote "(require 'face-remap)")
+             behavior-source))))
+
+(ert-deftest p3-config-org-present-preserves-hide-and-fill-package-wiring ()
+  (should
+   (equal
+    (p3-config-org-present-test--use-package-form 'hide-mode-line)
+    '(use-package hide-mode-line
+       :after (org-present))))
+  (should
+   (equal
+    (p3-config-org-present-test--use-package-form 'visual-fill-column)
+    '(use-package visual-fill-column))))
+
+(ert-deftest p3-config-org-present-preserves-bindings-hooks-and-scale ()
+  (should
+   (equal
+    (p3-config-org-present-test--keyword-values 'org-present :bind)
+    '(((:map org-mode-map
+             ("C-c P" . p3/org-present-start))
+       (:map org-present-mode-keymap
+             ("C-c C-j" . p3/org-present-next)
+             ("C-c C-k" . p3/org-present-prev)
+             ("SPC" . p3/org-present-next)
+             ("<backspace>" . p3/org-present-prev)
+             ("n" . p3/org-present-next)
+             ("p" . p3/org-present-prev)
+             ("f" . p3/org-present-toggle-fullscreen)
+             ("q" . org-present-quit))))))
+  (should
+   (equal
+    (p3-config-org-present-test--keyword-values 'org-present :hook)
+    '(((org-present-mode . p3/org-present-hook)
+       (org-present-mode-quit . p3/org-present-quit-hook)))))
+  (should
+   (equal
+    (p3-config-org-present-test--keyword-values 'org-present :config)
+    '((setq org-present-text-scale 4)))))
+
+(provide 'p3-config-org-present-test)
+
+;;; p3-config-org-present-test.el ends here

--- a/test/p3-config-org-roam-test.el
+++ b/test/p3-config-org-roam-test.el
@@ -1,0 +1,116 @@
+;;; p3-config-org-roam-test.el --- Org-roam config boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-org-roam-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-org-roam-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-org-roam-test--root))
+
+(defun p3-config-org-roam-test--forms ()
+  "Read all top-level forms from the Org-roam config module."
+  (with-temp-buffer
+    (insert-file-contents
+     (p3-config-org-roam-test--path "lisp/p3-config-org-roam.el"))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(defun p3-config-org-roam-test--use-package-form ()
+  "Return the top-level Org-roam `use-package' form."
+  (seq-find
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'use-package)
+          (eq (cadr form) 'org-roam)))
+   (p3-config-org-roam-test--forms)))
+
+(defun p3-config-org-roam-test--keyword-values (keyword)
+  "Return values following KEYWORD in the Org-roam `use-package' form."
+  (let* ((form (p3-config-org-roam-test--use-package-form))
+         (tail (memq keyword (cddr form)))
+         values)
+    (should tail)
+    (setq tail (cdr tail))
+    (while (and tail (not (keywordp (car tail))))
+      (push (car tail) values)
+      (setq tail (cdr tail)))
+    (nreverse values)))
+
+(ert-deftest p3-config-org-roam-loads-behavior-before-package-wiring ()
+  (let* ((forms (p3-config-org-roam-test--forms))
+         (behavior (seq-position
+                    forms '(p3/config-load-module 'p3-org-roam) #'equal))
+         (package (seq-position
+                   forms (p3-config-org-roam-test--use-package-form) #'equal)))
+    (should (integerp behavior))
+    (should (integerp package))
+    (should (< behavior package))))
+
+(ert-deftest p3-config-org-roam-preserves-hook-and-custom-values ()
+  (should (equal (p3-config-org-roam-test--keyword-values :hook)
+                 '((after-init . org-roam-mode))))
+  (should
+   (equal
+    (p3-config-org-roam-test--keyword-values :custom)
+    '((org-roam-database-connector 'sqlite-builtin)
+      (org-roam-directory "~/org/notes/roam/")
+      (org-roam-completion-everywhere t)
+      (org-roam-completion-system 'default)
+      (org-roam-capture-templates
+       '(("d" "default" plain "%?"
+          :if-new
+          (file+head "%<%Y%m%d%H%M%S>-${slug}.org"
+                     "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n")
+          :unnarrowed t)
+         ("n" "literature note" plain "* Heading\n %?"
+          :target
+          (file+head
+           "%(expand-file-name (or citar-org-roam-subdir \"\") org-roam-directory)/${citar-citekey}.org"
+           "#+title: ${citar-citekey} (${citar-date}). ${note-title}.\n#+created: %U\n#+last_modified: %U\n\n")
+          :unnarrowed t)))
+      (org-roam-dailies-directory "journal/")
+      (org-roam-dailies-capture-templates
+       '(("d" "default" entry "* %<%I:%M %p>: %?"
+          :target
+          (file+head "%<%Y-%m-%d>.org"
+                     "#+title: %<%Y-%m-%d %a>\n#+created: %U\n#+last_modified: %U\n"))))))))
+
+(ert-deftest p3-config-org-roam-preserves-bindings ()
+  (should
+   (equal
+    (p3-config-org-roam-test--keyword-values :bind)
+    '((("C-c n l" . org-roam-buffer-toggle)
+       ("C-c n f" . org-roam-node-find)
+       ("C-c n g" . org-roam-graph)
+       ("C-c n i" . org-roam-node-insert)
+       ("C-c n c" . org-roam-capture)
+       ("C-c n n" . org-roam-node-insert-immediate-with-tag)
+       ("C-c n s" . org-roam-rg-search)
+       ("C-c n d" . org-roam-dailies-goto-today)
+       ("C-c n t" . org-roam-dailies-capture-today)
+       ("C-c n C-t" . org-roam-tag-add)
+       ("C-c n a" . p3/org-roam-get-agenda))))))
+
+(ert-deftest p3-config-org-roam-preserves-display-and-autosync-config ()
+  (should
+   (equal
+    (p3-config-org-roam-test--keyword-values :config)
+    '((setq org-roam-node-display-template
+            (concat "${title:*} "
+                    (propertize "${tags:10}" 'face 'org-tag)))
+      (org-roam-db-autosync-mode)))))
+
+(provide 'p3-config-org-roam-test)
+
+;;; p3-config-org-roam-test.el ends here

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -111,6 +111,7 @@
       '(use-package p3-org-export
          :ensure nil
          :demand t
+         :functions p3-org-export-setup
          :config
          (p3-org-export-setup))))
     (should-not (member '(p3/config-load-module 'p3-org-export) forms))

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -90,7 +90,7 @@
        :init
        (org-babel-do-load-languages
         'org-babel-load-languages
-        '((emacs-lisp . t)
+        '((emacs-lisp .t)
           (R . t)
           (C . t)
           (python . t)

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -104,15 +104,22 @@
              org-ellipsis " ↴")))))
 
 (ert-deftest p3-config-org-preserves-export-pdf-and-agenda-wiring ()
-  (let ((forms (p3-config-org-test--forms "lisp/p3-config-org.el")))
+  (let* ((forms (p3-config-org-test--forms "lisp/p3-config-org.el"))
+         (require-position
+          (seq-position forms '(require 'p3-org-export) #'equal))
+         (package-form (p3-config-org-test--use-package-form 'p3-org-export))
+         (package-position (seq-position forms package-form #'equal)))
+    (should (integerp require-position))
+    (should (integerp package-position))
+    (should (< require-position package-position))
     (should
      (equal
-      (p3-config-org-test--use-package-form 'p3-org-export)
+      package-form
       '(use-package p3-org-export
          :ensure nil
          :demand t
          :config
-         (funcall 'p3-org-export-setup))))
+         (p3-org-export-setup))))
     (should-not (member '(p3/config-load-module 'p3-org-export) forms))
     (should
      (member

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -111,9 +111,8 @@
       '(use-package p3-org-export
          :ensure nil
          :demand t
-         :functions p3-org-export-setup
          :config
-         (p3-org-export-setup))))
+         (funcall 'p3-org-export-setup))))
     (should-not (member '(p3/config-load-module 'p3-org-export) forms))
     (should
      (member

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -105,13 +105,14 @@
 
 (ert-deftest p3-config-org-preserves-export-pdf-and-agenda-wiring ()
   (let* ((forms (p3-config-org-test--forms "lisp/p3-config-org.el"))
-         (require-position
-          (seq-position forms '(require 'p3-org-export) #'equal))
          (package-form (p3-config-org-test--use-package-form 'p3-org-export))
          (package-position (seq-position forms package-form #'equal)))
-    (should (integerp require-position))
+    (should
+     (member
+      '(declare-function p3-org-export-setup "p3-org-export" nil)
+      forms))
+    (should-not (member '(require 'p3-org-export) forms))
     (should (integerp package-position))
-    (should (< require-position package-position))
     (should
      (equal
       package-form

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -1,0 +1,132 @@
+;;; p3-config-org-test.el --- Org configuration boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-org-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-org-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-org-test--root))
+
+(defun p3-config-org-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-org-test--path relative))
+    (buffer-string)))
+
+(defun p3-config-org-test--forms (relative)
+  "Read all top-level Lisp forms from RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-org-test--path relative))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(defun p3-config-org-test--use-package-form (package)
+  "Return the `use-package' form for PACKAGE."
+  (seq-find
+   (lambda (form)
+     (and (consp form)
+          (eq (car form) 'use-package)
+          (eq (cadr form) package)))
+   (p3-config-org-test--forms "lisp/p3-config-org.el")))
+
+(ert-deftest p3-config-org-loads-core-behavior-before-binding-it ()
+  (let* ((forms (p3-config-org-test--forms "lisp/p3-config-org.el"))
+         (behavior (seq-position
+                    forms '(p3/config-load-module 'p3-org) #'equal))
+         (binding (seq-position
+                   forms
+                   '(define-key org-mode-map
+                      (kbd "C-c C-x C-o")
+                      #'p3/org-sort-todos)
+                   #'equal)))
+    (should (integerp behavior))
+    (should (integerp binding))
+    (should (< behavior binding))))
+
+(ert-deftest p3-config-org-preserves-core-settings-and-timestamp-hook ()
+  (let ((forms (p3-config-org-test--forms "lisp/p3-config-org.el")))
+    (should (member '(setq org-startup-folded 'content) forms))
+    (should
+     (member
+      '(add-hook 'org-mode-hook
+         (lambda nil
+           (setq-local time-stamp-active t
+                       time-stamp-start "#\\+last_modified:[ \t]*"
+                       time-stamp-end "$"
+                       time-stamp-format "\[%Y-%m-%d %3a %02H:%02M\]")
+           (add-hook 'before-save-hook 'time-stamp nil 'local)))
+      forms))
+    (should
+     (member
+      '(setq org-todo-keywords
+             '((sequence "TODO(t)" "WAIT(w)" "|" "DONE(d)"))
+             org-todo-keyword-faces
+             '(("WAIT" . "DarkOrange")))
+      forms))))
+
+(ert-deftest p3-config-org-preserves-org-package-and-babel-wiring ()
+  (should
+   (equal
+    (p3-config-org-test--use-package-form 'org)
+    '(use-package org
+       :defer t
+       :bind (:map org-mode-map
+                   ("C-c s" lambda nil (interactive)
+                    (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
+       :hook ((org-mode . flyspell-mode)
+              (org-mode . visual-line-mode)
+              (org-mode . org-indent-mode))
+       :init
+       (org-babel-do-load-languages
+        'org-babel-load-languages
+        '((emacs-lisp . t)
+          (R . t)
+          (C . t)
+          (python . t)
+          (latex . t)
+          (shell . t)))
+       :config
+       (setq org-confirm-babel-evaluate t
+             org-src-fontify-natively t
+             org-src-tab-acts-natively t
+             org-hide-emphasis-markers t
+             org-ellipsis " ↴")))))
+
+(ert-deftest p3-config-org-preserves-export-pdf-and-agenda-wiring ()
+  (let ((forms (p3-config-org-test--forms "lisp/p3-config-org.el")))
+    (should
+     (equal
+      (p3-config-org-test--use-package-form 'p3-org-export)
+      '(use-package p3-org-export
+         :ensure nil
+         :demand t
+         :config
+         (p3-org-export-setup))))
+    (should-not (member '(p3/config-load-module 'p3-org-export) forms))
+    (should
+     (member
+      '(when (eq system-type 'gnu/linux)
+         (add-to-list 'org-file-apps '("pdf" . "evince %s")))
+      forms))
+    (should
+     (equal
+      (p3-config-org-test--use-package-form 'org-agenda)
+      '(use-package org-agenda
+         :ensure nil
+         :config
+         (setq org-agenda-sorting-strategy '(priority-down)))))))
+
+(provide 'p3-config-org-test)
+
+;;; p3-config-org-test.el ends here

--- a/test/p3-config-python-test.el
+++ b/test/p3-config-python-test.el
@@ -222,6 +222,8 @@
 
 (ert-deftest p3-config-python-config-org-delegates-python-wiring ()
   (let* ((contents (p3-config-python-test--contents "config.org"))
+         (org-config
+          (p3-config-python-test--contents "lisp/p3-config-org.el"))
          (owner "(p3/config-load-module 'p3-config-python)"))
     (should (= 1 (p3-config-python-test--count-occurrences owner contents)))
     (dolist (forbidden '("(use-package p3-python"
@@ -230,7 +232,7 @@
                           "(add-hook 'python-ts-mode-hook"
                           "flycheck-python-flake8-executable"))
       (should-not (string-match-p (regexp-quote forbidden) contents)))
-    (should (string-match-p (regexp-quote "(python . t)") contents))))
+    (should (string-match-p (regexp-quote "(python . t)") org-config))))
 
 (provide 'p3-config-python-test)
 

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -77,9 +77,14 @@
       (delete-directory directory t))))
 
 (ert-deftest p3-config-org-owns-org-export-integration ()
-  (let ((contents (p3-config-test--contents "config.org")))
-    (should (string-match-p "(use-package p3-org-export" contents))
-    (should-not (string-match-p "(defun p3/org-export-to-office" contents))))
+  (let ((contents (p3-config-test--contents "config.org"))
+        (org-config (p3-config-test--contents "lisp/p3-config-org.el")))
+    (should
+     (string-match-p
+      (regexp-quote "(p3/config-load-module 'p3-config-org)") contents))
+    (should (string-match-p "(use-package p3-org-export" org-config))
+    (should-not (string-match-p "(defun p3/org-export-to-office" contents))
+    (should-not (string-match-p "(defun p3/org-export-to-office" org-config))))
 
 (ert-deftest p3-config-org-delegates-custom-subsystems-to-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
@@ -89,7 +94,8 @@
     (dolist (package '("vterm" "gptel"))
       (should (string-match-p (regexp-quote (format "(use-package %s" package))
                               contents)))
-    (dolist (module '(p3-config-ess p3-config-python))
+    (dolist (module '(p3-config-ess p3-config-org p3-config-org-roam
+                      p3-config-org-present p3-config-python))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -150,6 +156,24 @@
     (should (< terminal shell))
     (should (< shell shell-binding))))
 
+(ert-deftest p3-config-org-subsystem-order-is-explicit ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (org (p3-config-test--position
+               "(p3/config-load-module 'p3-config-org)" contents))
+         (roam (p3-config-test--position
+                "(p3/config-load-module 'p3-config-org-roam)" contents))
+         (poly-r (p3-config-test--position "(use-package poly-R" contents))
+         (present (p3-config-test--position
+                   "(p3/config-load-module 'p3-config-org-present)" contents))
+         (projectile (p3-config-test--position "(use-package projectile" contents))
+         (python (p3-config-test--position
+                  "(p3/config-load-module 'p3-config-python)" contents)))
+    (should (< org roam))
+    (should (< roam poly-r))
+    (should (< poly-r present))
+    (should (< present projectile))
+    (should (< projectile python))))
+
 (ert-deftest p3-config-python-preserves-subsystem-timing ()
   (let* ((contents (p3-config-test--contents "config.org"))
          (flycheck (p3-config-test--position "(use-package flycheck" contents))
@@ -163,11 +187,15 @@
     (should (< python rainbow))
     (should (< rainbow shell))))
 
-(ert-deftest p3-config-org-source-loads-seven-config-modules ()
+(ert-deftest p3-config-org-source-loads-ten-config-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
+    (should (= 10
+               (p3-config-test--count-occurrences
+                "(p3/config-load-module 'p3-config-" contents)))
     (dolist (module '(p3-config-base p3-config-editing p3-config-completion
-                      p3-config-ess p3-config-python p3-config-workspace
-                      p3-config-git))
+                      p3-config-ess p3-config-org p3-config-org-roam
+                      p3-config-org-present p3-config-python
+                      p3-config-workspace p3-config-git))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -211,7 +239,27 @@
                "(use-package python"
                "(use-package eglot"
                "(add-hook 'python-ts-mode-hook"
-               "flycheck-python-flake8-executable"))
+               "flycheck-python-flake8-executable"
+               "(defun p3/org-sort-todos"
+               "(defun org-set-line-checkbox"
+               "(use-package p3-org-export"
+               "(use-package org-agenda"
+               "(defun org-roam-generate-tagged-header"
+               "(defun org-roam-node-insert-immediate-with-tag"
+               "(defun org-roam-rg-search"
+               "(defun p3/org-roam-filter-by-tag"
+               "(defun p3/org-roam-list-notes"
+               "(defun p3/org-roam-list-notes-by-tag"
+               "(defun p3/org-roam-get-agenda"
+               "(use-package org-roam"
+               "(defvar-local p3/org-present--state"
+               "(defun p3/org-present-start"
+               "(defun p3/org-present-toggle-fullscreen"
+               "(defun p3/org-present-hook"
+               "(defun p3/org-present-quit-hook"
+               "(defun p3/org-present-prev"
+               "(defun p3/org-present-next"
+               "(use-package org-present"))
       (should-not (string-match-p (regexp-quote implementation) contents)))
     (dolist (package '(dashboard which-key vertico company undo-tree super-save
                        multiple-cursors magit git-gutter-fringe+ transpose-frame
@@ -219,6 +267,14 @@
       (should-not
        (string-match-p (regexp-quote (format "(use-package %s" package))
                        contents)))))
+
+(ert-deftest p3-config-org-leaves-adjacent-specialized-subsystems-in-place ()
+  (let ((contents (p3-config-test--contents "config.org")))
+    (dolist (needle '("(use-package citar"
+                      "(use-package citar-org-roam"
+                      "(setq org-latex-pdf-process"
+                      "(use-package poly-R"))
+      (should (string-match-p (regexp-quote needle) contents)))))
 
 (ert-deftest p3-config-ess-orchestration-has-one-owner ()
   (let* ((contents (p3-config-test--contents "config.org"))
@@ -234,6 +290,7 @@
 
 (ert-deftest p3-config-python-orchestration-has-one-owner ()
   (let* ((contents (p3-config-test--contents "config.org"))
+         (org-config (p3-config-test--contents "lisp/p3-config-org.el"))
          (owner "(p3/config-load-module 'p3-config-python)"))
     (should (= 1 (p3-config-test--count-occurrences owner contents)))
     (dolist (forbidden '("(use-package p3-python"
@@ -242,19 +299,32 @@
                           "(add-hook 'python-ts-mode-hook"
                           "flycheck-python-flake8-executable"))
       (should-not (string-match-p (regexp-quote forbidden) contents)))
-    (should (string-match-p (regexp-quote "(python . t)") contents))))
+    (should (string-match-p (regexp-quote "(python . t)") org-config))))
 
 (ert-deftest p3-config-behavior-library-owner-pattern-is-explicit ()
   (let ((base (p3-config-test--contents "lisp/p3-config-base.el"))
         (git (p3-config-test--contents "lisp/p3-config-git.el"))
+        (org (p3-config-test--contents "lisp/p3-config-org.el"))
+        (roam (p3-config-test--contents "lisp/p3-config-org-roam.el"))
+        (present (p3-config-test--contents "lisp/p3-config-org-present.el"))
         (commands (p3-config-test--contents "lisp/p3-commands.el"))
-        (git-behavior (p3-config-test--contents "lisp/p3-git.el")))
+        (git-behavior (p3-config-test--contents "lisp/p3-git.el"))
+        (org-behavior (p3-config-test--contents "lisp/p3-org.el"))
+        (roam-behavior (p3-config-test--contents "lisp/p3-org-roam.el"))
+        (present-behavior (p3-config-test--contents "lisp/p3-org-present.el")))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-commands)") base))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-git)") git))
-    (should-not (string-match-p "p3-config-" commands))
-    (should-not (string-match-p "p3-config-" git-behavior))))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-org)") org))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-org-roam)") roam))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-org-present)") present))
+    (dolist (behavior (list commands git-behavior org-behavior
+                            roam-behavior present-behavior))
+      (should-not (string-match-p "p3-config-" behavior)))))
 
 (ert-deftest p3-config-workspace-keeps-only-narrow-ess-display-policy ()
   (let ((contents (p3-config-test--contents "lisp/p3-config-workspace.el")))

--- a/test/p3-org-present-test.el
+++ b/test/p3-org-present-test.el
@@ -1,0 +1,142 @@
+;;; p3-org-present-test.el --- Tests for p3-org-present -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'ert)
+
+(defconst p3-org-present-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-org-present-test--root))
+(require 'p3-org-present)
+
+(defvar display-line-numbers-mode)
+(defvar hide-mode-line-mode)
+(defvar org-inline-image-overlays)
+(defvar visual-fill-column-center-text)
+(defvar visual-fill-column-mode)
+(defvar visual-fill-column-width)
+
+(ert-deftest p3-org-present-start-rejects-non-org-buffer ()
+  (with-temp-buffer
+    (fundamental-mode)
+    (should-error (p3/org-present-start) :type 'user-error)))
+
+(ert-deftest p3-org-present-start-delegates-in-org-buffer ()
+  (let (called)
+    (cl-letf (((symbol-function 'derived-mode-p)
+               (lambda (&rest _) t))
+              ((symbol-function 'org-present)
+               (lambda () (setq called t))))
+      (p3/org-present-start)
+      (should called))))
+
+(ert-deftest p3-org-present-fullscreen-toggles-fullboth ()
+  (let (fullscreen)
+    (cl-letf (((symbol-function 'frame-parameter)
+               (lambda (_frame parameter)
+                 (and (eq parameter 'fullscreen) fullscreen)))
+              ((symbol-function 'set-frame-parameter)
+               (lambda (_frame parameter value)
+                 (when (eq parameter 'fullscreen)
+                   (setq fullscreen value)))))
+      (p3/org-present-toggle-fullscreen)
+      (should (eq fullscreen 'fullboth))
+      (p3/org-present-toggle-fullscreen)
+      (should-not fullscreen))))
+
+(ert-deftest p3-org-present-navigation-delegates ()
+  (let ((next 0)
+        (prev 0))
+    (cl-letf (((symbol-function 'org-present-next)
+               (lambda () (setq next (1+ next))))
+              ((symbol-function 'org-present-prev)
+               (lambda () (setq prev (1+ prev)))))
+      (p3/org-present-next)
+      (p3/org-present-prev)
+      (should (= next 1))
+      (should (= prev 1)))))
+
+(ert-deftest p3-org-present-enter-and-quit-restore-buffer-state ()
+  (with-temp-buffer
+    (setq-local header-line-format "old header"
+                display-line-numbers-mode t
+                org-inline-image-overlays nil
+                visual-fill-column-mode nil
+                visual-fill-column-width 72
+                visual-fill-column-center-text nil
+                hide-mode-line-mode t)
+    (let (big-called
+          small-called
+          images-displayed
+          images-removed
+          remap-adds
+          remap-removes)
+      (cl-letf (((symbol-function 'display-line-numbers-mode)
+                 (lambda (arg)
+                   (setq-local display-line-numbers-mode (> arg 0))))
+                ((symbol-function 'org-present-big)
+                 (lambda () (setq big-called t)))
+                ((symbol-function 'org-present-small)
+                 (lambda () (setq small-called t)))
+                ((symbol-function 'org-display-inline-images)
+                 (lambda (&rest _)
+                   (setq images-displayed t
+                         org-inline-image-overlays '(shown))))
+                ((symbol-function 'org-remove-inline-images)
+                 (lambda ()
+                   (setq images-removed t
+                         org-inline-image-overlays nil)))
+                ((symbol-function 'visual-fill-column-mode)
+                 (lambda (arg)
+                   (setq-local visual-fill-column-mode (> arg 0))))
+                ((symbol-function 'hide-mode-line-mode)
+                 (lambda (arg)
+                   (setq-local hide-mode-line-mode (> arg 0))))
+                ((symbol-function 'face-remap-add-relative)
+                 (lambda (face &rest properties)
+                   (let ((cookie (list face properties)))
+                     (push cookie remap-adds)
+                     cookie)))
+                ((symbol-function 'face-remap-remove-relative)
+                 (lambda (cookie)
+                   (push cookie remap-removes))))
+        (p3/org-present-hook)
+        (should big-called)
+        (should images-displayed)
+        (should (equal header-line-format " "))
+        (should-not display-line-numbers-mode)
+        (should visual-fill-column-mode)
+        (should (= visual-fill-column-width 90))
+        (should visual-fill-column-center-text)
+        (should hide-mode-line-mode)
+        (should (= (length remap-adds) 3))
+        (should (member '(org-level-1 (:height 1.5)) remap-adds))
+        (should (member '(org-level-2 (:height 1.2)) remap-adds))
+        (should (member '(org-level-3 (:height 1.1)) remap-adds))
+        (should (equal (plist-get p3/org-present--state :header-line)
+                       "old header"))
+        (should (plist-get p3/org-present--state :line-numbers))
+        (should-not (plist-get p3/org-present--state :inline-images))
+        (should-not (plist-get p3/org-present--state :visual-fill))
+        (should (= (plist-get p3/org-present--state :visual-fill-width) 72))
+        (should-not (plist-get p3/org-present--state :visual-fill-center))
+        (should (plist-get p3/org-present--state :hide-mode-line))
+
+        (p3/org-present-quit-hook)
+        (should small-called)
+        (should images-removed)
+        (should (equal header-line-format "old header"))
+        (should display-line-numbers-mode)
+        (should-not visual-fill-column-mode)
+        (should (= visual-fill-column-width 72))
+        (should-not visual-fill-column-center-text)
+        (should hide-mode-line-mode)
+        (should (= (length remap-removes) 3))
+        (should-not p3/org-present--state)))))
+
+(provide 'p3-org-present-test)
+
+;;; p3-org-present-test.el ends here

--- a/test/p3-org-roam-test.el
+++ b/test/p3-org-roam-test.el
@@ -14,6 +14,15 @@
 (add-to-list 'load-path (expand-file-name "lisp" p3-org-roam-test--root))
 (require 'p3-org-roam)
 
+(ert-deftest p3-org-roam-preserves-tangled-config-dynamic-binding ()
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name "lisp/p3-org-roam.el" p3-org-roam-test--root))
+    (goto-char (point-min))
+    (should-not
+     (re-search-forward "lexical-binding:[ \t]*t"
+                        (line-end-position) t))))
+
 (ert-deftest p3-org-roam-tagged-header-preserves-blank-output ()
   (cl-letf (((symbol-function 'read-string)
              (lambda (&rest _) "")))
@@ -43,11 +52,7 @@
       (should (equal (p3/org-roam-list-notes)
                      '("a.org" "b.org" "c.org")))
       (should (equal (p3/org-roam-list-notes-by-tag "work")
-                     '("a.org" "c.org")))
-      (should (funcall (p3/org-roam-filter-by-tag "home")
-                       (cadr nodes)))
-      (should-not (funcall (p3/org-roam-filter-by-tag "home")
-                           (car nodes))))))
+                     '("a.org" "c.org"))))))
 
 (ert-deftest p3-org-roam-agenda-uses-all-notes-for-blank-tag ()
   (let (agenda-called

--- a/test/p3-org-roam-test.el
+++ b/test/p3-org-roam-test.el
@@ -1,0 +1,111 @@
+;;; p3-org-roam-test.el --- Tests for p3-org-roam -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'ert)
+
+(defconst p3-org-roam-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-org-roam-test--root))
+(require 'p3-org-roam)
+
+(ert-deftest p3-org-roam-tagged-header-preserves-blank-output ()
+  (cl-letf (((symbol-function 'read-string)
+             (lambda (&rest _) "")))
+    (should
+     (equal
+      (org-roam-generate-tagged-header)
+      "#+title: ${title}\n#+category:${title}\n#+created: %U\n#+last_modified: %U\n"))))
+
+(ert-deftest p3-org-roam-tagged-header-preserves-trailing-hash ()
+  (cl-letf (((symbol-function 'read-string)
+             (lambda (&rest _) "work")))
+    (should
+     (equal
+      (org-roam-generate-tagged-header)
+      "#+title: ${title}\n#+category:${title}\n#+filetags: work\n#+created: %U\n#+last_modified: %U\n#"))))
+
+(ert-deftest p3-org-roam-listing-and-tag-filtering-preserve-current-behavior ()
+  (let ((nodes '((:file "a.org" :tags ("work" "x"))
+                 (:file "b.org" :tags ("home"))
+                 (:file "c.org" :tags ("work")))))
+    (cl-letf (((symbol-function 'org-roam-node-list)
+               (lambda () nodes))
+              ((symbol-function 'org-roam-node-file)
+               (lambda (node) (plist-get node :file)))
+              ((symbol-function 'org-roam-node-tags)
+               (lambda (node) (plist-get node :tags))))
+      (should (equal (p3/org-roam-list-notes)
+                     '("a.org" "b.org" "c.org")))
+      (should (equal (p3/org-roam-list-notes-by-tag "work")
+                     '("a.org" "c.org")))
+      (should (funcall (p3/org-roam-filter-by-tag "home")
+                       (cadr nodes)))
+      (should-not (funcall (p3/org-roam-filter-by-tag "home")
+                           (car nodes))))))
+
+(ert-deftest p3-org-roam-agenda-uses-all-notes-for-blank-tag ()
+  (let (agenda-called
+        org-agenda-files)
+    (cl-letf (((symbol-function 'read-string)
+               (lambda (&rest _) ""))
+              ((symbol-function 'p3/org-roam-list-notes)
+               (lambda () '("a.org" "b.org")))
+              ((symbol-function 'org-agenda)
+               (lambda (&rest _)
+                 (setq agenda-called t))))
+      (p3/org-roam-get-agenda)
+      (should agenda-called)
+      (should (equal org-agenda-files '("a.org" "b.org"))))))
+
+(ert-deftest p3-org-roam-agenda-filters-notes-for-nonblank-tag ()
+  (let (agenda-called
+        seen-tag
+        org-agenda-files)
+    (cl-letf (((symbol-function 'read-string)
+               (lambda (&rest _) "work"))
+              ((symbol-function 'p3/org-roam-list-notes-by-tag)
+               (lambda (tag)
+                 (setq seen-tag tag)
+                 '("work.org")))
+              ((symbol-function 'org-agenda)
+               (lambda (&rest _)
+                 (setq agenda-called t))))
+      (p3/org-roam-get-agenda)
+      (should agenda-called)
+      (should (equal seen-tag "work"))
+      (should (equal org-agenda-files '("work.org"))))))
+
+(ert-deftest p3-org-roam-search-delegates-to-consult-ripgrep ()
+  (let ((org-roam-directory "/tmp/roam")
+        seen)
+    (cl-letf (((symbol-function 'consult-ripgrep)
+               (lambda (directory &optional initial)
+                 (setq seen (list directory initial)))))
+      (org-roam-rg-search)
+      (should (equal seen '("/tmp/roam" nil))))))
+
+(ert-deftest p3-org-roam-immediate-insert-preserves-tagged-template ()
+  (let (seen-args
+        seen-templates)
+    (cl-letf (((symbol-function 'org-roam-node-insert)
+               (lambda (&rest args)
+                 (setq seen-args args
+                       seen-templates org-roam-capture-templates))))
+      (org-roam-node-insert-immediate-with-tag 4 'extra)
+      (should (equal seen-args '(4 extra)))
+      (should (= (length seen-templates) 1))
+      (let ((template (car seen-templates)))
+        (should (equal (seq-take template 4)
+                       '("t" "tagged" plain "%?")))
+        (should (equal (plist-get (nthcdr 4 template) :immediate-finish)
+                       t))
+        (should (equal (plist-get (nthcdr 4 template) :unnarrowed)
+                       t))))))
+
+(provide 'p3-org-roam-test)
+
+;;; p3-org-roam-test.el ends here

--- a/test/p3-org-roam-test.el
+++ b/test/p3-org-roam-test.el
@@ -3,6 +3,8 @@
 (require 'cl-lib)
 (require 'ert)
 
+(defvar org-roam-directory nil)
+
 (defconst p3-org-roam-test--root
   (file-name-directory
    (directory-file-name

--- a/test/p3-org-test.el
+++ b/test/p3-org-test.el
@@ -1,0 +1,47 @@
+;;; p3-org-test.el --- Tests for p3-org -*- lexical-binding: t; -*-
+
+(require 'cl-lib)
+(require 'ert)
+
+(defconst p3-org-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(add-to-list 'load-path (expand-file-name "lisp" p3-org-test--root))
+(require 'p3-org)
+
+(ert-deftest p3-org-sort-todos-preserves-current-sort-call ()
+  (let (seen)
+    (cl-letf (((symbol-function 'org-sort-entries)
+               (lambda (&rest args)
+                 (setq seen args))))
+      (p3/org-sort-todos)
+      (should (equal seen (list nil ?o))))))
+
+(ert-deftest p3-org-set-line-checkbox-prefixes-current-line ()
+  (with-temp-buffer
+    (insert "alpha\nbeta\n")
+    (goto-char (point-min))
+    (org-set-line-checkbox 1)
+    (should (equal (buffer-string) "- [ ] alpha\nbeta\n"))
+    (should (looking-at "beta"))))
+
+(ert-deftest p3-org-set-line-checkbox-prefixes-active-region-lines ()
+  (with-temp-buffer
+    (insert "alpha\nbeta\ngamma\n")
+    (goto-char (point-min))
+    (set-mark (save-excursion
+                (forward-line 2)
+                (point)))
+    (setq transient-mark-mode t
+          mark-active t)
+    (org-set-line-checkbox 1)
+    (should (equal (buffer-string)
+                   "- [ ] alpha\n- [ ] beta\ngamma\n"))
+    (should (looking-at "gamma"))))
+
+(provide 'p3-org-test)
+
+;;; p3-org-test.el ends here


### PR DESCRIPTION
## Summary

- split Org core, Org-roam, and Org presentation configuration into three focused `p3-config-*` owners
- move reusable Org, Roam, and presentation behavior into three `p3-*` libraries
- preserve the existing Pandoc exporter implementation and its `use-package` activation/reload behavior
- keep Org -> Org-roam -> Poly-R -> Presentation ordering explicit in `config.org`
- add focused behavior/config-boundary tests and runtime-load smoke coverage

## Behavioral boundaries

- no Org/Babel/TODO/Agenda workflow redesign
- no Roam path, database, capture-template, or keybinding changes
- the existing trailing `#` in nonblank tagged Roam headers is intentionally preserved
- presentation state capture/restoration semantics are preserved
- `face-remap` now travels with the extracted presentation behavior that directly calls it, at the same effective startup point
- no Citar/BibTeX/RefTeX, LaTeX, Poly-R, Projectile, completion, or window-management changes
- `p3-org-export.el` and `test/p3-org-export-test.el` are byte-for-byte unchanged

## Verification

Ubuntu compiles all six new Lisp files with warnings as errors and optional package installation suppressed, smoke-loads all three new configuration owners (stubbing optional Org-roam/presentation package surfaces), and runs the full ERT suite. Windows runs the existing platform gate plus source-level tests for all three new configuration boundaries.

Design: `docs/superpowers/specs/2026-09-04-org-config-boundaries-design.md`
Plan: `docs/superpowers/plans/2026-09-05-org-config-boundaries.md`

Do not merge without explicit approval.