### PR TITLE
Clarify roadmap authority and structural backlog

### DIFF
--- a/docs/emacs-modernization-roadmap.md
+++ b/docs/emacs-modernization-roadmap.md
@@ -2,9 +2,11 @@
 
 ## Purpose and authority
 
-This document records the intended direction and current status of the Emacs configuration modernization work that grew out of the configuration review and comparison against stronger example configurations.
+This document records the intended direction and structural status of the Emacs configuration modernization work that grew out of the configuration review and comparison against stronger example configurations.
 
-Use the repository sources to answer what Emacs does today. Use this roadmap to answer what architectural direction is intended and what modernization work remains. Use GitHub issues and pull requests to track executable work. The files under `docs/superpowers/specs/` and `docs/superpowers/plans/` are detailed design and implementation history, not the current roadmap.
+Use the repository sources to answer what Emacs does today. Use this roadmap to answer what architectural direction is intended and what structural modernization work remains. Use GitHub Issues as the authoritative feature/UX backlog and pull requests to track active implementation. The files under `docs/superpowers/specs/` and `docs/superpowers/plans/` are detailed design and implementation history, not the current roadmap.
+
+The roadmap intentionally does not enumerate ordinary feature issues. That backlog changes too frequently and belongs in GitHub Issues.
 
 ## Target state
 
@@ -26,7 +28,7 @@ The configuration should remain a personal Emacs configuration, not become a fra
 4. **Preserve behavior during structural work.** Refactors should not silently redesign keybindings, project semantics, window workflows, platform behavior, or subsystem runtime contracts.
 5. **Test durable contracts.** Protect startup/reload semantics, project identity, platform behavior, ownership boundaries, and workflow helpers. Avoid tests that primarily freeze formatting or incidental source shape.
 
-## Status
+## Structural status
 
 | Area | Intended state | Status | Tracking |
 | --- | --- | --- | --- |
@@ -38,30 +40,22 @@ The configuration should remain a personal Emacs configuration, not become a fra
 | Editing and appearance | generic editing ownership consolidated; native mode line; Nerd Icons fallback path; no unused `workgroups2` framework | Complete for now | PRs #22, #23, #24 |
 | Reference management and export | Pandoc-based document export; Citar/Org/BibLaTeX reference workflow with Org-roam literature notes | Complete for current scope | PRs #5, #21 |
 | Completion | existing minibuffer and Company stack retained unless a concrete workflow deficiency justifies change | No standing redesign | — |
+| Legacy/dead configuration | unused MySQL and Poly-R integrations and the commented `Not in use` graveyard removed from the live config | Complete | PR #35 |
 | Package dependency lifecycle | determine whether the additional dependency-repair/preflight work is still wanted | Decision needed | draft PR #9 |
 
-## Remaining modernization decision
+## Remaining structural modernization
 
 ### Package dependency lifecycle — draft PR #9
 
-PR #9 is the one unresolved structural modernization item that should not remain indefinitely ambiguous. Its proposed scope goes beyond the already-completed bootstrap work: dependency-version repair, built-in dependency handling, fresh-process recompilation after package mutation, and preflight/fail-closed behavior.
+PR #9 should not remain indefinitely ambiguous. Its proposed scope goes beyond the already-completed bootstrap work: dependency-version repair, built-in dependency handling, fresh-process recompilation after package mutation, and preflight/fail-closed behavior.
 
-Decide explicitly whether to:
+Decide explicitly whether to finish a narrowed version because the current package lifecycle still has a demonstrated failure mode, or close it as superseded if the existing bootstrap is sufficient. Do not keep it open merely because the implementation exists.
 
-- finish a narrowed version because the current package lifecycle still has a demonstrated failure mode; or
-- close it as superseded if the existing bootstrap is sufficient.
+## Feature and UX backlog
 
-Do not keep it open merely because the implementation exists.
+GitHub Issues is authoritative for desired user-facing configuration work. New terminal, Org-roam, project/session, language workflow, Git/document, GPTel, Office-document, command-discovery, recording, and similar features should be tracked there rather than copied into this roadmap.
 
-## Active configuration feature and UX work
-
-These are real outstanding configuration tasks, but they do not by themselves mean the structural modernization is incomplete.
-
-- **Issue #20 — Replace vterm.** The current terminal UX has concrete problems around copy mode, multiline submission, and buffer behavior during process output. Any replacement should preserve the established project/platform boundaries rather than reopen the architecture.
-- **Issue #25 — Project-aware Org-roam literate workflow.** Add durable project hubs, associated notes, and project-scoped TODO aggregation as a thin integration over `project.el`, Org, Org Agenda, and Org-roam. Do not introduce a second project/task database or project-folder hierarchy.
-- **Issue #28 — Group `C-x` suggestions.** Improve which-key discoverability by grouping or reducing noisy suggestions without creating another keybinding framework.
-
-New feature work should enter this section only when it is concrete enough to have a tracker. General aspirations belong in the decision rules, not as pseudo-projects.
+Those issues should conform to the target state and decision rules above, but their existence does not by itself mean the structural modernization is incomplete.
 
 ## Not on the standing roadmap
 
@@ -74,19 +68,21 @@ Do not revive these directions without a new concrete problem that requires them
 - Projectile as a parallel project system;
 - Doom-modeline as a required presentation layer;
 - `all-the-icons` as the icon stack;
-- `workgroups2` or another workspace framework merely to replace it;
+- `workgroups2` or another workspace framework merely to replace it; native project/session continuity using `project.el` and Emacs tab/session primitives remains compatible with this roadmap when it solves a concrete continuity problem;
 - a custom notes/task database for project-aware literate work;
 - replacing Company or the minibuffer completion stack solely to match example configurations;
 - package-count minimization as a goal in itself;
 - broad configuration schemas/orchestration frameworks whose principal consumer is the config itself;
-- the closed visual PPTX editing spike unless it is separately promoted as supported work.
+- the closed custom visual PPTX editing spike as an implementation direction; separately tracked Office round-trip work should prefer existing conversion/rendering tools and thin Emacs integration.
 
 ## Historical design records
 
 `docs/superpowers/specs/` and `docs/superpowers/plans/` preserve constraints, alternatives, migration details, and test rationale for individual changes. Some describe work that has already shipped and some contain implementation-specific instructions that should not be carried forward automatically.
 
-If old plans disagree with the repository, the repository describes current behavior. If old plans disagree with this roadmap about future direction, this roadmap is the current intent.
+If old plans disagree with the repository, the repository describes current behavior. If old plans disagree with this roadmap about future architectural direction, this roadmap is the current intent.
 
 ## When the modernization is done
 
-Treat the standing modernization effort as complete when the PR #9 package-lifecycle decision is resolved and no concrete structural cleanup remains open solely because of the modernization cycle. At that point, issues such as terminal UX, project-aware Org-roam, which-key discoverability, and future package changes are ordinary feature or maintenance work rather than continuation of a configuration rewrite.
+Treat the standing modernization effort as complete when the package-lifecycle decision is resolved and no concrete structural cleanup remains open solely because of the modernization cycle.
+
+At that point, the remaining GitHub issues are ordinary feature or maintenance work rather than continuation of a configuration rewrite.


### PR DESCRIPTION
## Summary

Tighten the modernization roadmap so it does not duplicate the changing feature backlog.

- make GitHub Issues authoritative for feature/UX work;
- keep the roadmap focused on architectural direction and structural modernization status;
- record merged PR #35 as completed known legacy/dead-config cleanup;
- retain draft PR #9 as the unresolved package-lifecycle decision;
- remove the stale enumerated feature list;
- clarify that separately tracked Office round-trip work does not revive the closed custom PPTX-editor spike;
- clarify that native `project.el` + Emacs tab/session continuity does not violate the decision not to add another workspace framework merely to replace `workgroups2`.

## Why

After PR #27 merged, additional feature issues immediately made its enumerated backlog stale. The stable contract should be:

- roadmap = architectural direction and structural modernization state;
- issues = feature/UX backlog;
- pull requests = active implementation.

## Rebase update

`master` advanced when PR #35 merged. This branch was rebuilt on that merge commit and the roadmap now treats the MySQL/Poly-R/commented-graveyard cleanup as complete rather than active.

## Verification

One commit on current `master`; only `docs/emacs-modernization-roadmap.md` changes (18 additions, 22 deletions).

**Draft. Do not merge without explicit approval.**