### PR TITLE
Extract terminal configuration into focused module

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -46,6 +46,7 @@ jobs:
             lisp/p3-config-python.el \
             lisp/p3-python.el \
             lisp/p3-terminal.el \
+            lisp/p3-config-terminal.el \
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
             lisp/p3-gptel.el \
@@ -66,6 +67,18 @@ jobs:
             -l lisp/p3-config-loader.el \
             -l lisp/p3-config-python.el \
             --eval '(unless (and (featurep (quote p3-config-python)) (featurep (quote p3-python)) (equal flycheck-python-flake8-executable "flake8")) (kill-emacs 1))'
+
+      - name: Smoke-load Terminal configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            -l lisp/p3-platform.el \
+            -l lisp/p3-config-loader.el \
+            -l lisp/p3-config-terminal.el \
+            --eval '(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (keymapp p3/vterm-command-map) (string-match-p "vterm-bashrc" vterm-shell)) (kill-emacs 1))'
 
       - name: Smoke-load Org configuration boundary
         run: |
@@ -120,6 +133,7 @@ jobs:
             -l test/p3-config-python-test.el \
             -l test/p3-python-test.el \
             -l test/p3-terminal-test.el \
+            -l test/p3-config-terminal-test.el \
             -l test/p3-ess-test.el \
             -l test/p3-gptel-test.el \
             -l test/p3-r-tools-test.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -33,6 +33,7 @@ on:
       - "test/p3-config-org-roam-test.el"
       - "test/p3-config-org-present-test.el"
       - "test/p3-config-terminal-test.el"
+      - "test/p3-config-terminal-windows-test.el"
       - "test/p3-ess-test.el"
       - "test/p3-r-tools-test.el"
       - "test/p3-commands-test.el"
@@ -85,12 +86,8 @@ jobs:
         shell: powershell
         run: >-
           emacs -Q --batch -L lisp
-          --eval '(setq user-emacs-directory (file-name-as-directory default-directory))'
-          -l lisp/p3-platform.el
-          --eval '(setq linuxy-environment-path (file-name-as-directory (expand-file-name "usr/bin" (getenv "P3_TEST_MSYS2_ROOT"))))'
-          -l lisp/p3-config-loader.el
-          -l lisp/p3-config-terminal.el
-          --eval '(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (eq (key-binding (kbd "C-x C-u")) (quote shell)) (string-suffix-p "bash.exe" shell-file-name t)) (kill-emacs 1))'
+          -l test/p3-config-terminal-windows-test.el
+          -f ert-run-tests-batch-and-exit
 
       - name: Run Windows platform and project tests
         shell: powershell

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -19,6 +19,7 @@ on:
       - "lisp/p3-config-org.el"
       - "lisp/p3-config-org-roam.el"
       - "lisp/p3-config-org-present.el"
+      - "lisp/p3-config-terminal.el"
       - "lisp/p3-ess.el"
       - "lisp/p3-r-tools.el"
       - "test/p3-platform-test.el"
@@ -31,6 +32,7 @@ on:
       - "test/p3-config-org-test.el"
       - "test/p3-config-org-roam-test.el"
       - "test/p3-config-org-present-test.el"
+      - "test/p3-config-terminal-test.el"
       - "test/p3-ess-test.el"
       - "test/p3-r-tools-test.el"
       - "test/p3-commands-test.el"
@@ -97,6 +99,7 @@ jobs:
           -l test/p3-config-org-test.el
           -l test/p3-config-org-roam-test.el
           -l test/p3-config-org-present-test.el
+          -l test/p3-config-terminal-test.el
           -l test/p3-commands-test.el
           -l test/p3-git-test.el
           -f ert-run-tests-batch-and-exit

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -79,6 +79,18 @@ jobs:
           lisp/p3-config-loader.el
           lisp/p3-commands.el
           lisp/p3-git.el
+          lisp/p3-config-terminal.el
+
+      - name: Smoke-load Windows terminal configuration boundary
+        shell: powershell
+        run: >-
+          emacs -Q --batch -L lisp
+          --eval "(setq user-emacs-directory (file-name-as-directory default-directory))"
+          -l lisp/p3-platform.el
+          --eval "(setq linuxy-environment-path (file-name-as-directory (expand-file-name \"usr/bin\" (getenv \"P3_TEST_MSYS2_ROOT\"))))"
+          -l lisp/p3-config-loader.el
+          -l lisp/p3-config-terminal.el
+          --eval "(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (eq (key-binding (kbd \"C-x C-u\")) (quote shell)) (string-suffix-p \"bash.exe\" shell-file-name t)) (kill-emacs 1))"
 
       - name: Run Windows platform and project tests
         shell: powershell

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -72,7 +72,7 @@ jobs:
         shell: powershell
         run: >-
           emacs -Q --batch -L lisp
-          --eval "(setq byte-compile-error-on-warn t)"
+          --eval '(setq byte-compile-error-on-warn t)'
           -f batch-byte-compile
           lisp/p3-platform.el
           lisp/p3-project.el
@@ -85,12 +85,12 @@ jobs:
         shell: powershell
         run: >-
           emacs -Q --batch -L lisp
-          --eval "(setq user-emacs-directory (file-name-as-directory default-directory))"
+          --eval '(setq user-emacs-directory (file-name-as-directory default-directory))'
           -l lisp/p3-platform.el
-          --eval "(setq linuxy-environment-path (file-name-as-directory (expand-file-name \"usr/bin\" (getenv \"P3_TEST_MSYS2_ROOT\"))))"
+          --eval '(setq linuxy-environment-path (file-name-as-directory (expand-file-name "usr/bin" (getenv "P3_TEST_MSYS2_ROOT"))))'
           -l lisp/p3-config-loader.el
           -l lisp/p3-config-terminal.el
-          --eval "(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (eq (key-binding (kbd \"C-x C-u\")) (quote shell)) (string-suffix-p \"bash.exe\" shell-file-name t)) (kill-emacs 1))"
+          --eval '(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (eq (key-binding (kbd "C-x C-u")) (quote shell)) (string-suffix-p "bash.exe" shell-file-name t)) (kill-emacs 1))'
 
       - name: Run Windows platform and project tests
         shell: powershell

--- a/config.org
+++ b/config.org
@@ -425,50 +425,12 @@ Reusable interpreter, language-server, and REPL behavior remains in
 
 ** Shell
 
-Windows shell implementation lives in =p3-platform=, but setup remains here to
-preserve its original startup timing. Project-aware vterm behavior remains in
-=lisp/p3-terminal.el=.
+Terminal package wiring and platform-specific shell activation live in
+=lisp/p3-config-terminal.el=. Project-aware terminal behavior remains in
+=lisp/p3-terminal.el=, while Windows shell mechanics remain in =p3-platform=.
 
 #+BEGIN_SRC emacs-lisp
-  (use-package p3-terminal
-    :ensure nil
-    :demand t)
-
-  (p3/windows-configure-shell)
-
-  (when (eq system-type 'windows-nt)
-    (global-set-key (kbd "C-x C-u") #'shell))
-
-  (when (eq system-type 'gnu/linux)
-    (keymap-global-set "C-c T" p3/vterm-command-map)
-
-    (use-package vterm
-      :commands (vterm vterm-other-window)
-      :hook (vterm-mode . p3/vterm-mode-setup)
-      :bind (("C-x C-u" . p3/vterm)
-             :map vterm-mode-map
-             ("C-y" . vterm-yank)
-             ("M-y" . vterm-yank-pop)
-             ("C-S-v" . vterm-yank)
-             ("C-S-c" . p3/vterm-enter-copy-mode)
-             :map vterm-copy-mode-map
-             ("C-S-c" . vterm-copy-mode-done))
-      :custom
-      (vterm-max-scrollback 100000)
-      (vterm-kill-buffer-on-exit t)
-      (vterm-always-compile-module t)
-      :init
-      (setq vterm-environment
-            (cons (format "P3_BLESH_FILE=%s" (p3/blesh-file))
-                  (seq-remove
-                   (lambda (entry) (string-prefix-p "P3_BLESH_FILE=" entry))
-                   (and (boundp 'vterm-environment) vterm-environment)))
-            vterm-shell
-            (format "%s --noprofile --rcfile %s -i"
-                    (shell-quote-argument "/usr/bin/bash")
-                    (shell-quote-argument
-                     (expand-file-name "vterm-bashrc"
-                                       user-emacs-directory))))))
+  (p3/config-load-module 'p3-config-terminal)
 #+END_SRC
 
 ** Spelling

--- a/lisp/p3-config-terminal.el
+++ b/lisp/p3-config-terminal.el
@@ -1,5 +1,7 @@
 ;;; p3-config-terminal.el --- Terminal configuration -*- lexical-binding: t; -*-
 
+(require 'seq)
+(require 'subr-x)
 (require 'use-package)
 (require 'p3-config-loader)
 

--- a/lisp/p3-config-terminal.el
+++ b/lisp/p3-config-terminal.el
@@ -1,0 +1,61 @@
+;;; p3-config-terminal.el --- Terminal configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(defvar p3/vterm-command-map)
+(defvar vterm-always-compile-module)
+(defvar vterm-copy-mode-map)
+(defvar vterm-environment)
+(defvar vterm-kill-buffer-on-exit)
+(defvar vterm-max-scrollback)
+(defvar vterm-mode-map)
+(defvar vterm-shell)
+
+(declare-function p3/windows-configure-shell "p3-platform" ())
+(declare-function p3/blesh-file "p3-terminal" ())
+(declare-function p3/vterm "p3-terminal" (&optional new-session))
+(declare-function p3/vterm-enter-copy-mode "p3-terminal" ())
+(declare-function p3/vterm-mode-setup "p3-terminal" ())
+
+(p3/config-load-module 'p3-terminal)
+
+(p3/windows-configure-shell)
+
+(when (eq system-type 'windows-nt)
+  (global-set-key (kbd "C-x C-u") #'shell))
+
+(when (eq system-type 'gnu/linux)
+  (keymap-global-set "C-c T" p3/vterm-command-map)
+
+  (use-package vterm
+    :commands (vterm vterm-other-window)
+    :hook (vterm-mode . p3/vterm-mode-setup)
+    :bind (("C-x C-u" . p3/vterm)
+           :map vterm-mode-map
+           ("C-y" . vterm-yank)
+           ("M-y" . vterm-yank-pop)
+           ("C-S-v" . vterm-yank)
+           ("C-S-c" . p3/vterm-enter-copy-mode)
+           :map vterm-copy-mode-map
+           ("C-S-c" . vterm-copy-mode-done))
+    :custom
+    (vterm-max-scrollback 100000)
+    (vterm-kill-buffer-on-exit t)
+    (vterm-always-compile-module t)
+    :init
+    (setq vterm-environment
+          (cons (format "P3_BLESH_FILE=%s" (p3/blesh-file))
+                (seq-remove
+                 (lambda (entry) (string-prefix-p "P3_BLESH_FILE=" entry))
+                 (and (boundp 'vterm-environment) vterm-environment)))
+          vterm-shell
+          (format "%s --noprofile --rcfile %s -i"
+                  (shell-quote-argument "/usr/bin/bash")
+                  (shell-quote-argument
+                   (expand-file-name "vterm-bashrc"
+                                     user-emacs-directory))))))
+
+(provide 'p3-config-terminal)
+
+;;; p3-config-terminal.el ends here

--- a/test/p3-config-terminal-test.el
+++ b/test/p3-config-terminal-test.el
@@ -1,0 +1,105 @@
+;;; p3-config-terminal-test.el --- Terminal config boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-terminal-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-terminal-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-terminal-test--root))
+
+(defun p3-config-terminal-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-terminal-test--path relative))
+    (buffer-string)))
+
+(defun p3-config-terminal-test--forms ()
+  "Read all top-level forms from the terminal config module."
+  (with-temp-buffer
+    (insert-file-contents
+     (p3-config-terminal-test--path "lisp/p3-config-terminal.el"))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(ert-deftest p3-config-terminal-loads-behavior-before-shell-setup ()
+  (let* ((forms (p3-config-terminal-test--forms))
+         (behavior
+          (seq-position forms '(p3/config-load-module 'p3-terminal) #'equal))
+         (shell
+          (seq-position forms '(p3/windows-configure-shell) #'equal)))
+    (should (integerp behavior))
+    (should (integerp shell))
+    (should (< behavior shell))))
+
+(ert-deftest p3-config-terminal-preserves-platform-specific-wiring ()
+  (let ((forms (p3-config-terminal-test--forms)))
+    (should
+     (member
+      '(when (eq system-type 'windows-nt)
+         (global-set-key (kbd "C-x C-u") #'shell))
+      forms))
+    (should
+     (member
+      '(when (eq system-type 'gnu/linux)
+         (keymap-global-set "C-c T" p3/vterm-command-map)
+         (use-package vterm
+           :commands (vterm vterm-other-window)
+           :hook (vterm-mode . p3/vterm-mode-setup)
+           :bind (("C-x C-u" . p3/vterm)
+                  :map vterm-mode-map
+                  ("C-y" . vterm-yank)
+                  ("M-y" . vterm-yank-pop)
+                  ("C-S-v" . vterm-yank)
+                  ("C-S-c" . p3/vterm-enter-copy-mode)
+                  :map vterm-copy-mode-map
+                  ("C-S-c" . vterm-copy-mode-done))
+           :custom
+           (vterm-max-scrollback 100000)
+           (vterm-kill-buffer-on-exit t)
+           (vterm-always-compile-module t)
+           :init
+           (setq vterm-environment
+                 (cons (format "P3_BLESH_FILE=%s" (p3/blesh-file))
+                       (seq-remove
+                        (lambda (entry)
+                          (string-prefix-p "P3_BLESH_FILE=" entry))
+                        (and (boundp 'vterm-environment) vterm-environment)))
+                 vterm-shell
+                 (format "%s --noprofile --rcfile %s -i"
+                         (shell-quote-argument "/usr/bin/bash")
+                         (shell-quote-argument
+                          (expand-file-name "vterm-bashrc"
+                                            user-emacs-directory))))))
+      forms))))
+
+(ert-deftest p3-config-terminal-config-org-delegates-shell-boundary ()
+  (let ((contents (p3-config-terminal-test--contents "config.org")))
+    (should
+     (= 1
+        (let ((start 0)
+              (count 0)
+              (needle (regexp-quote
+                       "(p3/config-load-module 'p3-config-terminal)")))
+          (while (string-match needle contents start)
+            (setq count (1+ count)
+                  start (match-end 0)))
+          count)))
+    (dolist (forbidden '("(use-package p3-terminal"
+                          "(p3/windows-configure-shell)"
+                          "(use-package vterm"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(provide 'p3-config-terminal-test)
+
+;;; p3-config-terminal-test.el ends here

--- a/test/p3-config-terminal-windows-test.el
+++ b/test/p3-config-terminal-windows-test.el
@@ -1,0 +1,45 @@
+;;; p3-config-terminal-windows-test.el --- Native Windows terminal config smoke -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'subr-x)
+
+(defconst p3-config-terminal-windows-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(setq user-emacs-directory
+      (file-name-as-directory p3-config-terminal-windows-test--root))
+(add-to-list 'load-path
+             (expand-file-name "lisp" p3-config-terminal-windows-test--root))
+
+(require 'p3-platform)
+
+(defconst p3-config-terminal-windows-test--msys2-root
+  (or (getenv "P3_TEST_MSYS2_ROOT")
+      (error "P3_TEST_MSYS2_ROOT is not set"))
+  "Git for Windows MSYS2 root supplied by CI.")
+
+(setq linuxy-environment-path
+      (file-name-as-directory
+       (expand-file-name "usr/bin" p3-config-terminal-windows-test--msys2-root)))
+
+(load-file
+ (expand-file-name "lisp/p3-config-loader.el"
+                   p3-config-terminal-windows-test--root))
+(load-file
+ (expand-file-name "lisp/p3-config-terminal.el"
+                   p3-config-terminal-windows-test--root))
+
+(ert-deftest p3-config-terminal-native-windows-composition-loads ()
+  (should (eq system-type 'windows-nt))
+  (should (featurep 'p3-config-terminal))
+  (should (featurep 'p3-terminal))
+  (should (eq (key-binding (kbd "C-x C-u")) #'shell))
+  (should (string-suffix-p "bash.exe" shell-file-name t))
+  (should (memq #'p3/windows-shell-mode-setup shell-mode-hook)))
+
+(provide 'p3-config-terminal-windows-test)
+
+;;; p3-config-terminal-windows-test.el ends here

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -88,14 +88,13 @@
 
 (ert-deftest p3-config-org-delegates-custom-subsystems-to-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
-    (dolist (module '("p3-platform" "p3-core" "p3-terminal" "p3-gptel"))
+    (dolist (module '("p3-platform" "p3-core" "p3-gptel"))
       (should (string-match-p (regexp-quote (format "(use-package %s" module))
                               contents)))
-    (dolist (package '("vterm" "gptel"))
-      (should (string-match-p (regexp-quote (format "(use-package %s" package))
-                              contents)))
+    (should (string-match-p (regexp-quote "(use-package gptel") contents))
     (dolist (module '(p3-config-ess p3-config-org p3-config-org-roam
-                      p3-config-org-present p3-config-python))
+                      p3-config-org-present p3-config-python
+                      p3-config-terminal))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -126,8 +125,8 @@
                "(p3/config-load-module 'p3-config-ess)" contents))
          (r-program (p3-config-test--position
                      "(p3/windows-configure-r-program)" contents))
-         (shell (p3-config-test--position
-                 "(p3/windows-configure-shell)" contents)))
+         (terminal (p3-config-test--position
+                    "(p3/config-load-module 'p3-config-terminal)" contents)))
     (should (< newer auto))
     (should (< auto secrets))
     (should (< secrets rtools))
@@ -136,24 +135,31 @@
     (should (< editing completion))
     (should (< completion ess))
     (should (< ess r-program))
-    (should (< r-program shell))))
+    (should (< r-program terminal))))
 
 (ert-deftest p3-config-platform-setup-preserves-subsystem-timing ()
   (let* ((contents (p3-config-test--contents "config.org"))
+         (terminal-config
+          (p3-config-test--contents "lisp/p3-config-terminal.el"))
          (rtools (p3-config-test--position "(p3/windows-configure-rtools)" contents))
          (ess (p3-config-test--position
                "(p3/config-load-module 'p3-config-ess)" contents))
          (r-program (p3-config-test--position
                      "(p3/windows-configure-r-program)" contents))
-         (terminal (p3-config-test--position "(use-package p3-terminal" contents))
-         (shell (p3-config-test--position "(p3/windows-configure-shell)" contents))
+         (terminal (p3-config-test--position
+                    "(p3/config-load-module 'p3-config-terminal)" contents))
+         (behavior (p3-config-test--position
+                    "(p3/config-load-module 'p3-terminal)" terminal-config))
+         (shell (p3-config-test--position
+                 "(p3/windows-configure-shell)" terminal-config))
          (shell-binding (p3-config-test--position
-                         "(global-set-key (kbd \"C-x C-u\") #'shell)" contents)))
+                         "(global-set-key (kbd \"C-x C-u\") #'shell)"
+                         terminal-config)))
     (should-not (string-match-p "(p3/platform-setup)" contents))
     (should (< rtools ess))
     (should (< ess r-program))
     (should (< r-program terminal))
-    (should (< terminal shell))
+    (should (< behavior shell))
     (should (< shell shell-binding))))
 
 (ert-deftest p3-config-org-subsystem-order-is-explicit ()
@@ -181,21 +187,22 @@
          (python (p3-config-test--position
                   "(p3/config-load-module 'p3-config-python)" contents))
          (rainbow (p3-config-test--position "(use-package rainbow-mode" contents))
-         (shell (p3-config-test--position "(p3/windows-configure-shell)" contents)))
+         (terminal (p3-config-test--position
+                    "(p3/config-load-module 'p3-config-terminal)" contents)))
     (should (< flycheck projectile))
     (should (< projectile python))
     (should (< python rainbow))
-    (should (< rainbow shell))))
+    (should (< rainbow terminal))))
 
-(ert-deftest p3-config-org-source-loads-ten-config-modules ()
+(ert-deftest p3-config-org-source-loads-eleven-config-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
-    (should (= 10
+    (should (= 11
                (p3-config-test--count-occurrences
                 "(p3/config-load-module 'p3-config-" contents)))
     (dolist (module '(p3-config-base p3-config-editing p3-config-completion
                       p3-config-ess p3-config-org p3-config-org-roam
                       p3-config-org-present p3-config-python
-                      p3-config-workspace p3-config-git))
+                      p3-config-terminal p3-config-workspace p3-config-git))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -259,7 +266,10 @@
                "(defun p3/org-present-quit-hook"
                "(defun p3/org-present-prev"
                "(defun p3/org-present-next"
-               "(use-package org-present"))
+               "(use-package org-present"
+               "(use-package p3-terminal"
+               "(p3/windows-configure-shell)"
+               "(use-package vterm"))
       (should-not (string-match-p (regexp-quote implementation) contents)))
     (dolist (package '(dashboard which-key vertico company undo-tree super-save
                        multiple-cursors magit git-gutter-fringe+ transpose-frame
@@ -307,11 +317,13 @@
         (org (p3-config-test--contents "lisp/p3-config-org.el"))
         (roam (p3-config-test--contents "lisp/p3-config-org-roam.el"))
         (present (p3-config-test--contents "lisp/p3-config-org-present.el"))
+        (terminal (p3-config-test--contents "lisp/p3-config-terminal.el"))
         (commands (p3-config-test--contents "lisp/p3-commands.el"))
         (git-behavior (p3-config-test--contents "lisp/p3-git.el"))
         (org-behavior (p3-config-test--contents "lisp/p3-org.el"))
         (roam-behavior (p3-config-test--contents "lisp/p3-org-roam.el"))
-        (present-behavior (p3-config-test--contents "lisp/p3-org-present.el")))
+        (present-behavior (p3-config-test--contents "lisp/p3-org-present.el"))
+        (terminal-behavior (p3-config-test--contents "lisp/p3-terminal.el")))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-commands)") base))
     (should (string-match-p
@@ -322,8 +334,10 @@
              (regexp-quote "(p3/config-load-module 'p3-org-roam)") roam))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-org-present)") present))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-terminal)") terminal))
     (dolist (behavior (list commands git-behavior org-behavior
-                            roam-behavior present-behavior))
+                            roam-behavior present-behavior terminal-behavior))
       (should-not (string-match-p "p3-config-" behavior)))))
 
 (ert-deftest p3-config-workspace-keeps-only-narrow-ess-display-policy ()


### PR DESCRIPTION
## Summary

- add `p3-config-terminal.el` as the declarative Shell/vterm configuration owner
- keep `p3-terminal.el` unchanged as the reusable project-aware terminal behavior library
- move Windows shell activation, OS-specific terminal bindings, and vterm package wiring out of `config.org`
- preserve the Shell section's startup position after Rainbow and before Spelling
- exact-source load `p3-terminal.el` through the existing local-module loader
- add focused boundary tests plus Ubuntu and native-Windows runtime smoke coverage

## Behavioral boundaries

- no Windows/Rtools/MSYS2 shell implementation changes
- no CRLF/coding-system changes
- no vterm command/session behavior changes
- no keybinding changes
- no ble.sh bootstrap changes
- no window-placement changes
- no adjacent Spelling/TRAMP/Projectile/Python changes

## Verification

The pull-request gates now verify the terminal boundary on both supported platforms. Ubuntu runs warnings-as-errors compilation, a terminal boundary smoke load, and the full ERT suite. Windows warnings-as-errors byte-compiles `p3-config-terminal.el`, runs a native-Windows composition smoke test against the Git-for-Windows MSYS2 shell path, and then runs the existing platform/project and config architecture suites.

Do not merge without explicit approval.