### PR TITLE
Retire Projectile in favor of project.el

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -33,6 +33,7 @@ jobs:
             -f batch-byte-compile \
             lisp/p3-platform.el \
             lisp/p3-project.el \
+            lisp/p3-config-project.el \
             lisp/p3-config-loader.el \
             lisp/p3-core.el \
             lisp/p3-commands.el \
@@ -57,6 +58,13 @@ jobs:
             lisp/p3-config-org-roam.el \
             lisp/p3-org-present.el \
             lisp/p3-config-org-present.el
+
+      - name: Smoke-load Project configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            -l lisp/p3-config-project.el \
+            --eval '(unless (and (featurep (quote p3-config-project)) (eq (lookup-key global-map (kbd "C-c p")) project-prefix-map) (eq (lookup-key global-map (kbd "s-p")) project-prefix-map) (eq (lookup-key global-map (kbd "C-x p")) project-prefix-map)) (kill-emacs 1))'
 
       - name: Smoke-load Python configuration boundary
         run: |
@@ -142,6 +150,7 @@ jobs:
             -l test/p3-config-test.el \
             -l test/p3-config-ess-test.el \
             -l test/p3-project-test.el \
+            -l test/p3-config-project-test.el \
             -l test/p3-core-test.el \
             -l test/p3-platform-test.el \
             -l test/p3-config-python-test.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -6,6 +6,7 @@ on:
       - "config.org"
       - "lisp/p3-platform.el"
       - "lisp/p3-project.el"
+      - "lisp/p3-config-project.el"
       - "lisp/p3-config-loader.el"
       - "lisp/p3-commands.el"
       - "lisp/p3-git.el"
@@ -25,6 +26,7 @@ on:
       - "test/p3-platform-test.el"
       - "test/p3-project-test.el"
       - "test/p3-project-windows-test.el"
+      - "test/p3-config-project-test.el"
       - "test/p3-config-loader-test.el"
       - "test/p3-config-test.el"
       - "test/p3-config-ess-test.el"
@@ -77,6 +79,7 @@ jobs:
           -f batch-byte-compile
           lisp/p3-platform.el
           lisp/p3-project.el
+          lisp/p3-config-project.el
           lisp/p3-config-loader.el
           lisp/p3-commands.el
           lisp/p3-git.el
@@ -103,6 +106,7 @@ jobs:
           emacs -Q --batch -L lisp
           -l test/p3-config-loader-test.el
           -l test/p3-config-test.el
+          -l test/p3-config-project-test.el
           -l test/p3-config-ess-test.el
           -l test/p3-config-python-test.el
           -l test/p3-config-org-test.el

--- a/config.org
+++ b/config.org
@@ -378,20 +378,14 @@ state capture/restoration and presentation commands live in
   (p3/config-load-module 'p3-config-org-present)
 #+END_SRC
 
-** Projectile
-#+BEGIN_SRC emacs-lisp
-  (defun p3/projectile-r-project-file-p (&optional directory)
-    (or (projectile-verify-file-wildcard "?*.r" directory)
-        (projectile-verify-file-wildcard "?*.R" directory)))
+** Project
 
-  (use-package projectile
-    :bind (:map projectile-mode-map
-                ("s-p" . projectile-command-map)
-                ("C-c p" . projectile-command-map))
-    :init
-    (projectile-mode +1)
-    :config
-    (projectile-register-project-type 'r #'p3/projectile-r-project-file-p))
+Native project identity is established early by =lisp/p3-project.el=.
+User-facing project bindings live in =lisp/p3-config-project.el= and use the
+built-in =project.el= command map.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-project)
 #+END_SRC
 
 ** Python

--- a/docs/superpowers/plans/2026-09-05-retire-projectile.md
+++ b/docs/superpowers/plans/2026-09-05-retire-projectile.md
@@ -1,0 +1,679 @@
+# Retire Projectile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Projectile from the active Emacs configuration, replace its user-facing project prefix with native `project.el`, and move new R projects to `*.Rproj` project markers while preserving legacy `.projectile` boundaries.
+
+**Architecture:** `p3-project.el` remains the startup-critical owner of project identity and marker policy. A new `p3-config-project.el` owns only native project keybindings, while `p3-r-tools.el` stops generating Projectile-specific files. Existing `.projectile` files remain recognized for compatibility, but no Projectile package/runtime code remains active.
+
+**Tech Stack:** Emacs 29+ built-in `project.el`, Emacs Lisp, ERT, Org literate configuration, GitHub Actions on Ubuntu and native Windows.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-retire-projectile-design.md`
+
+## Global Constraints
+
+- Emacs 29+ remains the supported baseline.
+- `project.el` must remain the only project framework and the sole source of project identity.
+- Do not add a custom `project.el` backend or a Projectile fallback path.
+- Remove Projectile from active configuration, but do not uninstall packages from user package directories.
+- Keep `.projectile` in `project-vc-extra-root-markers` as legacy compatibility.
+- Add `*.Rproj` as the forward R-project marker and stop generating `.projectile` in new R projects.
+- Preserve `p3/project-root` and `p3/use-project-root-as-default-dir` interfaces and existing ESS, Python, R-tool, and terminal behavior.
+- Bind `C-c p` and `s-p` directly to native `project-prefix-map`; leave `C-x p` and all native project command semantics unchanged.
+- Do not reproduce Projectile command semantics, remembered-project state, keymap precedence, or shutdown behavior with compatibility machinery.
+- After adoption, one Emacs restart is required to retire an already-running `projectile-mode`; `C-c r` alone is not required to do so.
+- Preserve the Windows Rtools/MSYS2 marker-project file-enumeration contract.
+- Use static/local verification before opening the PR; use the Ubuntu and Windows PR workflows as one coherent final CI gate rather than an iterative diagnostic loop.
+- Do not modify historical specs/plans to erase Projectile from the migration history.
+
+## File Structure
+
+**Create**
+- `lisp/p3-config-project.el` — declarative native project keybindings only.
+- `test/p3-config-project-test.el` — focused owner/binding and config-delegation tests.
+
+**Modify**
+- `lisp/p3-project.el` — native marker policy; remove Projectile provider-defense machinery; add `*.Rproj` while retaining `.projectile`.
+- `test/p3-project-test.el` — marker/root/file-boundary tests and removal of obsolete Projectile-hook coverage.
+- `lisp/p3-r-tools.el` — stop scaffolding `.projectile`.
+- `test/p3-r-tools-test.el` — prove new R projects contain `.Rproj` and not `.projectile`.
+- `config.org` — replace the inline Projectile block with the native project config owner at the same orchestration position.
+- `lisp/p3-commands.el` — add a concise native Project section to the keybinding atlas.
+- `test/p3-commands-test.el` — pin the new atlas section.
+- `test/p3-config-test.el` — update module count, ordering, owner assertions, and absence of inline Projectile configuration.
+- `test/p3-project-windows-test.el` — exercise the forward `*.Rproj` marker on Windows.
+- `.github/workflows/emacs-tests.yml` — compile/smoke/load the native project config owner and focused test.
+- `.github/workflows/windows-platform-tests.yml` — add path triggers, compile the owner, and load its focused test.
+
+---
+
+### Task 1: Make native project markers independent of Projectile
+
+**Files:**
+- Modify: `test/p3-project-test.el`
+- Modify: `lisp/p3-project.el`
+
+**Interfaces:**
+- Consumes: built-in `project-current`, `project-root`, `project-files`, and `project-vc-extra-root-markers`.
+- Produces: unchanged `p3/project-root` and `p3/use-project-root-as-default-dir`; marker policy recognizing both legacy `.projectile` and forward `*.Rproj`.
+
+- [ ] **Step 1: Add failing `*.Rproj` marker tests before changing production code**
+
+Keep the existing `.projectile` descendant test, but rename it to make its compatibility role explicit. Remove the obsolete `p3-project-projectile-mode-hook-restores-native-provider` test only when the provider-defense production code is removed in Step 3.
+
+Add these tests to `test/p3-project-test.el`:
+
+```elisp
+(ert-deftest p3-project-rproj-marker-only-project-is-detected-from-descendant ()
+  (let* ((root (make-temp-file "p3-project-rproj-" t))
+         (child (expand-file-name "R/subdir" root)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (with-temp-file (expand-file-name "analysis.Rproj" root))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
+(ert-deftest p3-project-inner-rproj-marker-bounds-project-files ()
+  (skip-unless (executable-find "git"))
+  (let* ((outer (make-temp-file "p3-project-outer-rproj-" t))
+         (inner (expand-file-name "analysis" outer))
+         (child (expand-file-name "R/subdir" inner))
+         (inner-file (expand-file-name "R/inside.R" inner))
+         (outer-file (expand-file-name "outside.R" outer)))
+    (unwind-protect
+        (progn
+          (should
+           (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+          (make-directory child t)
+          (with-temp-file (expand-file-name "analysis.Rproj" inner))
+          (with-temp-file inner-file
+            (insert "inside <- TRUE\n"))
+          (with-temp-file outer-file
+            (insert "outside <- TRUE\n"))
+          (let* ((default-directory child)
+                 (project (project-current nil))
+                 (files (mapcar #'file-truename (project-files project))))
+            (should project)
+            (should
+             (equal (p3-project-test--canonical-directory (project-root project))
+                    (p3-project-test--canonical-directory inner)))
+            (should (member (file-truename inner-file) files))
+            (should-not (member (file-truename outer-file) files))))
+      (delete-directory outer t))))
+```
+
+Rename the existing compatibility test to:
+
+```elisp
+(ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
+  ...existing test body unchanged...)
+```
+
+- [ ] **Step 2: Run the focused project tests and verify the new forward-marker tests fail**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: the new `*.Rproj` tests fail because `p3-project.el` currently registers only `.projectile`; the existing `.projectile` compatibility and helper tests still pass.
+
+- [ ] **Step 3: Remove Projectile provider-defense code and register the forward marker**
+
+Change the top of `lisp/p3-project.el` to retain the existing Emacs-version guard and marker compatibility while removing all Projectile-specific runtime policy:
+
+```elisp
+;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
+
+(require 'project)
+
+(unless (boundp 'project-vc-extra-root-markers)
+  (error "P3 project support requires Emacs 29 or newer"))
+
+(dolist (marker '(".projectile" "*.Rproj"))
+  (add-to-list 'project-vc-extra-root-markers marker))
+```
+
+Delete these forms entirely:
+
+```elisp
+(declare-function project-projectile "projectile" (directory))
+
+(defun p3/project-keep-native-provider ()
+  ...)
+
+(add-hook 'projectile-mode-hook #'p3/project-keep-native-provider)
+(p3/project-keep-native-provider)
+```
+
+Leave `p3/project-root`, `p3/use-project-root-as-default-dir`, `provide`, and the file footer unchanged.
+
+At the same time remove `p3-project-projectile-mode-hook-restores-native-provider` from `test/p3-project-test.el`; that behavior is intentionally gone rather than replaced.
+
+- [ ] **Step 4: Run the focused project tests and verify marker/root/file semantics pass**
+
+Run the same focused command from Step 2.
+
+Expected: PASS, including:
+- normal helper delegation;
+- legacy `.projectile` descendant detection;
+- `*.Rproj` descendant detection;
+- nested `*.Rproj` root selection;
+- `project-files` includes `inside.R` and excludes outer `outside.R`.
+
+- [ ] **Step 5: Commit the native project semantic change**
+
+```bash
+git add lisp/p3-project.el test/p3-project-test.el
+git commit -m "Retire Projectile project provider policy"
+```
+
+---
+
+### Task 2: Stop scaffolding Projectile-specific R project files
+
+**Files:**
+- Modify: `test/p3-r-tools-test.el`
+- Modify: `lisp/p3-r-tools.el`
+
+**Interfaces:**
+- Consumes: the existing `<project-name>.Rproj` template generated by `p3-r-new-project` and the `*.Rproj` marker policy from Task 1.
+- Produces: newly scaffolded R projects containing `<project-name>.Rproj` but no `.projectile` sentinel.
+
+- [ ] **Step 1: Change the R scaffolding test to require the new forward state**
+
+In `p3-r-new-analysis-project-generates-expected-files`, replace the current positive `.projectile` assertion with:
+
+```elisp
+(should (file-exists-p (expand-file-name "analysis-demo.Rproj" root)))
+(should-not (file-exists-p (expand-file-name ".projectile" root)))
+```
+
+Keep the existing generated-script/profile assertions unchanged.
+
+- [ ] **Step 2: Run the focused R-tools tests and verify the changed assertion fails**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-r-tools-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: `p3-r-new-analysis-project-generates-expected-files` fails because `.projectile` is still emitted by `p3-r--common-project-files`.
+
+- [ ] **Step 3: Remove `.projectile` from the common R project scaffold**
+
+Change `p3-r--common-project-files` in `lisp/p3-r-tools.el` from:
+
+```elisp
+(defconst p3-r--common-project-files
+  '((:path "{{project-name}}.Rproj" :template "project.Rproj.tmpl")
+    (:path ".gitignore" :template "gitignore.tmpl")
+    (:path ".projectile" :content "")
+    (:path "R/01_prepareData.R" :template "script.R.tmpl"
+           :title "Preprocess data")
+    (:path "R/02_computeResults.R" :template "script.R.tmpl"
+           :title "Compute results"))
+  "Files shared by all R project profiles.")
+```
+
+to:
+
+```elisp
+(defconst p3-r--common-project-files
+  '((:path "{{project-name}}.Rproj" :template "project.Rproj.tmpl")
+    (:path ".gitignore" :template "gitignore.tmpl")
+    (:path "R/01_prepareData.R" :template "script.R.tmpl"
+           :title "Preprocess data")
+    (:path "R/02_computeResults.R" :template "script.R.tmpl"
+           :title "Compute results"))
+  "Files shared by all R project profiles.")
+```
+
+Do not rename, reformat, or otherwise alter the `.Rproj` template or profile structure.
+
+- [ ] **Step 4: Run the focused R-tools and project tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -l test/p3-r-tools-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS. This proves the generated `.Rproj` file is sufficient for the native project policy established in Task 1 and that `.projectile` is no longer emitted.
+
+- [ ] **Step 5: Commit the scaffolding migration**
+
+```bash
+git add lisp/p3-r-tools.el test/p3-r-tools-test.el
+git commit -m "Use Rproj files as forward project markers"
+```
+
+---
+
+### Task 3: Replace the Projectile UI layer with native project configuration
+
+**Files:**
+- Create: `test/p3-config-project-test.el`
+- Create: `lisp/p3-config-project.el`
+- Modify: `config.org`
+- Modify: `test/p3-config-test.el`
+- Modify: `lisp/p3-commands.el`
+- Modify: `test/p3-commands-test.el`
+
+**Interfaces:**
+- Consumes: built-in `project-prefix-map`, startup-loaded `p3-project.el`, and existing `p3/config-load-module` orchestration.
+- Produces: `p3-config-project` feature; global aliases `C-c p` and `s-p` to the exact native `project-prefix-map`; one config owner in the current Presentation → Project → Python position.
+
+- [ ] **Step 1: Create the focused owner test before creating the owner**
+
+Create `test/p3-config-project-test.el` with:
+
+```elisp
+;;; p3-config-project-test.el --- Native project config boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'project)
+(require 'p3-config-loader)
+
+(defconst p3-config-project-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-project-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name relative p3-config-project-test--root))
+    (buffer-string)))
+
+(ert-deftest p3-config-project-binds-native-project-prefixes ()
+  (let ((p3/config-lisp-directory
+         (expand-file-name "lisp" p3-config-project-test--root))
+        (old-c-c-p (lookup-key global-map (kbd "C-c p")))
+        (old-s-p (lookup-key global-map (kbd "s-p"))))
+    (unwind-protect
+        (progn
+          (p3/config-load-module 'p3-config-project)
+          (should (featurep 'p3-config-project))
+          (should (eq (lookup-key global-map (kbd "C-c p"))
+                      project-prefix-map))
+          (should (eq (lookup-key global-map (kbd "s-p"))
+                      project-prefix-map))
+          (should (eq (lookup-key global-map (kbd "C-x p"))
+                      project-prefix-map)))
+      (define-key global-map (kbd "C-c p") old-c-c-p)
+      (define-key global-map (kbd "s-p") old-s-p))))
+
+(ert-deftest p3-config-project-config-org-has-one-native-owner ()
+  (let ((contents (p3-config-project-test--contents "config.org")))
+    (should
+     (string-match-p
+      (regexp-quote "(p3/config-load-module 'p3-config-project)")
+      contents))
+    (dolist (forbidden '("(use-package projectile"
+                          "p3/projectile-r-project-file-p"
+                          "projectile-command-map"
+                          "projectile-register-project-type"
+                          "(projectile-mode +1)"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(provide 'p3-config-project-test)
+
+;;; p3-config-project-test.el ends here
+```
+
+- [ ] **Step 2: Update architecture and atlas tests before implementation**
+
+In `test/p3-config-test.el`:
+
+1. Replace ordering lookups for `"(use-package projectile"` with:
+
+```elisp
+"(p3/config-load-module 'p3-config-project)"
+```
+
+Use a local variable named `project-config`, not `projectile`, in both `p3-config-org-subsystem-order-is-explicit` and `p3-config-python-preserves-subsystem-timing`.
+
+2. Rename `p3-config-org-source-loads-twelve-config-modules` to `p3-config-org-source-loads-thirteen-config-modules`, change the expected count from `12` to `13`, and add `p3-config-project` to the explicit owner list.
+
+3. Add these Projectile forms to `p3-config-moved-implementation-is-not-inline`:
+
+```elisp
+"(use-package projectile"
+"(defun p3/projectile-r-project-file-p"
+"projectile-command-map"
+"projectile-register-project-type"
+"(projectile-mode +1)"
+```
+
+4. Add a dedicated owner assertion:
+
+```elisp
+(ert-deftest p3-config-project-orchestration-has-one-owner ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (owner "(p3/config-load-module 'p3-config-project)"))
+    (should (= 1 (p3-config-test--count-occurrences owner contents)))
+    (dolist (forbidden '("(use-package projectile"
+                          "p3/projectile-r-project-file-p"
+                          "projectile-command-map"
+                          "projectile-register-project-type"
+                          "(projectile-mode +1)"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+```
+
+In `test/p3-commands-test.el`, add:
+
+```elisp
+(ert-deftest p3-commands-keybinding-atlas-documents-native-project-prefix ()
+  (let ((section (assoc "Project" p3/keybinding-sections)))
+    (should section)
+    (should (equal (cdr (assoc "C-c p / C-x p" (cdr section)))
+                   "native project commands"))
+    (should (equal (cdr (assoc "s-p" (cdr section)))
+                   "native project commands"))))
+```
+
+- [ ] **Step 3: Run the focused config/architecture tests and verify they fail before implementation**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-project-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-commands-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: failures because `p3-config-project.el` does not yet exist, `config.org` still contains the inline Projectile block, the module count is still 12, and the atlas has no Project section.
+
+- [ ] **Step 4: Create the native project config owner**
+
+Create `lisp/p3-config-project.el` exactly as a small declarative owner:
+
+```elisp
+;;; p3-config-project.el --- Native project configuration -*- lexical-binding: t; -*-
+
+(require 'project)
+
+(global-set-key (kbd "C-c p") project-prefix-map)
+(global-set-key (kbd "s-p") project-prefix-map)
+
+(provide 'p3-config-project)
+
+;;; p3-config-project.el ends here
+```
+
+Do not add `use-package projectile`, compatibility wrappers, custom project commands, or a new minor mode.
+
+- [ ] **Step 5: Replace the inline Projectile block in `config.org` at the same orchestration position**
+
+Replace the current `** Projectile` section with:
+
+```org
+** Project
+
+Native project identity is established early by =lisp/p3-project.el=.
+User-facing project bindings live in =lisp/p3-config-project.el= and use the
+built-in =project.el= command map.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-project)
+#+END_SRC
+```
+
+Keep this section after Presentation and before Python.
+
+- [ ] **Step 6: Add the concise Project section to the keybinding atlas**
+
+In `lisp/p3-commands.el`, add immediately after the `Global` section:
+
+```elisp
+("Project"
+ ("C-c p / C-x p" . "native project commands")
+ ("s-p" . "native project commands"))
+```
+
+Do not enumerate the entire native project prefix.
+
+- [ ] **Step 7: Run focused project/config/atlas tests**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-project-test.el \
+  -l test/p3-config-project-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-commands-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS. In particular, `C-c p`, `s-p`, and `C-x p` resolve to the same built-in `project-prefix-map`, and `config.org` has exactly one native project config owner with no inline Projectile runtime forms.
+
+- [ ] **Step 8: Commit the native project UI/config boundary**
+
+```bash
+git add \
+  lisp/p3-config-project.el \
+  test/p3-config-project-test.el \
+  config.org \
+  test/p3-config-test.el \
+  lisp/p3-commands.el \
+  test/p3-commands-test.el
+git commit -m "Replace Projectile UI with project.el"
+```
+
+---
+
+### Task 4: Make Windows and CI coverage durable for the new boundary
+
+**Files:**
+- Modify: `test/p3-project-windows-test.el`
+- Modify: `.github/workflows/emacs-tests.yml`
+- Modify: `.github/workflows/windows-platform-tests.yml`
+
+**Interfaces:**
+- Consumes: `p3-config-project` from Task 3 and the `*.Rproj` marker policy from Task 1.
+- Produces: native Windows evidence that marker-only project discovery/file enumeration works with `*.Rproj`; CI triggers and compilation/test coverage for future isolated project-config edits.
+
+- [ ] **Step 1: Change the native Windows marker test to exercise the forward marker**
+
+In `test/p3-project-windows-test.el`, replace:
+
+```elisp
+(with-temp-file (expand-file-name ".projectile" root))
+```
+
+with:
+
+```elisp
+(with-temp-file (expand-file-name "windows-test.Rproj" root))
+```
+
+Leave the Rtools/MSYS2 setup, root assertion, and `project-files` enumeration assertion unchanged.
+
+- [ ] **Step 2: Extend the Ubuntu workflow for the new project config owner**
+
+In `.github/workflows/emacs-tests.yml`:
+
+1. Add `lisp/p3-config-project.el` to `Byte-compile extracted modules`, immediately after `lisp/p3-project.el`.
+
+2. Add a smoke step after package installation and before the existing Python smoke:
+
+```yaml
+      - name: Smoke-load Project configuration boundary
+        run: |
+          emacs -Q --batch \
+            -L lisp \
+            -l lisp/p3-config-project.el \
+            --eval '(unless (and (featurep (quote p3-config-project)) (eq (lookup-key global-map (kbd "C-c p")) project-prefix-map) (eq (lookup-key global-map (kbd "s-p")) project-prefix-map) (eq (lookup-key global-map (kbd "C-x p")) project-prefix-map)) (kill-emacs 1))'
+```
+
+3. Add `-l test/p3-config-project-test.el` to the full ERT suite immediately after `-l test/p3-project-test.el`.
+
+- [ ] **Step 3: Extend the Windows workflow path filters and gates**
+
+In `.github/workflows/windows-platform-tests.yml`:
+
+1. Add these `pull_request.paths` entries next to the existing project files:
+
+```yaml
+      - "lisp/p3-config-project.el"
+      - "test/p3-config-project-test.el"
+```
+
+2. Add `lisp/p3-config-project.el` to `Byte-compile Windows boundary modules` immediately after `lisp/p3-project.el`.
+
+3. Add `-l test/p3-config-project-test.el` to `Run Windows config architecture tests` immediately after `-l test/p3-config-test.el`.
+
+Do not add a new workflow or a second Windows job.
+
+- [ ] **Step 4: Run all locally runnable project/config tests before opening a PR**
+
+Run:
+
+```bash
+emacs -Q --batch -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-project-test.el \
+  -l test/p3-config-project-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-platform-test.el \
+  -l test/p3-config-python-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-terminal-test.el \
+  -l test/p3-config-terminal-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-commands-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: PASS on the current platform. `p3-project-windows-test.el` is deliberately not used as proof on non-Windows; the native Windows PR workflow is the authoritative gate for that contract.
+
+- [ ] **Step 5: Commit the CI/platform durability changes**
+
+```bash
+git add \
+  test/p3-project-windows-test.el \
+  .github/workflows/emacs-tests.yml \
+  .github/workflows/windows-platform-tests.yml
+git commit -m "Verify native project boundary across platforms"
+```
+
+---
+
+### Task 5: Final static audit, PR gate, and adversarial review
+
+**Files:**
+- Verify all files changed in Tasks 1–4.
+- No production changes should be introduced after the final PR-triggering commit unless verification exposes a real defect.
+
+**Interfaces:**
+- Consumes: the complete implementation and tests from Tasks 1–4.
+- Produces: one reviewable PR with exact-head Ubuntu and Windows evidence; no merge without explicit user approval.
+
+- [ ] **Step 1: Audit active runtime source for residual Projectile dependencies**
+
+Run:
+
+```bash
+git grep -n -E \
+  'use-package projectile|projectile-mode|projectile-command-map|projectile-register-project-type|project-projectile|p3/projectile-r-project-file-p' \
+  -- config.org init.el lisp
+```
+
+Expected: no matches.
+
+Then run:
+
+```bash
+git grep -n '\.projectile' -- config.org init.el lisp
+```
+
+Expected: only the intentional legacy compatibility marker in `lisp/p3-project.el`; `lisp/p3-r-tools.el` must not emit `.projectile`.
+
+- [ ] **Step 2: Verify the exact config orchestration shape**
+
+Run:
+
+```bash
+git grep -n "p3-config-project" -- config.org lisp test .github
+```
+
+Expected:
+- one `config.org` owner load;
+- one owner source file;
+- focused and architecture tests;
+- Ubuntu compile/smoke/full-suite coverage;
+- Windows path/compile/test coverage.
+
+Also verify the order in `config.org` remains:
+
+```text
+Org -> Org-roam -> Poly-R -> Presentation -> Project -> Python -> Rainbow -> Shell
+```
+
+- [ ] **Step 3: Run the full local Ubuntu-equivalent ERT command before opening the PR**
+
+Run the exact `Run ERT test suite` command from `.github/workflows/emacs-tests.yml`, including the new `test/p3-config-project-test.el` entry.
+
+Expected: zero unexpected failures. Skips are acceptable only where already intentional for unavailable platform/tool contracts.
+
+- [ ] **Step 4: Open PR #19 only after static/local verification is clean**
+
+PR title:
+
+```text
+Retire Projectile in favor of project.el
+```
+
+PR body must summarize:
+- Projectile removed from active runtime/configuration;
+- native `project-prefix-map` now owns `C-c p` and `s-p` while `C-x p` remains native;
+- new R projects use `*.Rproj` and stop creating `.projectile`;
+- legacy `.projectile` remains a compatibility marker;
+- native `project.el` switch/list semantics are intentionally not made Projectile-compatible;
+- one Emacs restart is required after adoption if `projectile-mode` is already running;
+- do not merge without explicit approval.
+
+Opening the PR is the single intended trigger for the final Ubuntu and Windows Actions gate.
+
+- [ ] **Step 5: Verify both workflows on the exact PR head**
+
+Require:
+- Ubuntu `Emacs tests`: success, including warnings-as-errors byte compilation, Project smoke, and full ERT suite.
+- `Windows platform tests`: success, including `*.Rproj` marker detection/file enumeration, project config byte compilation, focused project config test, and architecture tests.
+
+If a workflow fails, inspect the specific failing step/log and fix only the demonstrated root cause. Do not add diagnostic workflows or repeatedly rerun full CI without a code/test change that addresses the failure.
+
+- [ ] **Step 6: Perform an adversarial final review before asking for merge approval**
+
+Review the exact PR diff against `docs/superpowers/specs/2026-09-05-retire-projectile-design.md` and verify:
+- no hidden Projectile runtime/reference remains in active code;
+- `.projectile` compatibility was not accidentally removed;
+- R scaffolding no longer emits `.projectile`;
+- native project file boundaries are tested, not just roots;
+- no custom project backend or Projectile emulation was introduced;
+- no ESS/Python/terminal/R workflow drift is present;
+- Windows workflow triggers remain durable for isolated future project-config edits;
+- historical migration docs remain untouched apart from the new approved spec/plan.
+
+Do not merge PR #19 without explicit user approval.

--- a/docs/superpowers/plans/2026-09-05-retire-projectile.md
+++ b/docs/superpowers/plans/2026-09-05-retire-projectile.md
@@ -57,13 +57,24 @@
 - Consumes: built-in `project-current`, `project-root`, `project-files`, and `project-vc-extra-root-markers`.
 - Produces: unchanged `p3/project-root` and `p3/use-project-root-as-default-dir`; marker policy recognizing both legacy `.projectile` and forward `*.Rproj`.
 
-- [ ] **Step 1: Add failing `*.Rproj` marker tests before changing production code**
+- [ ] **Step 1: Add failing forward-marker and runtime-retirement tests before changing production code**
 
-Keep the existing `.projectile` descendant test, but rename it to make its compatibility role explicit. Remove the obsolete `p3-project-projectile-mode-hook-restores-native-provider` test only when the provider-defense production code is removed in Step 3.
-
-Add these tests to `test/p3-project-test.el`:
+Replace the existing `p3-project-marker-only-project-is-detected-from-descendant` test with the explicitly named compatibility test below, then add the two `*.Rproj` tests and the source-policy test:
 
 ```elisp
+(ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
+  (let* ((root (make-temp-file "p3-project-marker-" t))
+         (child (expand-file-name "R/subdir" root)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" root))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
 (ert-deftest p3-project-rproj-marker-only-project-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-rproj-" t))
          (child (expand-file-name "R/subdir" root)))
@@ -104,16 +115,25 @@ Add these tests to `test/p3-project-test.el`:
             (should (member (file-truename inner-file) files))
             (should-not (member (file-truename outer-file) files))))
       (delete-directory outer t))))
+
+(ert-deftest p3-project-source-has-no-projectile-runtime-policy ()
+  (let ((path (expand-file-name "lisp/p3-project.el" p3-project-test--root)))
+    (with-temp-buffer
+      (insert-file-contents path)
+      (let ((contents (buffer-string)))
+        (dolist (forbidden '("project-projectile"
+                            "projectile-mode-hook"
+                            "p3/project-keep-native-provider"))
+          (should-not (string-match-p (regexp-quote forbidden) contents)))
+        (should (string-match-p
+                 (regexp-quote "\".projectile\"") contents))
+        (should (string-match-p
+                 (regexp-quote "\"*.Rproj\"") contents))))))
 ```
 
-Rename the existing compatibility test to:
+Keep `p3-project-projectile-mode-hook-restores-native-provider` in place for this red run; remove it only when the provider-defense production code is removed in Step 3.
 
-```elisp
-(ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
-  ...existing test body unchanged...)
-```
-
-- [ ] **Step 2: Run the focused project tests and verify the new forward-marker tests fail**
+- [ ] **Step 2: Run the focused project tests and verify the new tests fail**
 
 Run:
 
@@ -123,11 +143,16 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: the new `*.Rproj` tests fail because `p3-project.el` currently registers only `.projectile`; the existing `.projectile` compatibility and helper tests still pass.
+Expected failures:
+- `p3-project-rproj-marker-only-project-is-detected-from-descendant` because `*.Rproj` is not registered yet;
+- `p3-project-inner-rproj-marker-bounds-project-files` for the same reason;
+- `p3-project-source-has-no-projectile-runtime-policy` because the provider-defense code still exists.
+
+The legacy `.projectile` compatibility and existing project helper tests must still pass.
 
 - [ ] **Step 3: Remove Projectile provider-defense code and register the forward marker**
 
-Change the top of `lisp/p3-project.el` to retain the existing Emacs-version guard and marker compatibility while removing all Projectile-specific runtime policy:
+Change the top of `lisp/p3-project.el` to:
 
 ```elisp
 ;;; p3-project.el --- Shared project identity for the personal Emacs config -*- lexical-binding: t; -*-
@@ -141,32 +166,43 @@ Change the top of `lisp/p3-project.el` to retain the existing Emacs-version guar
   (add-to-list 'project-vc-extra-root-markers marker))
 ```
 
-Delete these forms entirely:
+Delete these exact existing forms and comments from `lisp/p3-project.el`:
 
 ```elisp
 (declare-function project-projectile "projectile" (directory))
 
 (defun p3/project-keep-native-provider ()
-  ...)
+  "Keep Projectile from overriding native `project.el' project discovery."
+  (remove-hook 'project-find-functions #'project-projectile))
 
+;; Projectile intentionally registers itself as a project.el provider whenever
+;; `projectile-mode' changes state.  Keep its UI and commands, but remove that
+;; provider after the mode has finished updating its hooks.
 (add-hook 'projectile-mode-hook #'p3/project-keep-native-provider)
 (p3/project-keep-native-provider)
 ```
 
-Leave `p3/project-root`, `p3/use-project-root-as-default-dir`, `provide`, and the file footer unchanged.
+Leave these existing definitions unchanged:
 
-At the same time remove `p3-project-projectile-mode-hook-restores-native-provider` from `test/p3-project-test.el`; that behavior is intentionally gone rather than replaced.
+```elisp
+(defun p3/project-root ()
+  "Return the current built-in `project.el' root, if any."
+  (when-let ((project (project-current nil)))
+    (project-root project)))
+
+(defun p3/use-project-root-as-default-dir ()
+  "Use the current project root as the buffer's default directory."
+  (when-let ((root (p3/project-root)))
+    (setq-local default-directory root)))
+```
+
+Remove the obsolete `p3-project-projectile-mode-hook-restores-native-provider` test from `test/p3-project-test.el`; that behavior is intentionally deleted rather than replaced.
 
 - [ ] **Step 4: Run the focused project tests and verify marker/root/file semantics pass**
 
-Run the same focused command from Step 2.
+Run the same command from Step 2.
 
-Expected: PASS, including:
-- normal helper delegation;
-- legacy `.projectile` descendant detection;
-- `*.Rproj` descendant detection;
-- nested `*.Rproj` root selection;
-- `project-files` includes `inside.R` and excludes outer `outside.R`.
+Expected: PASS, including legacy `.projectile` detection, `*.Rproj` detection, nested `*.Rproj` root/file boundaries, and the assertion that no Projectile runtime policy remains in `p3-project.el`.
 
 - [ ] **Step 5: Commit the native project semantic change**
 
@@ -189,14 +225,17 @@ git commit -m "Retire Projectile project provider policy"
 
 - [ ] **Step 1: Change the R scaffolding test to require the new forward state**
 
-In `p3-r-new-analysis-project-generates-expected-files`, replace the current positive `.projectile` assertion with:
+In `p3-r-new-analysis-project-generates-expected-files`, use these assertions:
 
 ```elisp
 (should (file-exists-p (expand-file-name "analysis-demo.Rproj" root)))
 (should-not (file-exists-p (expand-file-name ".projectile" root)))
+(should (file-exists-p (expand-file-name "R/01_prepareData.R" root)))
+(should (file-exists-p (expand-file-name "R/utils.R" root)))
+(should-not (file-exists-p (expand-file-name "_targets.R" root)))
 ```
 
-Keep the existing generated-script/profile assertions unchanged.
+Keep the existing generated-script content assertion unchanged.
 
 - [ ] **Step 2: Run the focused R-tools tests and verify the changed assertion fails**
 
@@ -212,21 +251,7 @@ Expected: `p3-r-new-analysis-project-generates-expected-files` fails because `.p
 
 - [ ] **Step 3: Remove `.projectile` from the common R project scaffold**
 
-Change `p3-r--common-project-files` in `lisp/p3-r-tools.el` from:
-
-```elisp
-(defconst p3-r--common-project-files
-  '((:path "{{project-name}}.Rproj" :template "project.Rproj.tmpl")
-    (:path ".gitignore" :template "gitignore.tmpl")
-    (:path ".projectile" :content "")
-    (:path "R/01_prepareData.R" :template "script.R.tmpl"
-           :title "Preprocess data")
-    (:path "R/02_computeResults.R" :template "script.R.tmpl"
-           :title "Compute results"))
-  "Files shared by all R project profiles.")
-```
-
-to:
+Replace the current constant with:
 
 ```elisp
 (defconst p3-r--common-project-files
@@ -252,7 +277,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: PASS. This proves the generated `.Rproj` file is sufficient for the native project policy established in Task 1 and that `.projectile` is no longer emitted.
+Expected: PASS.
 
 - [ ] **Step 5: Commit the scaffolding migration**
 
@@ -341,17 +366,26 @@ Create `test/p3-config-project-test.el` with:
 
 In `test/p3-config-test.el`:
 
-1. Replace ordering lookups for `"(use-package projectile"` with:
+1. In both `p3-config-org-subsystem-order-is-explicit` and `p3-config-python-preserves-subsystem-timing`, replace the Projectile lookup with:
 
 ```elisp
-"(p3/config-load-module 'p3-config-project)"
+(project-config
+ (p3-config-test--position
+  "(p3/config-load-module 'p3-config-project)" contents))
 ```
 
-Use a local variable named `project-config`, not `projectile`, in both `p3-config-org-subsystem-order-is-explicit` and `p3-config-python-preserves-subsystem-timing`.
+and use `project-config` in the existing ordering assertions.
 
-2. Rename `p3-config-org-source-loads-twelve-config-modules` to `p3-config-org-source-loads-thirteen-config-modules`, change the expected count from `12` to `13`, and add `p3-config-project` to the explicit owner list.
+2. Rename `p3-config-org-source-loads-twelve-config-modules` to `p3-config-org-source-loads-thirteen-config-modules`, change the expected count from `12` to `13`, and make the owner list:
 
-3. Add these Projectile forms to `p3-config-moved-implementation-is-not-inline`:
+```elisp
+'(p3-config-base p3-config-editing p3-config-completion
+  p3-config-ess p3-config-gptel p3-config-org
+  p3-config-org-roam p3-config-org-present p3-config-project
+  p3-config-python p3-config-terminal p3-config-workspace p3-config-git)
+```
+
+3. Add these forms to `p3-config-moved-implementation-is-not-inline`:
 
 ```elisp
 "(use-package projectile"
@@ -361,7 +395,7 @@ Use a local variable named `project-config`, not `projectile`, in both `p3-confi
 "(projectile-mode +1)"
 ```
 
-4. Add a dedicated owner assertion:
+4. Add:
 
 ```elisp
 (ert-deftest p3-config-project-orchestration-has-one-owner ()
@@ -400,11 +434,11 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: failures because `p3-config-project.el` does not yet exist, `config.org` still contains the inline Projectile block, the module count is still 12, and the atlas has no Project section.
+Expected failures: the owner file does not exist, `config.org` still contains Projectile, the config owner count is still 12, and the atlas has no Project section.
 
 - [ ] **Step 4: Create the native project config owner**
 
-Create `lisp/p3-config-project.el` exactly as a small declarative owner:
+Create `lisp/p3-config-project.el` exactly as:
 
 ```elisp
 ;;; p3-config-project.el --- Native project configuration -*- lexical-binding: t; -*-
@@ -423,7 +457,7 @@ Do not add `use-package projectile`, compatibility wrappers, custom project comm
 
 - [ ] **Step 5: Replace the inline Projectile block in `config.org` at the same orchestration position**
 
-Replace the current `** Projectile` section with:
+Replace the entire current `** Projectile` section with:
 
 ```org
 ** Project
@@ -464,7 +498,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: PASS. In particular, `C-c p`, `s-p`, and `C-x p` resolve to the same built-in `project-prefix-map`, and `config.org` has exactly one native project config owner with no inline Projectile runtime forms.
+Expected: PASS. `C-c p`, `s-p`, and `C-x p` resolve to the same built-in `project-prefix-map`, and `config.org` has exactly one native project config owner with no inline Projectile runtime forms.
 
 - [ ] **Step 8: Commit the native project UI/config boundary**
 
@@ -514,7 +548,7 @@ In `.github/workflows/emacs-tests.yml`:
 
 1. Add `lisp/p3-config-project.el` to `Byte-compile extracted modules`, immediately after `lisp/p3-project.el`.
 
-2. Add a smoke step after package installation and before the existing Python smoke:
+2. Add this smoke step before the existing Python smoke:
 
 ```yaml
       - name: Smoke-load Project configuration boundary
@@ -566,7 +600,7 @@ emacs -Q --batch -L lisp \
   -f ert-run-tests-batch-and-exit
 ```
 
-Expected: PASS on the current platform. `p3-project-windows-test.el` is deliberately not used as proof on non-Windows; the native Windows PR workflow is the authoritative gate for that contract.
+Expected: PASS on the current platform. `p3-project-windows-test.el` is not proof on non-Windows; the native Windows PR workflow remains authoritative for that contract.
 
 - [ ] **Step 5: Commit the CI/platform durability changes**
 
@@ -584,7 +618,7 @@ git commit -m "Verify native project boundary across platforms"
 
 **Files:**
 - Verify all files changed in Tasks 1–4.
-- No production changes should be introduced after the final PR-triggering commit unless verification exposes a real defect.
+- Do not introduce production changes after the final PR-triggering commit unless verification demonstrates a real defect.
 
 **Interfaces:**
 - Consumes: the complete implementation and tests from Tasks 1–4.
@@ -625,34 +659,82 @@ Expected:
 - Ubuntu compile/smoke/full-suite coverage;
 - Windows path/compile/test coverage.
 
-Also verify the order in `config.org` remains:
+Verify `config.org` ordering remains:
 
 ```text
 Org -> Org-roam -> Poly-R -> Presentation -> Project -> Python -> Rainbow -> Shell
 ```
 
-- [ ] **Step 3: Run the full local Ubuntu-equivalent ERT command before opening the PR**
+- [ ] **Step 3: Run the full Ubuntu-equivalent ERT suite before opening the PR**
 
-Run the exact `Run ERT test suite` command from `.github/workflows/emacs-tests.yml`, including the new `test/p3-config-project-test.el` entry.
+Run:
 
-Expected: zero unexpected failures. Skips are acceptable only where already intentional for unavailable platform/tool contracts.
+```bash
+emacs -Q --batch \
+  -L lisp \
+  -l test/p3-config-loader-test.el \
+  -l test/p3-config-test.el \
+  -l test/p3-config-ess-test.el \
+  -l test/p3-project-test.el \
+  -l test/p3-config-project-test.el \
+  -l test/p3-core-test.el \
+  -l test/p3-platform-test.el \
+  -l test/p3-config-python-test.el \
+  -l test/p3-python-test.el \
+  -l test/p3-terminal-test.el \
+  -l test/p3-config-terminal-test.el \
+  -l test/p3-ess-test.el \
+  -l test/p3-gptel-test.el \
+  -l test/p3-config-gptel-test.el \
+  -l test/p3-r-tools-test.el \
+  -l test/p3-org-test.el \
+  -l test/p3-config-org-test.el \
+  -l test/p3-org-roam-test.el \
+  -l test/p3-config-org-roam-test.el \
+  -l test/p3-org-present-test.el \
+  -l test/p3-config-org-present-test.el \
+  -l test/p3-org-export-test.el \
+  -l test/p3-commands-test.el \
+  -l test/p3-git-test.el \
+  -f ert-run-tests-batch-and-exit
+```
+
+Expected: zero unexpected failures. Existing intentional skips for unavailable platform/tool contracts are acceptable.
 
 - [ ] **Step 4: Open PR #19 only after static/local verification is clean**
 
-PR title:
+Use title:
 
 ```text
 Retire Projectile in favor of project.el
 ```
 
-PR body must summarize:
-- Projectile removed from active runtime/configuration;
-- native `project-prefix-map` now owns `C-c p` and `s-p` while `C-x p` remains native;
-- new R projects use `*.Rproj` and stop creating `.projectile`;
-- legacy `.projectile` remains a compatibility marker;
-- native `project.el` switch/list semantics are intentionally not made Projectile-compatible;
-- one Emacs restart is required after adoption if `projectile-mode` is already running;
-- do not merge without explicit approval.
+Use body:
+
+```markdown
+## Summary
+
+- remove Projectile from active Emacs configuration and project identity/runtime policy
+- bind `C-c p` and `s-p` directly to the built-in `project-prefix-map`; leave native `C-x p` unchanged
+- use `*.Rproj` as the forward marker for generated R projects and stop creating `.projectile`
+- retain `.projectile` only as a legacy `project.el` compatibility marker
+- preserve existing ESS, Python, R-tool, terminal, and Windows project-root contracts
+
+## Intentional transition behavior
+
+- native `project.el` switching and remembered-project behavior is not made Projectile-compatible
+- global project aliases use the global map rather than a Projectile minor-mode map
+- if `projectile-mode` is already active when this change is adopted, restart Emacs once; `C-c r` alone is not expected to retire that existing session state
+- no Projectile cache importer, runtime shutdown shim, or package uninstall mechanism is added
+
+## Verification
+
+- focused ERT coverage proves legacy `.projectile` compatibility, `*.Rproj` project detection, nested `project-files` boundaries, native project prefix bindings, and R scaffold output
+- Ubuntu CI byte-compiles and smoke-loads the native project config owner and runs the full ERT suite
+- Windows CI exercises `*.Rproj` marker detection/file enumeration after normal Rtools/MSYS2 setup and includes the new config owner in durable path/compile/test coverage
+
+Do not merge without explicit approval.
+```
 
 Opening the PR is the single intended trigger for the final Ubuntu and Windows Actions gate.
 

--- a/docs/superpowers/specs/2026-09-05-retire-projectile-design.md
+++ b/docs/superpowers/specs/2026-09-05-retire-projectile-design.md
@@ -52,6 +52,8 @@ After this change, no active source configuration should load, enable, configure
 
 The change does not attempt to uninstall an already-installed Projectile package from a user's package directory. Package retirement means it is no longer part of the configuration or startup path.
 
+An already-running Emacs session is a special transition case. Because `projectile-mode` is currently enabled as a global minor mode, removing its configuration does not by itself disable that already-active mode or remove its minor-mode keymap/provider state during `C-c r`. The retirement is therefore considered complete only after one Emacs restart following adoption of this change. Do not add permanent runtime cleanup code merely to make the transition hot-reloadable.
+
 ### Native project command interface
 
 Add `lisp/p3-config-project.el` as the declarative owner of the user-facing native project bindings.
@@ -63,7 +65,13 @@ It will require built-in `project` and bind:
 
 The standard built-in `C-x p` binding remains untouched.
 
-This preserves the two existing high-level entry keys while replacing the implementation behind them with built-in `project.el` commands. No compatibility wrapper command or copied Projectile keymap is introduced.
+This preserves the two existing high-level entry keys while replacing the implementation behind them with built-in `project.el` commands. It does not preserve Projectile's command semantics. Native `project-switch-project`, `project-find-file`, remembered-project behavior, and the rest of `project-prefix-map` should retain their built-in behavior rather than be configured to imitate Projectile.
+
+In particular, users may initially see a different switch-project flow and fewer remembered projects. That is an intentional migration cost, not a regression to be papered over with compatibility wrappers.
+
+The new aliases live in the global map rather than Projectile's global minor-mode map, so their keymap precedence is slightly lower than before. `C-c p` is a user-reserved prefix and `s-p` is an explicit personal binding; accept this simplification unless an actual conflict is demonstrated. Do not introduce another global minor mode merely to reproduce Projectile's keymap precedence.
+
+No compatibility wrapper command or copied Projectile keymap is introduced.
 
 `config.org` will load `p3-config-project` in the same relative location currently occupied by the Projectile block: after Presentation and before Python. That avoids unrelated startup-order changes.
 
@@ -71,7 +79,7 @@ This preserves the two existing high-level entry keys while replacing the implem
 
 Newly generated R projects should stop creating an empty `.projectile` file.
 
-Instead, add `"*.Rproj"` to `project-vc-extra-root-markers` in `p3-project.el`. Emacs 29's `project.el` explicitly supports glob patterns in `project-vc-extra-root-markers`, so the existing `<project-name>.Rproj` file can define the project boundary without a Projectile-specific sentinel.
+Instead, add `"*.Rproj"` to `project-vc-extra-root-markers` in `p3-project.el`. Emacs 29's `project.el` supports glob patterns in `project-vc-extra-root-markers`, so the existing `<project-name>.Rproj` file can define the project boundary without a Projectile-specific sentinel.
 
 This preserves the important current semantic: an R analysis directory can define an inner project boundary even when it lives inside a larger Git repository.
 
@@ -91,7 +99,7 @@ A later cleanup can remove `.projectile` support only after there is evidence th
 
 Do not migrate Projectile's remembered-project database into `project.el`.
 
-Native `project.el` maintains its own known-project list. Users may initially see fewer remembered projects in `project-switch-project`; visiting or selecting projects through native project commands will repopulate that list normally.
+Native `project.el` maintains its own known-project list. Users may initially see fewer remembered projects in `project-switch-project`; selecting recognized projects through native project commands will repopulate that list normally. Arbitrary unmarked directories should not be treated as persistently known projects merely to mimic Projectile.
 
 Writing a one-off Projectile cache importer would add compatibility machinery for a framework being removed and is outside this design.
 
@@ -111,9 +119,11 @@ This change must not:
 - change terminal root or placement behavior;
 - add project tabs or a new project UI package;
 - add a custom `project.el` backend;
+- reproduce Projectile command semantics on top of `project.el`;
 - migrate Projectile's remembered-project database;
 - uninstall packages from user package directories;
 - rename or delete existing `.projectile` files;
+- add persistent Projectile shutdown/cleanup machinery for already-running sessions;
 - modify historical specs/plans to pretend Projectile was never part of the migration path.
 
 The supported Emacs baseline remains 29+.
@@ -126,6 +136,8 @@ Marker-defined non-VCS projects must still be detectable and enumerable after th
 
 Windows coverage should exercise the forward marker (`*.Rproj`) rather than only the legacy `.projectile` marker, while ordinary cross-platform tests continue to prove legacy `.projectile` compatibility.
 
+The Windows workflow must also remain durable for future isolated edits to the new project config owner. Add both `lisp/p3-config-project.el` and its focused test file to `.github/workflows/windows-platform-tests.yml` path filters, compile the owner in the Windows byte-compilation gate, and load its focused test where the existing Windows architecture tests run.
+
 No new Windows-specific project implementation should be introduced.
 
 ## Tests
@@ -137,20 +149,23 @@ Implementation must establish these invariants:
 3. `C-c p` and `s-p` resolve to native `project-prefix-map`; standard `C-x p` remains native.
 4. A normal Git repository is recognized by `project.el`.
 5. An `*.Rproj`-only project is recognized from a descendant directory.
-6. A nested `*.Rproj` marker inside an outer Git repository resolves to the inner project root.
+6. A nested `*.Rproj` marker inside an outer Git repository resolves to the inner project root, and `project-files` for that project includes files inside the inner project while excluding sibling files that belong only to the outer repository.
 7. A legacy `.projectile` marker still defines a project root.
 8. Newly generated R projects contain the normal `.Rproj` file and no longer create `.projectile`.
 9. Existing ESS, Python, R-tool, and terminal tests continue to prove shared `p3/project-root` consumption without behavioral drift.
 10. Native Windows tests detect and enumerate an `*.Rproj`-defined project after normal platform setup.
 11. `p3-config-project.el` byte-compiles with warnings treated as errors and has a focused smoke/boundary test.
-12. The aggregate config architecture tests reflect the new project config owner and the removal of inline Projectile configuration.
-13. The full ERT suite remains green.
+12. The Windows workflow path filters, compile step, and architecture-test load list include the new project config owner and focused test.
+13. The aggregate config architecture tests reflect the new project config owner and the removal of inline Projectile configuration.
+14. The full ERT suite remains green.
+
+The transition note must also be verified manually/documentarily: after adopting the merged change, restart Emacs once rather than relying on `C-c r` to disable an already-running Projectile session.
 
 Use static/local review and focused tests first. Run the normal Ubuntu and Windows CI workflows as one coherent final gate rather than as an iterative diagnostic loop.
 
 ## Expected result
 
-After this change:
+After this change and one Emacs restart:
 
 - `project.el` is the only project framework in active use;
 - `p3-project.el` owns early project semantics and marker policy;

--- a/docs/superpowers/specs/2026-09-05-retire-projectile-design.md
+++ b/docs/superpowers/specs/2026-09-05-retire-projectile-design.md
@@ -1,0 +1,161 @@
+# Retire Projectile in Favor of project.el
+
+## Goal
+
+Remove Projectile from the active Emacs architecture now that built-in `project.el` is already the sole source of P3 project identity. Preserve the project boundaries and user workflows that still matter without retaining a second project framework.
+
+This change is a cleanup of the project interaction layer, not a redesign of project semantics. ESS, Python, R tooling, and terminal behavior must continue to consume `p3/project-root` exactly as they do today.
+
+## Current state
+
+`p3-project.el` is loaded from `init.el` before the literate configuration and establishes native project semantics. It currently:
+
+- requires built-in `project`;
+- adds `.projectile` to `project-vc-extra-root-markers`;
+- removes Projectile's `project-projectile` provider whenever `projectile-mode` runs;
+- exposes `p3/project-root` and `p3/use-project-root-as-default-dir`.
+
+`config.org` still enables Projectile only as a command/UI layer. It binds `s-p` and `C-c p` to `projectile-command-map`, enables `projectile-mode`, and registers an R project type.
+
+The earlier project.el foundation deliberately retained Projectile temporarily. This change completes that migration.
+
+## Design
+
+### Native project identity remains authoritative
+
+`p3-project.el` remains the startup-critical project identity owner and stays required from `init.el` before normal configuration loading.
+
+The helper contract remains unchanged:
+
+- `p3/project-root` delegates to `project-current` and `project-root`;
+- callers that fall back to `default-directory` keep doing so;
+- no custom project backend is introduced.
+
+### Remove the Projectile runtime
+
+Delete all active Projectile configuration:
+
+- the `use-package projectile` declaration;
+- `projectile-mode` activation;
+- `projectile-command-map` bindings;
+- `p3/projectile-r-project-file-p`;
+- Projectile R project-type registration.
+
+Remove the Projectile-specific defensive policy from `p3-project.el`:
+
+- the `project-projectile` declaration;
+- `p3/project-keep-native-provider`;
+- the `projectile-mode-hook` registration;
+- the one-time provider cleanup call.
+
+After this change, no active source configuration should load, enable, configure, or call Projectile.
+
+The change does not attempt to uninstall an already-installed Projectile package from a user's package directory. Package retirement means it is no longer part of the configuration or startup path.
+
+### Native project command interface
+
+Add `lisp/p3-config-project.el` as the declarative owner of the user-facing native project bindings.
+
+It will require built-in `project` and bind:
+
+- `C-c p` to `project-prefix-map`;
+- `s-p` to `project-prefix-map`.
+
+The standard built-in `C-x p` binding remains untouched.
+
+This preserves the two existing high-level entry keys while replacing the implementation behind them with built-in `project.el` commands. No compatibility wrapper command or copied Projectile keymap is introduced.
+
+`config.org` will load `p3-config-project` in the same relative location currently occupied by the Projectile block: after Presentation and before Python. That avoids unrelated startup-order changes.
+
+### Forward project marker for R projects
+
+Newly generated R projects should stop creating an empty `.projectile` file.
+
+Instead, add `"*.Rproj"` to `project-vc-extra-root-markers` in `p3-project.el`. Emacs 29's `project.el` explicitly supports glob patterns in `project-vc-extra-root-markers`, so the existing `<project-name>.Rproj` file can define the project boundary without a Projectile-specific sentinel.
+
+This preserves the important current semantic: an R analysis directory can define an inner project boundary even when it lives inside a larger Git repository.
+
+The R scaffolder will therefore remove `(:path ".projectile" :content "")` from `p3-r--common-project-files` and continue creating the existing `.Rproj` file unchanged.
+
+### Legacy `.projectile` compatibility
+
+Keep `.projectile` in `project-vc-extra-root-markers` for now.
+
+This is intentionally a compatibility marker only. Existing projects may depend on it to define non-VCS or nested project boundaries. Removing support in the same change that retires the Projectile package could silently change project roots.
+
+No migration script, bulk repository rewrite, warning system, or automatic marker replacement is added. Existing `.projectile` files continue to work; new generated R projects stop creating them.
+
+A later cleanup can remove `.projectile` support only after there is evidence that no remaining projects require it.
+
+### Project list behavior
+
+Do not migrate Projectile's remembered-project database into `project.el`.
+
+Native `project.el` maintains its own known-project list. Users may initially see fewer remembered projects in `project-switch-project`; visiting or selecting projects through native project commands will repopulate that list normally.
+
+Writing a one-off Projectile cache importer would add compatibility machinery for a framework being removed and is outside this design.
+
+### Keybinding atlas
+
+Add a compact `Project` section to `p3/keybinding-sections` documenting the native project entry points, centered on `C-c p` / `C-x p`.
+
+Do not enumerate every command under the native project prefix. The atlas should remain a concise workflow guide rather than duplicate Emacs help.
+
+## Compatibility and non-goals
+
+This change must not:
+
+- alter `p3/project-root` semantics beyond adding `*.Rproj` as a recognized native marker;
+- change ESS process/session behavior;
+- change Python environment selection except insofar as the same project root continues to be consumed;
+- change terminal root or placement behavior;
+- add project tabs or a new project UI package;
+- add a custom `project.el` backend;
+- migrate Projectile's remembered-project database;
+- uninstall packages from user package directories;
+- rename or delete existing `.projectile` files;
+- modify historical specs/plans to pretend Projectile was never part of the migration path.
+
+The supported Emacs baseline remains 29+.
+
+## Windows contract
+
+The existing Windows project contract remains mandatory.
+
+Marker-defined non-VCS projects must still be detectable and enumerable after the existing Rtools/MSYS2 platform setup provides a Unix-compatible `find` program. This is particularly important because native `project.el` file enumeration for marker-only projects relies on that external `find` path on Windows.
+
+Windows coverage should exercise the forward marker (`*.Rproj`) rather than only the legacy `.projectile` marker, while ordinary cross-platform tests continue to prove legacy `.projectile` compatibility.
+
+No new Windows-specific project implementation should be introduced.
+
+## Tests
+
+Implementation must establish these invariants:
+
+1. Active configuration contains no Projectile package declaration, activation, command-map binding, project-type registration, or `project-projectile` provider policy.
+2. `p3-project.el` remains loaded from `init.el` before the literate config and continues to own project semantics.
+3. `C-c p` and `s-p` resolve to native `project-prefix-map`; standard `C-x p` remains native.
+4. A normal Git repository is recognized by `project.el`.
+5. An `*.Rproj`-only project is recognized from a descendant directory.
+6. A nested `*.Rproj` marker inside an outer Git repository resolves to the inner project root.
+7. A legacy `.projectile` marker still defines a project root.
+8. Newly generated R projects contain the normal `.Rproj` file and no longer create `.projectile`.
+9. Existing ESS, Python, R-tool, and terminal tests continue to prove shared `p3/project-root` consumption without behavioral drift.
+10. Native Windows tests detect and enumerate an `*.Rproj`-defined project after normal platform setup.
+11. `p3-config-project.el` byte-compiles with warnings treated as errors and has a focused smoke/boundary test.
+12. The aggregate config architecture tests reflect the new project config owner and the removal of inline Projectile configuration.
+13. The full ERT suite remains green.
+
+Use static/local review and focused tests first. Run the normal Ubuntu and Windows CI workflows as one coherent final gate rather than as an iterative diagnostic loop.
+
+## Expected result
+
+After this change:
+
+- `project.el` is the only project framework in active use;
+- `p3-project.el` owns early project semantics and marker policy;
+- `p3-config-project.el` owns native project keybindings;
+- Git and `*.Rproj` are the forward project-boundary mechanisms;
+- `.projectile` remains only as legacy compatibility;
+- newly generated R projects no longer contain Projectile-specific files;
+- no Projectile compatibility layer remains in runtime code.

--- a/init.el
+++ b/init.el
@@ -73,6 +73,10 @@
   (expand-file-name "lisp" user-emacs-directory))
 (add-to-list 'load-path p3/lisp-directory)
 
+;; Local .elc files are machine-local and may lag tracked source after an update.
+;; Prefer newer source before requiring any local startup library.
+(setq load-prefer-newer t)
+
 ;; Establish native project semantics before the literate config or any
 ;; project-aware package has a chance to populate `project.el' caches.
 (require 'p3-project)

--- a/lisp/p3-commands.el
+++ b/lisp/p3-commands.el
@@ -14,6 +14,9 @@
      ("C-c ?" . "open this atlas")
      ("C-h B" . "show context-sensitive bindings")
      ("M-o" . "select window"))
+    ("Project"
+     ("C-c p / C-x p" . "native project commands")
+     ("s-p" . "native project commands"))
     ("R / ESS"
      ("C-c R" . "R project, templates, and tools")
      ("C-c i" . "evaluate library section")

--- a/lisp/p3-config-project.el
+++ b/lisp/p3-config-project.el
@@ -1,0 +1,10 @@
+;;; p3-config-project.el --- Native project configuration -*- lexical-binding: t; -*-
+
+(require 'project)
+
+(global-set-key (kbd "C-c p") project-prefix-map)
+(global-set-key (kbd "s-p") project-prefix-map)
+
+(provide 'p3-config-project)
+
+;;; p3-config-project.el ends here

--- a/lisp/p3-project.el
+++ b/lisp/p3-project.el
@@ -2,22 +2,11 @@
 
 (require 'project)
 
-(declare-function project-projectile "projectile" (directory))
-
 (unless (boundp 'project-vc-extra-root-markers)
   (error "P3 project support requires Emacs 29 or newer"))
 
-(add-to-list 'project-vc-extra-root-markers ".projectile")
-
-(defun p3/project-keep-native-provider ()
-  "Keep Projectile from overriding native `project.el' project discovery."
-  (remove-hook 'project-find-functions #'project-projectile))
-
-;; Projectile intentionally registers itself as a project.el provider whenever
-;; `projectile-mode' changes state.  Keep its UI and commands, but remove that
-;; provider after the mode has finished updating its hooks.
-(add-hook 'projectile-mode-hook #'p3/project-keep-native-provider)
-(p3/project-keep-native-provider)
+(dolist (marker '(".projectile" "*.Rproj"))
+  (add-to-list 'project-vc-extra-root-markers marker))
 
 (defun p3/project-root ()
   "Return the current built-in `project.el' root, if any."

--- a/lisp/p3-r-tools.el
+++ b/lisp/p3-r-tools.el
@@ -56,7 +56,6 @@
 (defconst p3-r--common-project-files
   '((:path "{{project-name}}.Rproj" :template "project.Rproj.tmpl")
     (:path ".gitignore" :template "gitignore.tmpl")
-    (:path ".projectile" :content "")
     (:path "R/01_prepareData.R" :template "script.R.tmpl"
            :title "Preprocess data")
     (:path "R/02_computeResults.R" :template "script.R.tmpl"

--- a/lisp/p3-r-tools.el
+++ b/lisp/p3-r-tools.el
@@ -428,7 +428,6 @@ Use the active region when available; otherwise process the entire buffer."
 (defalias 'p3/ess-library-and-source #'p3-r-evaluate-library-section)
 (defalias 'write-to-read-conversion-multi #'p3-r-write-to-read)
 (defalias 'p3/archive-r-scripts #'p3-r-archive-scripts)
-(defalias 'p3/projectile-open-r-helper-functions-file #'p3-r-open-helper-file)
 
 (defun p3/generate-roxygen-header (title &optional minimal)
   "Return a rendered R script header for TITLE.

--- a/test/p3-commands-test.el
+++ b/test/p3-commands-test.el
@@ -43,6 +43,14 @@
 (ert-deftest p3-commands-keybinding-atlas-keeps-global-section ()
   (should (equal (caar p3/keybinding-sections) "Global")))
 
+(ert-deftest p3-commands-keybinding-atlas-documents-native-project-prefix ()
+  (let ((section (assoc "Project" p3/keybinding-sections)))
+    (should section)
+    (should (equal (cdr (assoc "C-c p / C-x p" (cdr section)))
+                   "native project commands"))
+    (should (equal (cdr (assoc "s-p" (cdr section)))
+                   "native project commands"))))
+
 (provide 'p3-commands-test)
 
 ;;; p3-commands-test.el ends here

--- a/test/p3-config-project-test.el
+++ b/test/p3-config-project-test.el
@@ -1,0 +1,53 @@
+;;; p3-config-project-test.el --- Native project config boundary tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'project)
+(require 'p3-config-loader)
+
+(defconst p3-config-project-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name))))
+  "Root of the Emacs configuration under test.")
+
+(defun p3-config-project-test--contents (relative)
+  "Return contents of repository file RELATIVE."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name relative p3-config-project-test--root))
+    (buffer-string)))
+
+(ert-deftest p3-config-project-binds-native-project-prefixes ()
+  (let ((p3/config-lisp-directory
+         (expand-file-name "lisp" p3-config-project-test--root))
+        (old-c-c-p (lookup-key global-map (kbd "C-c p")))
+        (old-s-p (lookup-key global-map (kbd "s-p"))))
+    (unwind-protect
+        (progn
+          (p3/config-load-module 'p3-config-project)
+          (should (featurep 'p3-config-project))
+          (should (eq (lookup-key global-map (kbd "C-c p"))
+                      project-prefix-map))
+          (should (eq (lookup-key global-map (kbd "s-p"))
+                      project-prefix-map))
+          (should (eq (lookup-key global-map (kbd "C-x p"))
+                      project-prefix-map)))
+      (define-key global-map (kbd "C-c p") old-c-c-p)
+      (define-key global-map (kbd "s-p") old-s-p))))
+
+(ert-deftest p3-config-project-config-org-has-one-native-owner ()
+  (let ((contents (p3-config-project-test--contents "config.org")))
+    (should
+     (string-match-p
+      (regexp-quote "(p3/config-load-module 'p3-config-project)")
+      contents))
+    (dolist (forbidden '("(use-package projectile"
+                          "p3/projectile-r-project-file-p"
+                          "projectile-command-map"
+                          "projectile-register-project-type"
+                          "(projectile-mode +1)"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(provide 'p3-config-project-test)
+
+;;; p3-config-project-test.el ends here

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -93,7 +93,7 @@
                               contents)))
     (dolist (module '(p3-config-ess p3-config-gptel p3-config-org
                       p3-config-org-roam p3-config-org-present
-                      p3-config-python p3-config-terminal))
+                      p3-config-project p3-config-python p3-config-terminal))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -170,38 +170,43 @@
          (poly-r (p3-config-test--position "(use-package poly-R" contents))
          (present (p3-config-test--position
                    "(p3/config-load-module 'p3-config-org-present)" contents))
-         (projectile (p3-config-test--position "(use-package projectile" contents))
+         (project-config
+          (p3-config-test--position
+           "(p3/config-load-module 'p3-config-project)" contents))
          (python (p3-config-test--position
                   "(p3/config-load-module 'p3-config-python)" contents)))
     (should (< org roam))
     (should (< roam poly-r))
     (should (< poly-r present))
-    (should (< present projectile))
-    (should (< projectile python))))
+    (should (< present project-config))
+    (should (< project-config python))))
 
 (ert-deftest p3-config-python-preserves-subsystem-timing ()
   (let* ((contents (p3-config-test--contents "config.org"))
          (flycheck (p3-config-test--position "(use-package flycheck" contents))
-         (projectile (p3-config-test--position "(use-package projectile" contents))
+         (project-config
+          (p3-config-test--position
+           "(p3/config-load-module 'p3-config-project)" contents))
          (python (p3-config-test--position
                   "(p3/config-load-module 'p3-config-python)" contents))
          (rainbow (p3-config-test--position "(use-package rainbow-mode" contents))
          (terminal (p3-config-test--position
                     "(p3/config-load-module 'p3-config-terminal)" contents)))
-    (should (< flycheck projectile))
-    (should (< projectile python))
+    (should (< flycheck project-config))
+    (should (< project-config python))
     (should (< python rainbow))
     (should (< rainbow terminal))))
 
-(ert-deftest p3-config-org-source-loads-twelve-config-modules ()
+(ert-deftest p3-config-org-source-loads-thirteen-config-modules ()
   (let ((contents (p3-config-test--contents "config.org")))
-    (should (= 12
+    (should (= 13
                (p3-config-test--count-occurrences
                 "(p3/config-load-module 'p3-config-" contents)))
     (dolist (module '(p3-config-base p3-config-editing p3-config-completion
                       p3-config-ess p3-config-gptel p3-config-org
-                      p3-config-org-roam p3-config-org-present p3-config-python
-                      p3-config-terminal p3-config-workspace p3-config-git))
+                      p3-config-org-roam p3-config-org-present p3-config-project
+                      p3-config-python p3-config-terminal p3-config-workspace
+                      p3-config-git))
       (should
        (string-match-p
         (regexp-quote (format "(p3/config-load-module '%s)" module))
@@ -270,7 +275,12 @@
                "(p3/windows-configure-shell)"
                "(use-package vterm"
                "(use-package gptel"
-               "(use-package p3-gptel"))
+               "(use-package p3-gptel"
+               "(use-package projectile"
+               "(defun p3/projectile-r-project-file-p"
+               "projectile-command-map"
+               "projectile-register-project-type"
+               "(projectile-mode +1)"))
       (should-not (string-match-p (regexp-quote implementation) contents)))
     (dolist (package '(dashboard which-key vertico company undo-tree super-save
                        multiple-cursors magit git-gutter-fringe+ transpose-frame
@@ -298,6 +308,17 @@
      (string-match-p
       (regexp-quote "(keymap-global-set \"C-c R\"") contents))
     (should (< ess r-program))))
+
+(ert-deftest p3-config-project-orchestration-has-one-owner ()
+  (let* ((contents (p3-config-test--contents "config.org"))
+         (owner "(p3/config-load-module 'p3-config-project)"))
+    (should (= 1 (p3-config-test--count-occurrences owner contents)))
+    (dolist (forbidden '("(use-package projectile"
+                          "p3/projectile-r-project-file-p"
+                          "projectile-command-map"
+                          "projectile-register-project-type"
+                          "(projectile-mode +1)"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
 
 (ert-deftest p3-config-python-orchestration-has-one-owner ()
   (let* ((contents (p3-config-test--contents "config.org"))

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -25,6 +25,38 @@
              (lambda (_project) "/tmp/native-project/")))
     (should (equal (p3/project-root) "/tmp/native-project/"))))
 
+(ert-deftest p3-project-plain-git-project-is-detected-from-descendant ()
+  (skip-unless (executable-find "git"))
+  (let* ((root (make-temp-file "p3-project-git-" t))
+         (child (expand-file-name "src/subdir" root)))
+    (unwind-protect
+        (progn
+          (should
+           (zerop (call-process "git" nil nil nil "-C" root "init" "-q")))
+          (make-directory child t)
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
+(ert-deftest p3-project-init-prefers-newer-source-before-early-local-requires ()
+  (let ((path (expand-file-name "init.el" p3-project-test--root)))
+    (with-temp-buffer
+      (insert-file-contents path)
+      (let* ((contents (buffer-string))
+             (newer (string-match
+                     (regexp-quote "(setq load-prefer-newer t)") contents))
+             (project (string-match
+                       (regexp-quote "(require 'p3-project)") contents))
+             (loader (string-match
+                      (regexp-quote "(require 'p3-config-loader)") contents)))
+        (should newer)
+        (should project)
+        (should loader)
+        (should (< newer project))
+        (should (< newer loader))))))
+
 (ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-marker-" t))
          (child (expand-file-name "R/subdir" root)))

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -25,30 +25,6 @@
              (lambda (_project) "/tmp/native-project/")))
     (should (equal (p3/project-root) "/tmp/native-project/"))))
 
-(ert-deftest p3-project-projectile-mode-hook-restores-native-provider ()
-  (skip-unless (executable-find "git"))
-  (let ((root (make-temp-file "p3-project-provider-" t)))
-    (unwind-protect
-        (progn
-          (should
-           (zerop (call-process "git" nil nil nil "-C" root "init" "-q")))
-          (let ((project-find-functions '(project-projectile project-try-vc))
-                (default-directory root))
-            (cl-letf (((symbol-function 'project-projectile)
-                       (lambda (_directory)
-                         (ert-fail
-                          "Projectile must not provide P3 project identity"))))
-              (run-hooks 'projectile-mode-hook)
-              (should-not (memq #'project-projectile project-find-functions))
-              (should (memq #'project-try-vc project-find-functions))
-              (let ((project (project-current nil)))
-                (should project)
-                (should
-                 (equal (p3-project-test--canonical-directory
-                         (project-root project))
-                        (p3-project-test--canonical-directory root)))))))
-      (delete-directory root t))))
-
 (ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-marker-" t))
          (child (expand-file-name "R/subdir" root)))

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -49,7 +49,7 @@
                         (p3-project-test--canonical-directory root)))))))
       (delete-directory root t))))
 
-(ert-deftest p3-project-marker-only-project-is-detected-from-descendant ()
+(ert-deftest p3-project-legacy-projectile-marker-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-marker-" t))
          (child (expand-file-name "R/subdir" root)))
     (unwind-protect
@@ -62,22 +62,60 @@
                     (p3-project-test--canonical-directory root)))))
       (delete-directory root t))))
 
-(ert-deftest p3-project-inner-marker-wins-over-outer-git-root ()
+(ert-deftest p3-project-rproj-marker-only-project-is-detected-from-descendant ()
+  (let* ((root (make-temp-file "p3-project-rproj-" t))
+         (child (expand-file-name "R/subdir" root)))
+    (unwind-protect
+        (progn
+          (make-directory child t)
+          (with-temp-file (expand-file-name "analysis.Rproj" root))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory root)))))
+      (delete-directory root t))))
+
+(ert-deftest p3-project-inner-rproj-marker-bounds-project-files ()
   (skip-unless (executable-find "git"))
-  (let* ((outer (make-temp-file "p3-project-outer-" t))
+  (let* ((outer (make-temp-file "p3-project-outer-rproj-" t))
          (inner (expand-file-name "analysis" outer))
-         (child (expand-file-name "R" inner)))
+         (child (expand-file-name "R/subdir" inner))
+         (inner-file (expand-file-name "R/inside.R" inner))
+         (outer-file (expand-file-name "outside.R" outer)))
     (unwind-protect
         (progn
           (should
            (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
           (make-directory child t)
-          (with-temp-file (expand-file-name ".projectile" inner))
-          (let ((default-directory child))
+          (with-temp-file (expand-file-name "analysis.Rproj" inner))
+          (with-temp-file inner-file
+            (insert "inside <- TRUE\n"))
+          (with-temp-file outer-file
+            (insert "outside <- TRUE\n"))
+          (let* ((default-directory child)
+                 (project (project-current nil))
+                 (files (mapcar #'file-truename (project-files project))))
+            (should project)
             (should
-             (equal (p3-project-test--canonical-directory (p3/project-root))
-                    (p3-project-test--canonical-directory inner)))))
+             (equal (p3-project-test--canonical-directory (project-root project))
+                    (p3-project-test--canonical-directory inner)))
+            (should (member (file-truename inner-file) files))
+            (should-not (member (file-truename outer-file) files))))
       (delete-directory outer t))))
+
+(ert-deftest p3-project-source-has-no-projectile-runtime-policy ()
+  (let ((path (expand-file-name "lisp/p3-project.el" p3-project-test--root)))
+    (with-temp-buffer
+      (insert-file-contents path)
+      (let ((contents (buffer-string)))
+        (dolist (forbidden '("project-projectile"
+                            "projectile-mode-hook"
+                            "p3/project-keep-native-provider"))
+          (should-not (string-match-p (regexp-quote forbidden) contents)))
+        (should (string-match-p
+                 (regexp-quote "\".projectile\"") contents))
+        (should (string-match-p
+                 (regexp-quote "\"*.Rproj\"") contents))))))
 
 (ert-deftest p3-project-default-directory-is-buffer-local ()
   (with-temp-buffer

--- a/test/p3-project-test.el
+++ b/test/p3-project-test.el
@@ -38,6 +38,23 @@
                     (p3-project-test--canonical-directory root)))))
       (delete-directory root t))))
 
+(ert-deftest p3-project-legacy-projectile-marker-wins-over-outer-git-root ()
+  (skip-unless (executable-find "git"))
+  (let* ((outer (make-temp-file "p3-project-legacy-outer-" t))
+         (inner (expand-file-name "analysis" outer))
+         (child (expand-file-name "R" inner)))
+    (unwind-protect
+        (progn
+          (should
+           (zerop (call-process "git" nil nil nil "-C" outer "init" "-q")))
+          (make-directory child t)
+          (with-temp-file (expand-file-name ".projectile" inner))
+          (let ((default-directory child))
+            (should
+             (equal (p3-project-test--canonical-directory (p3/project-root))
+                    (p3-project-test--canonical-directory inner)))))
+      (delete-directory outer t))))
+
 (ert-deftest p3-project-rproj-marker-only-project-is-detected-from-descendant ()
   (let* ((root (make-temp-file "p3-project-rproj-" t))
          (child (expand-file-name "R/subdir" root)))

--- a/test/p3-project-windows-test.el
+++ b/test/p3-project-windows-test.el
@@ -35,7 +35,7 @@
           (should (file-readable-p bash))
           (should (file-readable-p find))
           (make-directory child t)
-          (with-temp-file (expand-file-name ".projectile" root))
+          (with-temp-file (expand-file-name "windows-test.Rproj" root))
           (with-temp-file data-file
             (insert "x <- 1\n"))
           (p3/windows-configure-rtools)

--- a/test/p3-r-tools-test.el
+++ b/test/p3-r-tools-test.el
@@ -68,7 +68,7 @@
     (let ((root (expand-file-name "analysis-demo" parent)))
       (p3-r-new-project root 'analysis)
       (should (file-exists-p (expand-file-name "analysis-demo.Rproj" root)))
-      (should (file-exists-p (expand-file-name ".projectile" root)))
+      (should-not (file-exists-p (expand-file-name ".projectile" root)))
       (should (file-exists-p (expand-file-name "R/01_prepareData.R" root)))
       (should (file-exists-p (expand-file-name "R/utils.R" root)))
       (should-not (file-exists-p (expand-file-name "_targets.R" root)))

--- a/test/p3-r-tools-test.el
+++ b/test/p3-r-tools-test.el
@@ -148,6 +148,9 @@
   (dolist (key '("p" "h" "w" "c" "s" "a" "m" "d" "l" "v" "r" "f"))
     (should (commandp (keymap-lookup p3-r-command-map key)))))
 
+(ert-deftest p3-r-tools-does-not-retain-projectile-helper-alias ()
+  (should-not (fboundp 'p3/projectile-open-r-helper-functions-file)))
+
 (provide 'p3-r-tools-test)
 
 ;;; p3-r-tools-test.el ends here


### PR DESCRIPTION
## Summary

- remove Projectile from active Emacs configuration and project identity/runtime policy
- bind `C-c p` and `s-p` directly to the built-in `project-prefix-map`; leave native `C-x p` unchanged
- use `*.Rproj` as the forward marker for generated R projects and stop creating `.projectile`
- retain `.projectile` only as a legacy `project.el` compatibility marker
- set `load-prefer-newer` before early local startup requires so stale machine-local `.elc` files cannot override updated `p3-project` or `p3-config-loader` source
- preserve existing ESS, Python, R-tool, terminal, and Windows project-root contracts

## Intentional transition behavior

- native `project.el` switching and remembered-project behavior is not made Projectile-compatible
- global project aliases use the global map rather than a Projectile minor-mode map
- if `projectile-mode` is already active when this change is adopted, restart Emacs once; `C-c r` alone is not expected to retire that existing session state
- no Projectile cache importer, runtime shutdown shim, or package uninstall mechanism is added

## Verification

- focused ERT coverage proves plain Git discovery, legacy `.projectile` compatibility, `*.Rproj` project detection, nested `project-files` boundaries, native project prefix bindings, R scaffold output, and early stale-bytecode protection
- the stale-bytecode startup regression was first demonstrated red: the new startup-order test was the only unexpected ERT failure before the `init.el` fix
- Ubuntu CI byte-compiles and smoke-loads the native project config owner and runs the full ERT suite
- Windows CI exercises `*.Rproj` marker detection/file enumeration after normal Rtools/MSYS2 setup and includes the new config owner in durable path/compile/test coverage

Do not merge without explicit approval.