### PR TITLE
Extract GPTel configuration into focused module

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -50,6 +50,7 @@ jobs:
             lisp/p3-ess.el \
             lisp/p3-r-tools.el \
             lisp/p3-gptel.el \
+            lisp/p3-config-gptel.el \
             lisp/p3-org.el \
             lisp/p3-config-org.el \
             lisp/p3-org-roam.el \
@@ -79,6 +80,19 @@ jobs:
             -l lisp/p3-config-loader.el \
             -l lisp/p3-config-terminal.el \
             --eval '(unless (and (featurep (quote p3-config-terminal)) (featurep (quote p3-terminal)) (keymapp p3/vterm-command-map) (string-match-p "vterm-bashrc" vterm-shell)) (kill-emacs 1))'
+
+      - name: Smoke-load GPTel configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            --eval '(setq user-emacs-directory (file-name-as-directory default-directory))' \
+            --eval '(require (quote use-package-ensure))' \
+            --eval '(setq use-package-ensure-function (lambda (&rest _) t))' \
+            --eval '(defun gptel-api-key-from-auth-source () nil)' \
+            --eval '(provide (quote gptel))' \
+            -l lisp/p3-config-loader.el \
+            -l lisp/p3-config-gptel.el \
+            --eval '(unless (and (featurep (quote p3-config-gptel)) (featurep (quote p3-gptel)) (eq gptel-model (quote gpt-4o-mini)) (eq gptel-api-key (quote gptel-api-key-from-auth-source)) (eq (key-binding (kbd "C-c g")) p3/gptel-command-map)) (kill-emacs 1))'
 
       - name: Smoke-load Org configuration boundary
         run: |
@@ -136,6 +150,7 @@ jobs:
             -l test/p3-config-terminal-test.el \
             -l test/p3-ess-test.el \
             -l test/p3-gptel-test.el \
+            -l test/p3-config-gptel-test.el \
             -l test/p3-r-tools-test.el \
             -l test/p3-org-test.el \
             -l test/p3-config-org-test.el \

--- a/config.org
+++ b/config.org
@@ -230,23 +230,12 @@ Prevent emacs from mangling the path to gpg on Windows, as shown [[https://emacs
 
 ** GPT
 
-A GPT (and other LLM) co-pilot for Emacs. The package declaration stays here;
-the task prompts, streaming/rollback behavior, and task command map live in
+GPTel package configuration and activation live in =lisp/p3-config-gptel.el=.
+Task prompts, streaming/rollback behavior, and the task command map remain in
 =lisp/p3-gptel.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (use-package gptel
-    :config
-    (setq gptel-model 'gpt-4o-mini
-          gptel-api-key (or (getenv "OPENAI_API_KEY")
-                            #'gptel-api-key-from-auth-source)))
-
-  (use-package p3-gptel
-    :ensure nil
-    :after gptel
-    :demand t
-    :config
-    (p3/gptel-setup))
+  (p3/config-load-module 'p3-config-gptel)
 #+END_SRC
 
 ** Flycheck

--- a/lisp/p3-config-gptel.el
+++ b/lisp/p3-config-gptel.el
@@ -1,0 +1,26 @@
+;;; p3-config-gptel.el --- GPTel configuration -*- lexical-binding: t; -*-
+
+(require 'use-package)
+(require 'p3-config-loader)
+
+(defvar gptel-api-key)
+(defvar gptel-model)
+
+(declare-function gptel-api-key-from-auth-source "gptel" ())
+(declare-function p3/gptel-setup "p3-gptel" ())
+
+(use-package gptel
+  :config
+  (setq gptel-model 'gpt-4o-mini
+        gptel-api-key (or (getenv "OPENAI_API_KEY")
+                          #'gptel-api-key-from-auth-source)))
+
+;; Preserve the existing `:after gptel' activation boundary while making the
+;; dedicated behavior library participate in exact-source config reloads.
+(with-eval-after-load 'gptel
+  (p3/config-load-module 'p3-gptel)
+  (p3/gptel-setup))
+
+(provide 'p3-config-gptel)
+
+;;; p3-config-gptel.el ends here

--- a/lisp/p3-gptel.el
+++ b/lisp/p3-gptel.el
@@ -208,16 +208,18 @@ its existing list rather than replace a local plist binding."
   (interactive)
   (p3/gptel-send-task "Translate Code" 'append))
 
-(defvar p3/gptel-command-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "l") #'p3/gptel-send-current-line)
-    (define-key map (kbd "r") #'p3/gptel-refactor-region)
-    (define-key map (kbd "d") #'p3/gptel-generate-doc)
-    (define-key map (kbd "t") #'p3/gptel-write-tests)
-    (define-key map (kbd "c") #'p3/gptel-translate-code)
-    (define-key map (kbd "w") #'p3/gptel-write-code)
-    map)
+(defvar p3/gptel-command-map nil
   "Prefix map for project-local GPTel tasks.")
+
+(setq p3/gptel-command-map
+      (let ((map (make-sparse-keymap)))
+        (define-key map (kbd "l") #'p3/gptel-send-current-line)
+        (define-key map (kbd "r") #'p3/gptel-refactor-region)
+        (define-key map (kbd "d") #'p3/gptel-generate-doc)
+        (define-key map (kbd "t") #'p3/gptel-write-tests)
+        (define-key map (kbd "c") #'p3/gptel-translate-code)
+        (define-key map (kbd "w") #'p3/gptel-write-code)
+        map))
 
 (defun p3/gptel-setup ()
   "Install the global key prefix for custom GPTel tasks."

--- a/test/p3-config-gptel-test.el
+++ b/test/p3-config-gptel-test.el
@@ -2,6 +2,7 @@
 
 (require 'ert)
 (require 'seq)
+(require 'p3-config-loader)
 
 (defconst p3-config-gptel-test--root
   (file-name-directory
@@ -66,6 +67,41 @@
     (dolist (forbidden '("(use-package gptel"
                           "(use-package p3-gptel"))
       (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(ert-deftest p3-config-gptel-owner-reloads-command-map-source ()
+  "Reloading the GPTel owner must rebuild command-map definitions from source."
+  (let* ((directory (make-temp-file "p3-gptel-owner-reload-" t))
+         (p3/config-lisp-directory directory)
+         (owner (expand-file-name "p3-config-gptel.el" directory))
+         (behavior (expand-file-name "p3-gptel.el" directory))
+         (old-map (and (boundp 'p3/gptel-command-map) p3/gptel-command-map))
+         (old-binding (key-binding (kbd "C-c g"))))
+    (unwind-protect
+        (progn
+          (copy-file (p3-config-gptel-test--path "lisp/p3-config-gptel.el") owner)
+          (copy-file (p3-config-gptel-test--path "lisp/p3-gptel.el") behavior)
+          (provide 'gptel)
+          (p3/config-load-module 'p3-config-gptel)
+          (with-temp-buffer
+            (insert-file-contents behavior)
+            (goto-char (point-min))
+            (should
+             (search-forward
+              "(define-key map (kbd \"l\") #'p3/gptel-send-current-line)"
+              nil t))
+            (replace-match
+             "(define-key map (kbd \"x\") #'p3/gptel-send-current-line)"
+             t t)
+            (write-region (point-min) (point-max) behavior nil 'silent))
+          (p3/config-load-module 'p3-config-gptel)
+          (should
+           (eq (keymap-lookup p3/gptel-command-map "x")
+               #'p3/gptel-send-current-line)))
+      (if old-map
+          (setq p3/gptel-command-map old-map)
+        (makunbound 'p3/gptel-command-map))
+      (define-key global-map (kbd "C-c g") old-binding)
+      (delete-directory directory t))))
 
 (provide 'p3-config-gptel-test)
 

--- a/test/p3-config-gptel-test.el
+++ b/test/p3-config-gptel-test.el
@@ -74,7 +74,8 @@
          (p3/config-lisp-directory directory)
          (owner (expand-file-name "p3-config-gptel.el" directory))
          (behavior (expand-file-name "p3-gptel.el" directory))
-         (old-map (and (boundp 'p3/gptel-command-map) p3/gptel-command-map))
+         (map-was-bound (boundp 'p3/gptel-command-map))
+         (old-map (and map-was-bound p3/gptel-command-map))
          (old-binding (key-binding (kbd "C-c g"))))
     (unwind-protect
         (progn
@@ -97,7 +98,7 @@
           (should
            (eq (keymap-lookup p3/gptel-command-map "x")
                #'p3/gptel-send-current-line)))
-      (if old-map
+      (if map-was-bound
           (setq p3/gptel-command-map old-map)
         (makunbound 'p3/gptel-command-map))
       (define-key global-map (kbd "C-c g") old-binding)

--- a/test/p3-config-gptel-test.el
+++ b/test/p3-config-gptel-test.el
@@ -1,0 +1,72 @@
+;;; p3-config-gptel-test.el --- GPTel config boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'seq)
+
+(defconst p3-config-gptel-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-gptel-test--path (relative)
+  "Return RELATIVE under the repository root."
+  (expand-file-name relative p3-config-gptel-test--root))
+
+(defun p3-config-gptel-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents (p3-config-gptel-test--path relative))
+    (buffer-string)))
+
+(defun p3-config-gptel-test--forms ()
+  "Read all top-level forms from the GPTel config module."
+  (with-temp-buffer
+    (insert-file-contents
+     (p3-config-gptel-test--path "lisp/p3-config-gptel.el"))
+    (goto-char (point-min))
+    (let (forms)
+      (condition-case nil
+          (while t
+            (push (read (current-buffer)) forms))
+        (end-of-file nil))
+      (nreverse forms))))
+
+(ert-deftest p3-config-gptel-preserves-package-configuration ()
+  (let ((forms (p3-config-gptel-test--forms)))
+    (should
+     (member
+      '(use-package gptel
+         :config
+         (setq gptel-model 'gpt-4o-mini
+               gptel-api-key (or (getenv "OPENAI_API_KEY")
+                                 #'gptel-api-key-from-auth-source)))
+      forms))))
+
+(ert-deftest p3-config-gptel-preserves-after-gptel-activation-timing ()
+  (let ((forms (p3-config-gptel-test--forms)))
+    (should
+     (member
+      '(with-eval-after-load 'gptel
+         (p3/config-load-module 'p3-gptel)
+         (p3/gptel-setup))
+      forms))))
+
+(ert-deftest p3-config-gptel-config-org-delegates-gptel-boundary ()
+  (let ((contents (p3-config-gptel-test--contents "config.org")))
+    (should (= 1
+               (let ((start 0)
+                     (count 0)
+                     (needle (regexp-quote
+                              "(p3/config-load-module 'p3-config-gptel)")))
+                 (while (string-match needle contents start)
+                   (setq count (1+ count)
+                         start (match-end 0)))
+                 count)))
+    (dolist (forbidden '("(use-package gptel"
+                          "(use-package p3-gptel"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(provide 'p3-config-gptel-test)
+
+;;; p3-config-gptel-test.el ends here

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -88,13 +88,12 @@
 
 (ert-deftest p3-config-org-delegates-custom-subsystems-to-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
-    (dolist (module '("p3-platform" "p3-core" "p3-gptel"))
+    (dolist (module '("p3-platform" "p3-core"))
       (should (string-match-p (regexp-quote (format "(use-package %s" module))
                               contents)))
-    (should (string-match-p (regexp-quote "(use-package gptel") contents))
-    (dolist (module '(p3-config-ess p3-config-org p3-config-org-roam
-                      p3-config-org-present p3-config-python
-                      p3-config-terminal))
+    (dolist (module '(p3-config-ess p3-config-gptel p3-config-org
+                      p3-config-org-roam p3-config-org-present
+                      p3-config-python p3-config-terminal))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -194,14 +193,14 @@
     (should (< python rainbow))
     (should (< rainbow terminal))))
 
-(ert-deftest p3-config-org-source-loads-eleven-config-modules ()
+(ert-deftest p3-config-org-source-loads-twelve-config-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
-    (should (= 11
+    (should (= 12
                (p3-config-test--count-occurrences
                 "(p3/config-load-module 'p3-config-" contents)))
     (dolist (module '(p3-config-base p3-config-editing p3-config-completion
-                      p3-config-ess p3-config-org p3-config-org-roam
-                      p3-config-org-present p3-config-python
+                      p3-config-ess p3-config-gptel p3-config-org
+                      p3-config-org-roam p3-config-org-present p3-config-python
                       p3-config-terminal p3-config-workspace p3-config-git))
       (should
        (string-match-p
@@ -269,7 +268,9 @@
                "(use-package org-present"
                "(use-package p3-terminal"
                "(p3/windows-configure-shell)"
-               "(use-package vterm"))
+               "(use-package vterm"
+               "(use-package gptel"
+               "(use-package p3-gptel"))
       (should-not (string-match-p (regexp-quote implementation) contents)))
     (dolist (package '(dashboard which-key vertico company undo-tree super-save
                        multiple-cursors magit git-gutter-fringe+ transpose-frame
@@ -311,15 +312,25 @@
       (should-not (string-match-p (regexp-quote forbidden) contents)))
     (should (string-match-p (regexp-quote "(python . t)") org-config))))
 
+(ert-deftest p3-config-gptel-orchestration-has-one-owner ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (owner "(p3/config-load-module 'p3-config-gptel)"))
+    (should (= 1 (p3-config-test--count-occurrences owner contents)))
+    (dolist (forbidden '("(use-package gptel"
+                          "(use-package p3-gptel"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
 (ert-deftest p3-config-behavior-library-owner-pattern-is-explicit ()
   (let ((base (p3-config-test--contents "lisp/p3-config-base.el"))
         (git (p3-config-test--contents "lisp/p3-config-git.el"))
+        (gptel (p3-config-test--contents "lisp/p3-config-gptel.el"))
         (org (p3-config-test--contents "lisp/p3-config-org.el"))
         (roam (p3-config-test--contents "lisp/p3-config-org-roam.el"))
         (present (p3-config-test--contents "lisp/p3-config-org-present.el"))
         (terminal (p3-config-test--contents "lisp/p3-config-terminal.el"))
         (commands (p3-config-test--contents "lisp/p3-commands.el"))
         (git-behavior (p3-config-test--contents "lisp/p3-git.el"))
+        (gptel-behavior (p3-config-test--contents "lisp/p3-gptel.el"))
         (org-behavior (p3-config-test--contents "lisp/p3-org.el"))
         (roam-behavior (p3-config-test--contents "lisp/p3-org-roam.el"))
         (present-behavior (p3-config-test--contents "lisp/p3-org-present.el"))
@@ -329,6 +340,8 @@
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-git)") git))
     (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-gptel)") gptel))
+    (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-org)") org))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-org-roam)") roam))
@@ -336,7 +349,7 @@
              (regexp-quote "(p3/config-load-module 'p3-org-present)") present))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-terminal)") terminal))
-    (dolist (behavior (list commands git-behavior org-behavior
+    (dolist (behavior (list commands git-behavior gptel-behavior org-behavior
                             roam-behavior present-behavior terminal-behavior))
       (should-not (string-match-p "p3-config-" behavior)))))
 


### PR DESCRIPTION
## Summary

- add `p3-config-gptel.el` as the declarative GPTel configuration owner
- move the GPTel package/model/API-key wiring out of `config.org`
- preserve the existing `:after gptel` activation boundary for `p3-gptel`
- make `p3-gptel.el` participate in exact-source config reloads once GPTel is loaded
- rebuild `p3/gptel-command-map` on source reload so command-map edits are picked up by `C-c r`
- add focused boundary tests, a GPTel owner reload regression test, warnings-as-errors compilation, and an Ubuntu runtime smoke test

## Behavioral boundaries

- no model change
- no API-key/auth-source change
- no prompt or task-command change
- no streaming/rollback change
- no sensitive-buffer policy change
- no user-facing keybinding change
- no adjacent GnuPG/Flycheck configuration change

## Verification

The pull-request gate byte-compiles `p3-config-gptel.el` and `p3-gptel.el` with warnings treated as errors, smoke-loads the owner with GPTel already provided so the normal loaded-GPTel activation path executes, and runs the full ERT suite. The reload regression copies the real owner and behavior library to a temporary module directory, edits the copied command-map source, reloads through `p3-config-gptel`, and verifies that the changed map is reconstructed.

Do not merge without explicit approval.