### PR TITLE
Fix duplicate modeline mode icon

### DIFF
--- a/lisp/p3-config-appearance.el
+++ b/lisp/p3-config-appearance.el
@@ -321,14 +321,12 @@
         (downcase (string-trim (buffer-name) "\\*+" "\\*+")))))
 
 (defun p3/appearance--mode-segment ()
-  "Return major-mode identity with an optional icon and mandatory text."
+  "Return textual major-mode identity."
   (let* ((text (or (p3/appearance--format-construct mode-name)
                    (symbol-name major-mode)))
          (text (if (string-empty-p text) (symbol-name major-mode) text)))
     (unless (p3/appearance--redundant-mode-name-p text)
-      (let ((icon (p3/appearance--safe-icon
-                   #'nerd-icons-icon-for-mode major-mode :height 0.95)))
-        (if icon (format "%s  %s" icon text) text)))))
+      text)))
 
 (defun p3/appearance--process-segment ()
   "Return existing mode-provided process state on sufficiently wide windows."

--- a/lisp/p3-config-appearance.el
+++ b/lisp/p3-config-appearance.el
@@ -26,7 +26,6 @@
 
 (declare-function nerd-icons-icon-for-file "nerd-icons" (file &rest args))
 (declare-function nerd-icons-icon-for-buffer "nerd-icons" (&rest args))
-(declare-function nerd-icons-icon-for-mode "nerd-icons" (mode &rest args))
 (declare-function nerd-icons-octicon "nerd-icons" (name &rest args))
 (declare-function nerd-icons-codicon "nerd-icons" (name &rest args))
 (declare-function nerd-icons-sucicon "nerd-icons" (name &rest args))

--- a/test/p3-config-appearance-test.el
+++ b/test/p3-config-appearance-test.el
@@ -182,11 +182,14 @@
     (emacs-lisp-mode)
     (setq buffer-file-name "/tmp/example.el"
           p3/appearance--icons-available t)
-    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) t)))
+    (cl-letf (((symbol-function 'display-graphic-p) (lambda (&optional _) t))
+              ((symbol-function 'nerd-icons-icon-for-mode)
+               (lambda (&rest _) (ert-fail "major-mode icon rendered"))))
       (let ((file-segment (p3/appearance--file-segment))
             (mode-segment (p3/appearance--mode-segment)))
         (should (string-match-p "F  example\\.el" file-segment))
-        (should (equal "Emacs-Lisp" mode-segment))))))
+        (should (stringp mode-segment))
+        (should-not (string-empty-p mode-segment))))))
 
 (ert-deftest p3-appearance-mode-line-icons-require-graphical-frame ()
   (p3-config-appearance-test--load-appearance)

--- a/test/p3-config-appearance-test.el
+++ b/test/p3-config-appearance-test.el
@@ -176,7 +176,7 @@
                        (substring-no-properties
                         (p3/appearance--file-label))))))))
 
-(ert-deftest p3-appearance-file-and-mode-segments-use-icons-when-enabled ()
+(ert-deftest p3-appearance-file-segment-owns-icon-when-enabled ()
   (p3-config-appearance-test--load-appearance)
   (with-temp-buffer
     (emacs-lisp-mode)
@@ -186,7 +186,7 @@
       (let ((file-segment (p3/appearance--file-segment))
             (mode-segment (p3/appearance--mode-segment)))
         (should (string-match-p "F  example\\.el" file-segment))
-        (should (string-match-p "M  Emacs-Lisp" mode-segment))))))
+        (should (equal "Emacs-Lisp" mode-segment))))))
 
 (ert-deftest p3-appearance-mode-line-icons-require-graphical-frame ()
   (p3-config-appearance-test--load-appearance)


### PR DESCRIPTION
Make the far-left file/buffer identity the sole mode/file icon owner. The major-mode segment remains textual. Includes a regression test that fails against the current implementation before the production change.