### PR TITLE
Finish residual config.org ownership cleanup

### DIFF
--- a/config.org
+++ b/config.org
@@ -26,10 +26,11 @@ overrides are available when their respective setup stages run.
     (load-file p3/secrets-file))
 #+END_SRC
 
-Platform-specific discovery lives in =lisp/p3-platform.el=. On Windows, select
-the Rtools/MSYS2 environment here so Git and other subprocess-using packages
-see its Unix tools early in startup. R and shell configuration remain in their
-original subsystem sections below.
+Platform-specific discovery and defaults live in =lisp/p3-platform.el=. On
+Windows, select the Rtools/MSYS2 environment here so Git and other
+subprocess-using packages see its Unix tools early in startup. Configure the
+platform-appropriate TRAMP default at the same boundary. R and shell
+configuration remain at their subsystem boundaries below.
 
 #+BEGIN_SRC emacs-lisp
   (eval-and-compile
@@ -39,13 +40,15 @@ original subsystem sections below.
     :ensure nil
     :demand t
     :config
-    (p3/windows-configure-rtools))
+    (p3/windows-configure-rtools)
+    (p3/platform-configure-tramp))
 #+END_SRC
 
 * Base
 
-Broad global configuration, startup UI, package-update wiring, process defaults,
-backups, Dired, and the keybinding atlas live in =lisp/p3-config-base.el=.
+Broad global configuration lives in =lisp/p3-config-base.el=: startup UI,
+configuration commands, package-update wiring, process and coding defaults,
+backups, Dired, and the keybinding atlas.
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-base)
@@ -62,26 +65,12 @@ in =lisp/p3-config-appearance.el=.
 
 * Editing
 
-Generic editing semantics and package setup live in =lisp/p3-config-editing.el=.
-The owner loads before completion so Consult retains the final =C-s= and =C-r=
-bindings; staged setup calls below preserve the original activation positions
-without coupling configuration modules to one another.
+Generic editing semantics and package setup live in =lisp/p3-config-editing.el=,
+including completion-adjacent editing tools, diagnostics, spelling, color
+previews, the simple C++ compile hook, and LaTeX editing hooks.
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-editing)
-#+END_SRC
-
-* Functions
-
-Shared project and configuration commands live in =lisp/p3-core.el=. Keep the
-literate file responsible for loading the module and exposing its bindings.
-
-#+BEGIN_SRC emacs-lisp
-  (use-package p3-core
-    :ensure nil
-    :demand t
-    :bind (("C-c e" . p3/config-visit)
-           ("C-c r" . p3/config-reload)))
 #+END_SRC
 
 * Modes
@@ -101,28 +90,15 @@ live in =lisp/p3-config-completion.el=.
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-completion)
-  (p3/config-editing-setup-thesaurus-and-snippets)
-#+END_SRC
-
-** C++
-
-Special compile command for C++
-
-#+BEGIN_SRC emacs-lisp
-  (use-package compile
-    :ensure nil
-    :defer t
-    :hook (c++-mode lambda ()
-        (set (make-local-variable 'compile-command)
-          (format "g++ %s" (file-name-nondirectory buffer-file-name)))))
 #+END_SRC
 
 ** ESS
 
-ESS package wiring, R-mode hooks, keybindings, buffer defaults, and ESS-specific
-Company configuration live in =lisp/p3-config-ess.el=. Project-aware ESS
-process/session behavior remains in =lisp/p3-ess.el=, while project templates
-and user-facing R workflow commands remain in =lisp/p3-r-tools.el=.
+ESS package wiring, R-mode hooks, keybindings, buffer defaults, RMarkdown
+coding/compile defaults, and ESS-specific Company configuration live in
+=lisp/p3-config-ess.el=. Project-aware ESS process/session behavior remains in
+=lisp/p3-ess.el=, while project templates and user-facing R workflow commands
+remain in =lisp/p3-r-tools.el=.
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-ess)
@@ -152,7 +128,6 @@ Task prompts, streaming/rollback behavior, and the task command map remain in
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-gptel)
-  (p3/config-editing-setup-diagnostics)
 #+END_SRC
 
 ** Buffers, Windows, and Frames
@@ -162,30 +137,6 @@ side-window rule live in =lisp/p3-config-workspace.el=.
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-workspace)
-#+END_SRC
-
-** LaTeX
-
-Flyspell for LaTeX
-
-#+BEGIN_SRC emacs-lisp
-  (add-hook 'LaTeX-mode-hook 'flyspell-mode)
-#+END_SRC
-
-Auto-fill
-
-#+BEGIN_SRC emacs-lisp
-  (add-hook 'LaTeX-mode-hook 'turn-on-auto-fill)
-#+END_SRC
-
-Process latex pdf with bibtex [[https://tex.stackexchange.com/questions/197707/using-bibtex-from-org-mode-bbl-and-aux-files-are-incorrectly-generated][as shown here]]
-
-#+BEGIN_SRC emacs-lisp
-(setq org-latex-pdf-process
-      '("pdflatex -interaction nonstopmode -output-directory %o %f"
-"bibtex %b"
-"pdflatex -interaction nonstopmode -output-directory %o %f"
-"pdflatex -interaction nonstopmode -output-directory %o %f"))
 #+END_SRC
 
 ** Git
@@ -200,7 +151,7 @@ git-gutter, and bindings live in =lisp/p3-config-git.el=.
 ** org
 
 Org core behavior lives in =lisp/p3-org.el=. Declarative Org, Babel, TODO,
-Agenda, PDF-opening, and export-activation configuration lives in
+Agenda, LaTeX export, PDF-opening, and export-activation configuration lives in
 =lisp/p3-config-org.el=.
 
 #+BEGIN_SRC emacs-lisp
@@ -246,7 +197,6 @@ Reusable interpreter, language-server, and REPL behavior remains in
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-python)
-  (p3/config-editing-setup-color-helper)
 #+END_SRC
 
 ** Shell
@@ -257,40 +207,4 @@ Terminal package wiring and platform-specific shell activation live in
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-terminal)
-  (p3/config-editing-setup-spelling)
-#+END_SRC
-
-** TRAMP
-
-TRAMP default settings
-
-#+BEGIN_SRC emacs-lisp
-  (require 'tramp)
-    (when (eq system-type 'windows-nt)
-      (setq tramp-default-method "plink"))
-    (when (eq system-type 'gnu/linux)
-      (setq tramp-default-method "ssh"))
-#+END_SRC
-
-* Encoding
-
-Use utf-8 everywhere all the time
-
-#+BEGIN_SRC emacs-lisp
-  (setenv "LANG" "en_US.UTF-8")
-  (setenv "LC_ALL" "en_US.UTF-8")
-  (set-language-environment "UTF-8")
-  (prefer-coding-system 'utf-8)
-  (setq locale-coding-system 'utf-8)
-  (set-default-coding-systems 'utf-8-unix)
-  (setq default-process-coding-system '(utf-8-unix . utf-8-unix))
-  (set-buffer-file-coding-system 'utf-8)
-  (set-file-name-coding-system 'utf-8)
-  (set-selection-coding-system 'utf-8)
-#+END_SRC
-
-Set Rmd to CRLF
-
-#+BEGIN_SRC emacs-lisp
-    (add-to-list 'file-coding-system-alist '("\\.Rmd\\'" . utf-8-dos))
 #+END_SRC

--- a/lisp/p3-config-base.el
+++ b/lisp/p3-config-base.el
@@ -3,6 +3,7 @@
 (require 'use-package)
 (require 'p3-config-loader)
 (p3/config-load-module 'p3-commands)
+(p3/config-load-module 'p3-core)
 
 (defvar dashboard-startup-banner)
 (defvar dashboard-center-content)
@@ -29,6 +30,11 @@
 (declare-function package-refresh-contents "package" (&optional async))
 (declare-function package-list-packages "package" (&optional no-fetch))
 (declare-function p3/windows-shell "p3-commands" ())
+(declare-function p3/config-visit "p3-core" ())
+(declare-function p3/config-reload "p3-core" ())
+
+(global-set-key (kbd "C-c e") #'p3/config-visit)
+(global-set-key (kbd "C-c r") #'p3/config-reload)
 
 (use-package dashboard
   :config
@@ -155,6 +161,17 @@
 (setq mouse-wheel-progressive-speed nil)
 
 (setq delete-by-moving-to-trash t)
+
+(setenv "LANG" "en_US.UTF-8")
+(setenv "LC_ALL" "en_US.UTF-8")
+(set-language-environment "UTF-8")
+(prefer-coding-system 'utf-8)
+(setq locale-coding-system 'utf-8)
+(set-default-coding-systems 'utf-8-unix)
+(setq default-process-coding-system '(utf-8-unix . utf-8-unix))
+(set-buffer-file-coding-system 'utf-8)
+(set-file-name-coding-system 'utf-8)
+(set-selection-coding-system 'utf-8)
 
 (use-package async
   :init

--- a/lisp/p3-config-editing.el
+++ b/lisp/p3-config-editing.el
@@ -12,8 +12,8 @@
 (defvar yas-snippet-dirs)
 (defvar flycheck-global-modes)
 (defvar flycheck-checker-error-threshold)
-(defvar p3/windows-hunspell-program)
-(defvar p3/windows-hunspell-dictionary-directory)
+(defvar p3/windows-hunspell-program nil)
+(defvar p3/windows-hunspell-dictionary-directory nil)
 (defvar ispell-program-name)
 (defvar ispell-local-dictionary)
 (defvar ispell-dictionary)
@@ -83,32 +83,26 @@
          ("C-}" . mc/mark-previous-like-this)
          ("C-|" . mc/mark-all-like-this)))
 
-(defun p3/config-editing-setup-thesaurus-and-snippets ()
-  "Configure generic thesaurus and snippet support."
-  (use-package synosaurus
-    :diminish synosaurus-mode
-    :init    (synosaurus-mode)
-    :config  (setq synosaurus-choose-method 'popup))
+(use-package synosaurus
+  :diminish synosaurus-mode
+  :init (synosaurus-mode)
+  :config (setq synosaurus-choose-method 'popup))
 
-  (use-package yasnippet
-    :init
-    (yas-global-mode 1)
-    :config
-    (add-to-list 'yas-snippet-dirs "~/.emacs.d/snippets")))
+(use-package yasnippet
+  :init
+  (yas-global-mode 1)
+  :config
+  (add-to-list 'yas-snippet-dirs "~/.emacs.d/snippets"))
 
-(defun p3/config-editing-setup-diagnostics ()
-  "Configure global Flycheck behavior."
-  (use-package flycheck
-    :hook (after-init . global-flycheck-mode)
-    :config
-    (setq flycheck-global-modes '(not LaTeX-mode latex-mode org-mode))
-    (setq flycheck-checker-error-threshold 1000)))
+(use-package flycheck
+  :hook (after-init . global-flycheck-mode)
+  :config
+  (setq flycheck-global-modes '(not LaTeX-mode latex-mode org-mode))
+  (setq flycheck-checker-error-threshold 1000))
 
-(defun p3/config-editing-setup-color-helper ()
-  "Configure color previews for programming buffers."
-  (use-package rainbow-mode
-    :config
-    (add-hook 'prog-mode-hook #'rainbow-mode)))
+(use-package rainbow-mode
+  :config
+  (add-hook 'prog-mode-hook #'rainbow-mode))
 
 (defun p3/config-editing-setup-spelling ()
   "Configure platform-specific Hunspell and Ispell behavior."
@@ -130,6 +124,17 @@
           ispell-dictionary "english"
           ispell-local-dictionary-alist
           '(("en_US" "[[:alpha:]]" "[^[:alpha:]]" "[']" nil ("-d" "en_US") nil utf-8)))))
+
+(p3/config-editing-setup-spelling)
+
+(add-hook 'c++-mode-hook
+          (lambda ()
+            (set (make-local-variable 'compile-command)
+                 (format "g++ %s"
+                         (file-name-nondirectory buffer-file-name)))))
+
+(add-hook 'LaTeX-mode-hook #'flyspell-mode)
+(add-hook 'LaTeX-mode-hook #'turn-on-auto-fill)
 
 (provide 'p3-config-editing)
 

--- a/lisp/p3-config-ess.el
+++ b/lisp/p3-config-ess.el
@@ -95,6 +95,8 @@
         ess-gen-proc-buffer-name-function
         'ess-gen-proc-buffer-name:project-or-directory))
 
+(add-to-list 'file-coding-system-alist '("\\.Rmd\\'" . utf-8-dos))
+
 (defun compile-rmd ()
   (set (make-local-variable 'compile-command)
        (concat "R -e \"rmarkdown::render('" buffer-file-name "')\"")))

--- a/lisp/p3-config-org.el
+++ b/lisp/p3-config-org.el
@@ -8,6 +8,7 @@
 (defvar org-ellipsis)
 (defvar org-file-apps)
 (defvar org-hide-emphasis-markers)
+(defvar org-latex-pdf-process)
 (defvar org-mode-map)
 (defvar org-src-fontify-natively)
 (defvar org-src-tab-acts-natively)
@@ -40,8 +41,7 @@
   :bind (:map org-mode-map
               ("C-c s" lambda () (interactive)
                (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
-  :hook ((org-mode . flyspell-mode)
-         (org-mode . visual-line-mode)
+  :hook ((org-mode . visual-line-mode)
          (org-mode . org-indent-mode))
   :init
   (org-babel-do-load-languages
@@ -60,6 +60,12 @@
         org-ellipsis " ↴"))
 
 (define-key org-mode-map (kbd "C-c C-x C-o") #'p3/org-sort-todos)
+
+(setq org-latex-pdf-process
+      '("pdflatex -interaction nonstopmode -output-directory %o %f"
+        "bibtex %b"
+        "pdflatex -interaction nonstopmode -output-directory %o %f"
+        "pdflatex -interaction nonstopmode -output-directory %o %f"))
 
 (use-package p3-org-export
   :ensure nil

--- a/lisp/p3-platform.el
+++ b/lisp/p3-platform.el
@@ -17,6 +17,7 @@
 (defvar explicit-shell-file-name)
 (defvar inferior-R-program-name)
 (defvar package-gnupghome-dir)
+(defvar tramp-default-method)
 
 (defgroup p3/platform nil
   "Platform-specific behavior for the personal Emacs configuration."
@@ -51,6 +52,12 @@ Set this in secrets.el when a machine should not use auto-detection.")
 (defun p3/windows-p ()
   "Return non-nil when Emacs is running natively on Windows."
   (eq system-type 'windows-nt))
+
+(defun p3/platform-configure-tramp ()
+  "Configure the default TRAMP method for the current supported platform."
+  (pcase system-type
+    ('windows-nt (setq tramp-default-method "plink"))
+    ('gnu/linux (setq tramp-default-method "ssh"))))
 
 (defun p3/windows-normalize-gnupg-path (windows-path)
   "Normalize WINDOWS-PATH for the package GnuPG home workaround."

--- a/test/p3-config-appearance-test.el
+++ b/test/p3-config-appearance-test.el
@@ -112,9 +112,7 @@
       (should-not (string-match-p (regexp-quote forbidden) config)))
     (should-not (string-match-p "dashboard-icon-type" base))
     (should (string-match-p "initial-scratch-message" base))
-    (should (string-match-p "ring-bell-function" base))
-    (should (string-match-p "default-process-coding-system" config))
-    (should (string-match-p "\\\\.Rmd" config))))
+    (should (string-match-p "ring-bell-function" base))))
 
 (ert-deftest p3-config-appearance-preserves-platform-visual-invariants ()
   (let ((appearance

--- a/test/p3-config-editing-ownership-test.el
+++ b/test/p3-config-editing-ownership-test.el
@@ -13,10 +13,6 @@
      (expand-file-name relative p3-config-editing-ownership-test--root))
     (buffer-string)))
 
-(defun p3-config-editing-ownership-test--position (needle contents)
-  (or (string-match (regexp-quote needle) contents)
-      (ert-fail (format "Missing expected form: %s" needle))))
-
 (ert-deftest p3-config-editing-owns-generic-editing-packages ()
   (let ((config (p3-config-editing-ownership-test--contents "config.org"))
         (editing
@@ -50,6 +46,51 @@
                "ispell-dictionary \"english\""))
       (should (string-match-p (regexp-quote setting) editing)))))
 
+(ert-deftest p3-config-editing-owns-cpp-compile-hook ()
+  (let ((config (p3-config-editing-ownership-test--contents "config.org"))
+        (editing
+         (p3-config-editing-ownership-test--contents
+          "lisp/p3-config-editing.el")))
+    (dolist (needle '("c++-mode-hook" "compile-command" "g++ %s"))
+      (should (string-match-p (regexp-quote needle) editing)))
+    (should-not (string-match-p "c++-mode-hook" config))))
+
+(ert-deftest p3-config-editing-owns-latex-editing-hooks ()
+  (let ((config (p3-config-editing-ownership-test--contents "config.org"))
+        (editing
+         (p3-config-editing-ownership-test--contents
+          "lisp/p3-config-editing.el")))
+    (dolist (needle '("LaTeX-mode-hook" "flyspell-mode" "turn-on-auto-fill"))
+      (should (string-match-p (regexp-quote needle) editing)))
+    (should-not (string-match-p "LaTeX-mode-hook" config))))
+
+(ert-deftest p3-config-residual-policy-has-narrow-owners ()
+  (let ((config (p3-config-editing-ownership-test--contents "config.org"))
+        (base (p3-config-editing-ownership-test--contents "lisp/p3-config-base.el"))
+        (ess (p3-config-editing-ownership-test--contents "lisp/p3-config-ess.el"))
+        (platform (p3-config-editing-ownership-test--contents "lisp/p3-platform.el")))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-core)") base))
+    (should (string-match-p "default-process-coding-system" base))
+    (should (string-match-p "file-coding-system-alist" ess))
+    (should-not (string-match-p "file-coding-system-alist" base))
+    (should (string-match-p "tramp-default-method" platform))
+    (should-not (string-match-p "tramp-default-method" base))
+    (dolist (forbidden '("(use-package p3-core"
+                          "(setq default-process-coding-system"
+                          "file-coding-system-alist"
+                          "tramp-default-method"))
+      (should-not (string-match-p (regexp-quote forbidden) config)))))
+
+(ert-deftest p3-config-org-owns-latex-export-process ()
+  (let ((config (p3-config-editing-ownership-test--contents "config.org"))
+        (org-config
+         (p3-config-editing-ownership-test--contents "lisp/p3-config-org.el")))
+    (should (string-match-p (regexp-quote "(setq org-latex-pdf-process")
+                            org-config))
+    (should-not (string-match-p (regexp-quote "(setq org-latex-pdf-process")
+                                config))))
+
 (ert-deftest p3-config-editing-does-not-depend-on-other-config-modules ()
   (let ((editing
          (p3-config-editing-ownership-test--contents
@@ -60,46 +101,6 @@
                        p3-config-terminal))
       (should-not
        (string-match-p (regexp-quote (symbol-name feature)) editing)))))
-
-(ert-deftest p3-config-editing-preserves-activation-order-in-orchestration ()
-  (let* ((config (p3-config-editing-ownership-test--contents "config.org"))
-         (completion
-          (p3-config-editing-ownership-test--position
-           "(p3/config-load-module 'p3-config-completion)" config))
-         (thesaurus-snippets
-          (p3-config-editing-ownership-test--position
-           "(p3/config-editing-setup-thesaurus-and-snippets)" config))
-         (cpp
-          (p3-config-editing-ownership-test--position
-           "(use-package compile" config))
-         (gptel
-          (p3-config-editing-ownership-test--position
-           "(p3/config-load-module 'p3-config-gptel)" config))
-         (diagnostics
-          (p3-config-editing-ownership-test--position
-           "(p3/config-editing-setup-diagnostics)" config))
-         (workspace
-          (p3-config-editing-ownership-test--position
-           "(p3/config-load-module 'p3-config-workspace)" config))
-         (python
-          (p3-config-editing-ownership-test--position
-           "(p3/config-load-module 'p3-config-python)" config))
-         (color-helper
-          (p3-config-editing-ownership-test--position
-           "(p3/config-editing-setup-color-helper)" config))
-         (terminal
-          (p3-config-editing-ownership-test--position
-           "(p3/config-load-module 'p3-config-terminal)" config))
-         (spelling
-          (p3-config-editing-ownership-test--position
-           "(p3/config-editing-setup-spelling)" config))
-         (tramp
-          (p3-config-editing-ownership-test--position
-           "(require 'tramp)" config)))
-    (should (< completion thesaurus-snippets cpp))
-    (should (< gptel diagnostics workspace))
-    (should (< python color-helper terminal))
-    (should (< terminal spelling tramp))))
 
 (ert-deftest p3-config-editing-remains-early-owner ()
   (let* ((config (p3-config-editing-ownership-test--contents "config.org"))

--- a/test/p3-config-org-test.el
+++ b/test/p3-config-org-test.el
@@ -84,8 +84,7 @@
        :bind (:map org-mode-map
                    ("C-c s" lambda nil (interactive)
                     (insert "#+BEGIN_SRC emacs-lisp\n#+END_SRC")))
-       :hook ((org-mode . flyspell-mode)
-              (org-mode . visual-line-mode)
+       :hook ((org-mode . visual-line-mode)
               (org-mode . org-indent-mode))
        :init
        (org-babel-do-load-languages

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -87,10 +87,12 @@
     (should-not (string-match-p "(defun p3/org-export-to-office" org-config))))
 
 (ert-deftest p3-config-org-delegates-custom-subsystems-to-modules ()
-  (let ((contents (p3-config-test--contents "config.org")))
-    (dolist (module '("p3-platform" "p3-core"))
-      (should (string-match-p (regexp-quote (format "(use-package %s" module))
-                              contents)))
+  (let ((contents (p3-config-test--contents "config.org"))
+        (base (p3-config-test--contents "lisp/p3-config-base.el")))
+    (should (string-match-p (regexp-quote "(use-package p3-platform") contents))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-core)") base))
+    (should-not (string-match-p (regexp-quote "(use-package p3-core") contents))
     (dolist (module '(p3-config-ess p3-config-gptel p3-config-org
                       p3-config-org-roam p3-config-org-present
                       p3-config-project p3-config-python p3-config-reference
@@ -305,9 +307,7 @@
                           "bib-files-directory"
                           "p3/bib-library"
                           "p3/pdf-library"))
-      (should-not (string-match-p (regexp-quote forbidden) contents)))
-    (should (string-match-p
-             (regexp-quote "(setq org-latex-pdf-process") contents))))
+      (should-not (string-match-p (regexp-quote forbidden) contents)))))
 
 (ert-deftest p3-config-ess-orchestration-has-one-owner ()
   (let* ((contents (p3-config-test--contents "config.org"))
@@ -372,6 +372,8 @@
         (terminal-behavior (p3-config-test--contents "lisp/p3-terminal.el")))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-commands)") base))
+    (should (string-match-p
+             (regexp-quote "(p3/config-load-module 'p3-core)") base))
     (should (string-match-p
              (regexp-quote "(p3/config-load-module 'p3-git)") git))
     (should (string-match-p


### PR DESCRIPTION
## Summary

Finish the remaining configuration-module migration without adding new module layers.

- move `p3-core` and generic coding policy into Base;
- keep RMarkdown coding/compile defaults with ESS;
- keep platform-specific TRAMP defaults behind `p3-platform` at the early platform boundary;
- move C++ and LaTeX editing configuration into Editing;
- move the Org LaTeX export process into Org configuration;
- remove transitional Editing staging calls from `config.org`;
- keep order-sensitive Rtools, R executable, and GnuPG stages explicit in `config.org`;
- preserve the Windows-sensitive spelling setup as a small re-runnable helper inside Editing;
- stop auto-enabling Flyspell in Org buffers to avoid the observed `org-element` cache/parser failure path while retaining visual-line and indent hooks.

## Verification

- review fixes remove the stale appearance/encoding assertion and helper-name preservation test;
- Org boundary regression updated for the intentional Flyspell removal;
- Linux: byte compilation, all configuration-boundary smoke checks, and the full ERT suite pass;
- Windows: boundary compilation, editing/terminal regressions, platform/project tests, and the architecture suite pass;
- one commit on current `master`; ten existing files changed; no new modules or files.