### PR TITLE
Sort config.org mode sections alphabetically

### DIFF
--- a/config.org
+++ b/config.org
@@ -74,13 +74,13 @@ previews, the simple C++ compile hook, and LaTeX editing hooks.
 #+END_SRC
 
 * Modes
-** References
+** Buffers, Windows, and Frames
 
-Reference capture, retrieval, citation, literature-note, project-association,
-and PDF behavior lives in =lisp/p3-config-reference.el=.
+Window selection, navigation, resizing, and the existing narrow ESS process
+side-window rule live in =lisp/p3-config-workspace.el=.
 
 #+BEGIN_SRC emacs-lisp
-  (p3/config-load-module 'p3-config-reference)
+  (p3/config-load-module 'p3-config-workspace)
 #+END_SRC
 
 ** Completion-related
@@ -111,6 +111,15 @@ startup boundary.
   (p3/windows-configure-r-program)
 #+END_SRC
 
+** Git
+
+Git subprocess/synchronization behavior lives in =lisp/p3-git.el=; Magit,
+git-gutter, and bindings live in =lisp/p3-config-git.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-git)
+#+END_SRC
+
 ** GnuPG
 
 Windows GnuPG home-path normalization lives in =lisp/p3-platform.el=. Keep the
@@ -128,24 +137,6 @@ Task prompts, streaming/rollback behavior, and the task command map remain in
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-gptel)
-#+END_SRC
-
-** Buffers, Windows, and Frames
-
-Window selection, navigation, resizing, and the existing narrow ESS process
-side-window rule live in =lisp/p3-config-workspace.el=.
-
-#+BEGIN_SRC emacs-lisp
-  (p3/config-load-module 'p3-config-workspace)
-#+END_SRC
-
-** Git
-
-Git subprocess/synchronization behavior lives in =lisp/p3-git.el=; Magit,
-git-gutter, and bindings live in =lisp/p3-config-git.el=.
-
-#+BEGIN_SRC emacs-lisp
-  (p3/config-load-module 'p3-config-git)
 #+END_SRC
 
 ** org
@@ -197,6 +188,15 @@ Reusable interpreter, language-server, and REPL behavior remains in
 
 #+BEGIN_SRC emacs-lisp
   (p3/config-load-module 'p3-config-python)
+#+END_SRC
+
+** References
+
+Reference capture, retrieval, citation, literature-note, project-association,
+and PDF behavior lives in =lisp/p3-config-reference.el=.
+
+#+BEGIN_SRC emacs-lisp
+  (p3/config-load-module 'p3-config-reference)
 #+END_SRC
 
 ** Shell

--- a/test/p3-config-test.el
+++ b/test/p3-config-test.el
@@ -122,28 +122,13 @@
          (appearance (p3-config-test--position
                       "(p3/config-load-module 'p3-config-appearance)" contents))
          (editing (p3-config-test--position
-                   "(p3/config-load-module 'p3-config-editing)" contents))
-         (reference (p3-config-test--position
-                     "(p3/config-load-module 'p3-config-reference)" contents))
-         (completion (p3-config-test--position
-                      "(p3/config-load-module 'p3-config-completion)" contents))
-         (ess (p3-config-test--position
-               "(p3/config-load-module 'p3-config-ess)" contents))
-         (r-program (p3-config-test--position
-                     "(p3/windows-configure-r-program)" contents))
-         (terminal (p3-config-test--position
-                    "(p3/config-load-module 'p3-config-terminal)" contents)))
+                   "(p3/config-load-module 'p3-config-editing)" contents)))
     (should (< newer auto))
     (should (< auto secrets))
     (should (< secrets rtools))
     (should (< rtools base))
     (should (< base appearance))
-    (should (< appearance editing))
-    (should (< editing reference))
-    (should (< reference completion))
-    (should (< completion ess))
-    (should (< ess r-program))
-    (should (< r-program terminal))))
+    (should (< appearance editing))))
 
 (ert-deftest p3-config-platform-setup-preserves-subsystem-timing ()
   (let* ((contents (p3-config-test--contents "config.org"))


### PR DESCRIPTION
## Summary

Make the `* Modes` section of `config.org` easier to scan by sorting its mode subsections alphabetically.

- preserve `Startup`, `Base`, `Appearance`, and `Editing` ordering;
- keep each mode subsection's contents unchanged;
- preserve the ESS Windows R-program boundary within the ESS subsection;
- narrow the old broad early-orchestration test so it protects only genuine early startup order instead of freezing the incidental `References` -> `Completion` presentation order;
- retain the existing focused tests for Editing, platform/ESS, Org, Python, and Terminal ordering.

## Scope

- `config.org` — alphabetical mode-section ordering only;
- `test/p3-config-test.el` — remove stale incidental source-order assertions exposed by the reorder.

## Verification

- branch is two commits ahead and zero behind current `master`;
- Linux Emacs tests pass on exact head `60b0c638e7f9857b69f96784d5504c2c19852e3d`, including all 298 ERT tests;
- Windows platform tests pass on the same exact head.

**Ready for review. Do not merge without explicit approval.**