### PR TITLE
Retire unused workgroups2 configuration

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -180,6 +180,7 @@ jobs:
             -L lisp \
             -l test/p3-config-loader-test.el \
             -l test/p3-config-test.el \
+            -l test/p3-config-retirement-test.el \
             -l test/p3-config-appearance-test.el \
             -l test/p3-config-editing-ownership-test.el \
             -l test/p3-config-ess-test.el \

--- a/.github/workflows/windows-platform-tests.yml
+++ b/.github/workflows/windows-platform-tests.yml
@@ -32,6 +32,7 @@ on:
       - "test/p3-config-project-test.el"
       - "test/p3-config-loader-test.el"
       - "test/p3-config-test.el"
+      - "test/p3-config-retirement-test.el"
       - "test/p3-config-appearance-test.el"
       - "test/p3-config-editing-ownership-test.el"
       - "test/p3-config-editing-windows-test.el"
@@ -127,6 +128,7 @@ jobs:
           emacs -Q --batch -L lisp
           -l test/p3-config-loader-test.el
           -l test/p3-config-test.el
+          -l test/p3-config-retirement-test.el
           -l test/p3-config-appearance-test.el
           -l test/p3-config-editing-ownership-test.el
           -l test/p3-config-project-test.el

--- a/config.org
+++ b/config.org
@@ -336,16 +336,6 @@ TRAMP default settings
       (setq tramp-default-method "ssh"))
 #+END_SRC
 
-** workgroups
-
-#+BEGIN_SRC emacs-lisp
-  (use-package workgroups2
-    :init
-    (setq wg-prefix-key "C-c z"
-          wg-session-load-on-start nil)
-    (workgroups-mode 1))
-#+END_SRC
-
 * Encoding
 
 Use utf-8 everywhere all the time

--- a/test/p3-config-retirement-test.el
+++ b/test/p3-config-retirement-test.el
@@ -1,0 +1,27 @@
+;;; p3-config-retirement-test.el --- Retired configuration regressions -*- lexical-binding: t; -*-
+
+(require 'ert)
+
+(defconst p3-config-retirement-test--root
+  (file-name-directory
+   (directory-file-name
+    (file-name-directory (or load-file-name buffer-file-name)))))
+
+(defun p3-config-retirement-test--config ()
+  "Return the authoritative literate configuration contents."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name "config.org" p3-config-retirement-test--root))
+    (buffer-string)))
+
+(ert-deftest p3-config-workgroups2-remains-retired ()
+  (let ((contents (p3-config-retirement-test--config)))
+    (dolist (forbidden '("(use-package workgroups2"
+                          "wg-prefix-key"
+                          "wg-session-load-on-start"
+                          "(workgroups-mode 1)"))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
+
+(provide 'p3-config-retirement-test)
+
+;;; p3-config-retirement-test.el ends here


### PR DESCRIPTION
## Scope

Remove the unused `workgroups2` startup configuration and free its `C-c z` prefix without adding a replacement workspace framework.

This is intentionally narrow:

- remove the `workgroups2` block from `config.org`
- add a focused regression preventing the package and its startup variables from returning
- run that regression on both Ubuntu and Windows architecture gates
- make no other workspace, window-management, project, or keybinding changes

## TDD evidence

RED head `4ab53160c1d2d2a90e71a53ba4a69184233f3b8a`:

- Ubuntu Emacs tests #222 ran 292 tests.
- The only unexpected result was `p3-config-workgroups2-remains-retired`.
- It failed on the existing `(use-package workgroups2` declaration.
- Compilation, smoke boundaries, and all other expected tests passed.

The production change then removes only the ten-line `workgroups2` heading/configuration block.

## Adversarial review

No replacement workspace framework is introduced, no adjacent window/project configuration changes, and `C-c z` is simply released.

One transition detail is intentional: an Emacs session that already enabled `workgroups-mode` will keep that live minor-mode state until Emacs is restarted. After adopting this change, restart the Emacs daemon once. No permanent legacy shutdown shim is added for this one-time transition.

## Verification

Exact head: `cadf2b10795582e63653e6cb66503d4986e85ec2`

- Ubuntu Emacs tests #223: passed, including strict compilation, all smoke boundaries, and the full ERT suite with the retirement regression.
- Windows platform tests #129: passed, including Windows boundary compilation, editing regression, terminal smoke, platform/project tests, and config architecture tests with the retirement regression.
- Branch is 0 commits behind `master`.
- Scope is exactly four files: 10 production lines deleted from `config.org`, the focused retirement test, and the two workflow inclusions required to execute it.

**Draft. Do not merge without explicit approval.**