### PR TITLE
Polish project tab appearance

### DIFF
--- a/.github/workflows/emacs-tests.yml
+++ b/.github/workflows/emacs-tests.yml
@@ -182,6 +182,7 @@ jobs:
             -l test/p3-config-test.el \
             -l test/p3-config-retirement-test.el \
             -l test/p3-config-appearance-test.el \
+            -l test/p3-tab-bar-appearance-test.el \
             -l test/p3-config-editing-ownership-test.el \
             -l test/p3-config-ess-test.el \
             -l test/p3-project-test.el \

--- a/lisp/p3-config-appearance.el
+++ b/lisp/p3-config-appearance.el
@@ -119,7 +119,8 @@
       tab-bar-separator "  "
       tab-bar-format '(tab-bar-format-history
                        tab-bar-format-tabs
-                       tab-bar-separator))
+                       tab-bar-separator
+                       tab-bar-format-add-tab))
 
 ;; Retire the old modeline when this source is reloaded into an existing
 ;; session. This does not load or configure doom-modeline.

--- a/lisp/p3-config-appearance.el
+++ b/lisp/p3-config-appearance.el
@@ -4,6 +4,7 @@
 (require 'hl-line)
 (require 'project)
 (require 'subr-x)
+(require 'tab-bar)
 (require 'use-package)
 
 (defvar dashboard-icon-type)
@@ -34,6 +35,9 @@
 (declare-function dashboard-insert-startupify-lists "dashboard" (&optional force-refresh))
 (declare-function flycheck-count-errors "flycheck" (errors))
 (declare-function doom-modeline-mode "doom-modeline" (&optional arg))
+
+(defconst p3/appearance-accent-color "#FFD700"
+  "Shared accent color for high-value current-context UI.")
 
 (defface p3/appearance-project-face
   '((t (:inherit font-lock-keyword-face :weight semi-bold)))
@@ -93,7 +97,27 @@
 (set-face-attribute 'mode-line-inactive nil :box nil :weight 'normal)
 (set-face-attribute 'line-number-current-line nil
                     :weight 'bold
-                    :foreground "#FFD700")
+                    :foreground p3/appearance-accent-color)
+(set-face-attribute 'tab-bar nil
+                    :inherit 'mode-line-inactive
+                    :foreground 'unspecified
+                    :background 'unspecified
+                    :box nil)
+(set-face-attribute 'tab-bar-tab nil
+                    :inherit 'tab-bar
+                    :foreground p3/appearance-accent-color
+                    :background 'unspecified
+                    :weight 'semi-bold
+                    :box nil)
+(set-face-attribute 'tab-bar-tab-inactive nil
+                    :inherit '(shadow tab-bar)
+                    :foreground 'unspecified
+                    :background 'unspecified
+                    :weight 'normal
+                    :box nil)
+(setq tab-bar-close-button-show 'selected
+      tab-bar-new-button-show nil
+      tab-bar-separator "  ")
 
 ;; Retire the old modeline when this source is reloaded into an existing
 ;; session. This does not load or configure doom-modeline.

--- a/lisp/p3-config-appearance.el
+++ b/lisp/p3-config-appearance.el
@@ -116,8 +116,10 @@
                     :weight 'normal
                     :box nil)
 (setq tab-bar-close-button-show 'selected
-      tab-bar-new-button-show nil
-      tab-bar-separator "  ")
+      tab-bar-separator "  "
+      tab-bar-format '(tab-bar-format-history
+                       tab-bar-format-tabs
+                       tab-bar-separator))
 
 ;; Retire the old modeline when this source is reloaded into an existing
 ;; session. This does not load or configure doom-modeline.

--- a/test/p3-tab-bar-appearance-test.el
+++ b/test/p3-tab-bar-appearance-test.el
@@ -22,7 +22,8 @@
   (should (eq (face-attribute 'tab-bar-tab-inactive :weight nil t) 'normal))
   (should-not (face-attribute 'tab-bar-tab-inactive :box nil nil))
   (should (eq tab-bar-close-button-show 'selected))
-  (should-not tab-bar-new-button-show))
+  (should (memq 'tab-bar-format-tabs tab-bar-format))
+  (should-not (memq 'tab-bar-format-add-tab tab-bar-format)))
 
 (provide 'p3-tab-bar-appearance-test)
 

--- a/test/p3-tab-bar-appearance-test.el
+++ b/test/p3-tab-bar-appearance-test.el
@@ -1,0 +1,29 @@
+;;; p3-tab-bar-appearance-test.el --- Project tab appearance tests -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'tab-bar)
+(require 'p3-config-appearance-test)
+
+(ert-deftest p3-tab-bar-active-project-uses-shared-accent ()
+  (p3-config-appearance-test--load-appearance)
+  (should (boundp 'p3/appearance-accent-color))
+  (should (equal p3/appearance-accent-color "#FFD700"))
+  (should (equal (face-foreground 'line-number-current-line nil t)
+                 p3/appearance-accent-color))
+  (should (equal (face-foreground 'tab-bar-tab nil t)
+                 p3/appearance-accent-color))
+  (should (eq (face-attribute 'tab-bar-tab :weight nil t) 'semi-bold))
+  (should-not (face-attribute 'tab-bar-tab :box nil nil)))
+
+(ert-deftest p3-tab-bar-inactive-projects-recede-and-controls-stay-quiet ()
+  (p3-config-appearance-test--load-appearance)
+  (should (equal (face-foreground 'tab-bar-tab-inactive nil t)
+                 (face-foreground 'shadow nil t)))
+  (should (eq (face-attribute 'tab-bar-tab-inactive :weight nil t) 'normal))
+  (should-not (face-attribute 'tab-bar-tab-inactive :box nil nil))
+  (should (eq tab-bar-close-button-show 'selected))
+  (should-not tab-bar-new-button-show))
+
+(provide 'p3-tab-bar-appearance-test)
+
+;;; p3-tab-bar-appearance-test.el ends here

--- a/test/p3-tab-bar-appearance-test.el
+++ b/test/p3-tab-bar-appearance-test.el
@@ -23,7 +23,7 @@
   (should-not (face-attribute 'tab-bar-tab-inactive :box nil nil))
   (should (eq tab-bar-close-button-show 'selected))
   (should (memq 'tab-bar-format-tabs tab-bar-format))
-  (should-not (memq 'tab-bar-format-add-tab tab-bar-format)))
+  (should (memq 'tab-bar-format-add-tab tab-bar-format)))
 
 (provide 'p3-tab-bar-appearance-test)
 


### PR DESCRIPTION
## Summary

Polish the native project Tab Bar without changing project/workspace behavior.

- reuse the existing `#FFD700` current-context accent for the active project title and current line number;
- flatten active/inactive tab faces by removing button-like boxes and explicit background slabs;
- render inactive project titles through the existing `shadow` face at normal weight;
- show the close control only on the selected tab;
- preserve native tab history and the subdued built-in `+` control using supported `tab-bar-format` configuration;
- keep all styling in the appearance owner; no changes to project-tab identity, creation, reuse, or window-layout behavior;
- add focused ERT coverage for the tab appearance contract.

## Implementation notes

The first control implementation used `tab-bar-new-button-show`, which strict Emacs 29 byte compilation correctly rejected as obsolete. The final implementation uses `tab-bar-format` instead. A later TDD checkpoint also verified that the approved subdued `+` remains present rather than being accidentally removed.

## Verification

Final head `bbda946d4acad4fa9d3be5dabae405804a5acbf2`:

- Linux/Emacs workflow: passed strict byte compilation, all smoke-load boundaries, and the full ERT suite: **312 tests, 310 expected passes, 0 unexpected, 2 normal skips**.
- Windows platform workflow: passed boundary byte compilation, editing and terminal regressions, platform/project tests, and config architecture tests.
- Final diff is limited to `lisp/p3-config-appearance.el`, the focused tab appearance test, and its CI test-loader entry.